### PR TITLE
feat(v6.6.0): API consistency + SSE stability + route registration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,9 @@ from backend.routers import (  # noqa: E402
     config_api,
     mcp,
     plugins,
+    persistence,
+    knowledge,
+    trash,
 )
 
 app.include_router(sessions.router)
@@ -57,6 +60,9 @@ app.include_router(agents.router)
 app.include_router(config_api.router)
 app.include_router(mcp.router)
 app.include_router(plugins.router)
+app.include_router(persistence.router)
+app.include_router(knowledge.router)
+app.include_router(trash.router)
 
 
 # ==================== 静态文件和前端 ====================

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -2304,5 +2304,6 @@ async def mcp_sse_endpoint(request: Request):
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
         },
     )

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -3,12 +3,15 @@
 
 import asyncio
 import json
+import logging
 import time
 from collections import deque
 from typing import Any, Dict, List, Set
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger("hermes-mcp")
 
 router = APIRouter(tags=["events"])
 
@@ -17,6 +20,9 @@ _event_buffer: deque = deque(maxlen=200)
 
 # 活跃的 SSE 连接
 _subscribers: Set[asyncio.Queue] = set()
+
+# 心跳间隔（秒）- 远程环境下 15 秒保活
+_SSE_HEARTBEAT_INTERVAL = 15
 
 
 def emit_event(event_type: str, data: Any = None, source: str = "system"):
@@ -51,16 +57,20 @@ async def sse_stream():
             for event in list(_event_buffer)[-5:]:
                 yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
 
-            # 实时推送
+            # 实时推送 + 心跳保活
             while True:
                 try:
-                    event = await asyncio.wait_for(queue.get(), timeout=30)
+                    event = await asyncio.wait_for(
+                        queue.get(), timeout=_SSE_HEARTBEAT_INTERVAL
+                    )
                     yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
                 except asyncio.TimeoutError:
-                    # 心跳保活
-                    yield ": heartbeat\n\n"
+                    # SSE 标准心跳：以冒号开头的行作为注释，客户端会忽略
+                    yield ": keepalive\n\n"
         except asyncio.CancelledError:
-            pass
+            logger.debug("SSE 连接已取消")
+        except Exception as e:
+            logger.warning(f"SSE 连接异常断开: {e}")
         finally:
             _subscribers.discard(queue)
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -143,6 +143,12 @@ async def set_session_tags(session_id: str, body: Dict[str, Any]) -> Dict[str, A
     return result
 
 
+@router.post("/{session_id}/tags", summary="设置会话标签 (POST)")
+async def set_session_tags_post(session_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
+    """设置会话标签（POST 备用，兼容不支持 PUT 的客户端）"""
+    return await set_session_tags(session_id, body)
+
+
 @router.put("/{session_id}/title", summary="重命名会话")
 async def rename_session(session_id: str, body: Dict[str, str]) -> Dict[str, Any]:
     """重命名会话标题"""
@@ -352,7 +358,12 @@ async def add_session_message(session_id: str, body: Dict[str, str]) -> Dict[str
     """向指定会话添加一条消息"""
     role = body.get("role", "user")
     content = body.get("content", "")
-    return hermes_service.add_session_message(session_id, role, content)
+    result = hermes_service.add_session_message(session_id, role, content)
+    # 同时返回 session 信息以便前端更新
+    session = hermes_service.get_session(session_id)
+    if session:
+        result["session"] = session
+    return result
 
 
 @router.delete("/{session_id}", summary="删除会话")

--- a/backend/services/hermes_service.py
+++ b/backend/services/hermes_service.py
@@ -926,6 +926,19 @@ class HermesService:
         }
         if warnings:
             result["warnings"] = warnings
+
+        # 返回更新后的内容，便于验证
+        if "MEMORY.md" in updated:
+            try:
+                result["memory"] = (memories_dir / "MEMORY.md").read_text(encoding="utf-8")
+            except Exception:
+                pass
+        if "USER.md" in updated:
+            try:
+                result["user"] = (memories_dir / "USER.md").read_text(encoding="utf-8")
+            except Exception:
+                pass
+
         return result
 
     # ==================== 定时任务管理 ====================

--- a/backend/version.py
+++ b/backend/version.py
@@ -17,7 +17,7 @@ import os
 # ============================================
 # 唯一版本号 - 修改这里即可
 # ============================================
-__version__ = os.environ.get("APP_VERSION", "6.5.2")
+__version__ = os.environ.get("APP_VERSION", "6.6.0")
 
 # 版本元信息
 __version_meta__ = {


### PR DESCRIPTION
## v6.6.0 功能修复

### API 一致性 (FX-01~07)
- FX-03: 添加消息响应包含 session 对象
- FX-04: 新增 POST /{session_id}/tags 备用路由
- FX-05: 导出 Markdown/CSV 确认可用
- FX-06/07: /api/meta 和 /openapi.json 确认可用

### SSE 稳定性 (FX-08~10)
- FX-08: 心跳间隔 30s→15s，改进日志
- FX-09: 确认标准 SSE 格式
- FX-10: MCP SSE 端点补充 X-Accel-Buffering header

### 路由注册修复 (FX-11~15)
- FX-12: 注册 persistence router
- FX-13: 注册 knowledge router
- FX-14: 注册 trash router
- FX-15: update_memory 响应包含更新后内容