### PR TITLE
feat: Phase 1 - 核心工具积木化 (53个工具模块)

### DIFF
--- a/backend/mcp/tools/file/list_dir.py
+++ b/backend/mcp/tools/file/list_dir.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""列出目录内容（文件和子目录）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_directory",
+        description="列出目录内容（文件和子目录）",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "目录绝对路径"},
+                "pattern": {"type": "string", "description": "glob 过滤模式（如 *.py）"}
+            },
+            "required": ["path"]
+        },
+        handler=handle,
+        tags=["file"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """列出目录内容"""
+    import os as _os
+    dpath = args.get("path", "")
+    pattern = args.get("pattern", "")
+    if not _os.path.isdir(dpath):
+        return error_response(f"目录不存在: {dpath}")
+    try:
+        import glob as _glob
+        if pattern:
+            items = _glob.glob(_os.path.join(dpath, pattern))
+        else:
+            items = _os.listdir(dpath)
+        result = []
+        for item in sorted(items):
+            full = item if _os.path.isabs(item) else _os.path.join(dpath, item)
+            if _os.path.isdir(full):
+                result.append({"name": item, "type": "directory"})
+            else:
+                size = _os.path.getsize(full)
+                result.append({"name": item, "type": "file", "size": size})
+        return success_response(data={
+            "path": dpath,
+            "items": result,
+            "total": len(result),
+        })
+    except Exception as e:
+        return error_response(f"列出目录失败: {e}")

--- a/backend/mcp/tools/file/read.py
+++ b/backend/mcp/tools/file/read.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""读取文件内容（支持文本文件，大文件自动截断）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_file",
+        description="读取文件内容（支持文本文件，大文件自动截断）",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "文件绝对路径"},
+                "offset": {"type": "integer", "default": 0, "description": "起始行号（从0开始）"},
+                "limit": {"type": "integer", "default": 500, "description": "最大读取行数"}
+            },
+            "required": ["path"]
+        },
+        handler=handle,
+        tags=["file"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """读取文件内容"""
+    import os as _os
+    fpath = args.get("path", "")
+    offset = int(args.get("offset", 0))
+    limit = int(args.get("limit", 500))
+    if not _os.path.isfile(fpath):
+        return error_response(f"文件不存在: {fpath}")
+    try:
+        with open(fpath, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+        total = len(lines)
+        selected = lines[offset:offset + limit]
+        content = "".join(selected)
+        return success_response(data={
+            "path": fpath,
+            "total_lines": total,
+            "offset": offset,
+            "limit": limit,
+            "display_range": f"{offset+1}-{min(offset+limit, total)}",
+            "content": content,
+        })
+    except Exception as e:
+        return error_response(f"读取文件失败: {e}")

--- a/backend/mcp/tools/file/search.py
+++ b/backend/mcp/tools/file/search.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""在目录中搜索包含指定内容的文件"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="search_files",
+        description="在目录中搜索包含指定内容的文件",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "搜索根目录"},
+                "pattern": {"type": "string", "description": "搜索内容（正则表达式）"},
+                "file_pattern": {"type": "string", "description": "文件过滤（如 *.py）"},
+                "max_results": {"type": "integer", "default": 20, "description": "最大结果数"}
+            },
+            "required": ["path", "pattern"]
+        },
+        handler=handle,
+        tags=["file"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """在目录中搜索包含指定内容的文件"""
+    import os as _os
+    root = args.get("path", "")
+    pattern = args.get("pattern", "")
+    file_pattern = args.get("file_pattern", "")
+    max_results = int(args.get("max_results", 20))
+    if not _os.path.isdir(root):
+        return error_response(f"目录不存在: {root}")
+    try:
+        import re as _re
+        import glob as _glob
+        regex = _re.compile(pattern)
+        results = []
+        # 收集文件
+        if file_pattern:
+            files = []
+            for ext in _glob.glob(_os.path.join(root, "**", file_pattern), recursive=True):
+                if _os.path.isfile(ext):
+                    files.append(ext)
+        else:
+            files = []
+            for dirpath, dirnames, filenames in _os.walk(root):
+                for fn in filenames:
+                    files.append(_os.path.join(dirpath, fn))
+        # 搜索
+        for fpath in files:
+            if len(results) >= max_results:
+                break
+            try:
+                with open(fpath, "r", encoding="utf-8", errors="replace") as f:
+                    for i, line in enumerate(f, 1):
+                        if regex.search(line):
+                            results.append({
+                                "file": fpath,
+                                "line": i,
+                                "content": line.strip()[:120],
+                            })
+                            if len(results) >= max_results:
+                                break
+            except Exception:
+                continue
+        return success_response(data={
+            "pattern": pattern,
+            "root": root,
+            "total_matches": len(results),
+            "results": results,
+        })
+    except Exception as e:
+        return error_response(f"搜索失败: {e}")

--- a/backend/mcp/tools/file/write.py
+++ b/backend/mcp/tools/file/write.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""写入文件内容（自动创建父目录）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="write_file",
+        description="写入文件内容（自动创建父目录）",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "文件绝对路径"},
+                "content": {"type": "string", "description": "要写入的内容"}
+            },
+            "required": ["path", "content"]
+        },
+        handler=handle,
+        tags=["file"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """写入文件内容"""
+    import os as _os
+    fpath = args.get("path", "")
+    content = args.get("content", "")
+    if not fpath:
+        return error_response("请提供文件路径")
+    try:
+        _os.makedirs(_os.path.dirname(fpath), exist_ok=True)
+        with open(fpath, "w", encoding="utf-8") as f:
+            f.write(content)
+        return success_response(message=f"文件已写入: {fpath} ({len(content)} 字符)")
+    except Exception as e:
+        return error_response(f"写入文件失败: {e}")

--- a/backend/mcp/tools/memory/add_learning.py
+++ b/backend/mcp/tools/memory/add_learning.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""添加一条学习记录（记录工具使用中的发现）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="add_learning",
+        description="添加一条学习记录（记录工具使用中的发现）",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "学习内容"},
+                "tool": {"type": "string", "description": "相关工具名（可选）"},
+                "error": {"type": "string", "description": "相关错误（可选）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """添加一条学习记录"""
+    import os as _os
+    from datetime import datetime, timezone
+    content = args.get("content", "")
+    if not content:
+        return error_response("请提供学习内容")
+    tool_name = args.get("tool", "")
+    error_info = args.get("error", "")
+
+    try:
+        from backend.config import get_hermes_home
+        learnings_path = get_hermes_home() / "learnings.md"
+    except Exception:
+        learnings_path = _os.path.expanduser("~/.hermes/learnings.md")
+
+    try:
+        _os.makedirs(_os.path.dirname(learnings_path), exist_ok=True)
+
+        # 构建新条目
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        entry_lines = [f"\n## [{now}] {tool_name}"]
+        entry_lines.append(f"- **内容**: {content}")
+        if tool_name:
+            entry_lines.append(f"- **工具**: {tool_name}")
+        if error_info:
+            entry_lines.append(f"- **错误**: {error_info}")
+        new_entry = "\n".join(entry_lines) + "\n"
+
+        # 读取现有内容并检查条数
+        existing = ""
+        if _os.path.isfile(learnings_path):
+            with open(learnings_path, "r", encoding="utf-8", errors="replace") as f:
+                existing = f.read()
+
+        # 计算现有条数
+        entry_count = existing.count("\n## ")
+
+        # 超过 50 条时删除最旧的条目
+        if entry_count >= 50:
+            # 找到第一个条目（最旧的）并删除
+            first_entry_end = existing.find("\n## ", 1)
+            if first_entry_end != -1:
+                existing = existing[first_entry_end:]
+            else:
+                existing = ""
+
+        # 写入
+        with open(learnings_path, "w", encoding="utf-8") as f:
+            f.write(existing + new_entry)
+
+        return success_response(message=f"学习记录已添加 ({tool_name or '通用'})")
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/query_external.py
+++ b/backend/mcp/tools/memory/query_external.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""查询外部记忆（语义搜索历史记忆）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="query_memory",
+        description="查询外部记忆（语义搜索历史记忆）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索查询"},
+                "limit": {"type": "integer", "default": 5, "description": "返回条数"}
+            },
+            "required": ["query"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """查询外部记忆"""
+    query = args.get("query", "")
+    if not query:
+        return error_response("请提供搜索查询。")
+    limit = int(args.get("limit", 5))
+    try:
+        from backend.config import get_hermes_home
+        memory_file = get_hermes_home() / "external_memory.md"
+        if not memory_file.exists():
+            return success_response(data=None, message="暂无外部记忆。使用 store_memory 存储记忆。")
+
+        text = memory_file.read_text(encoding="utf-8")
+        entries = text.split("## [")
+        # 简单关键词匹配
+        query_lower = query.lower()
+        matched = []
+        for entry in entries:
+            if query_lower in entry.lower():
+                matched.append("## [" + entry)
+                if len(matched) >= limit:
+                    break
+
+        if not matched:
+            return success_response(data={"matched": 0, "entries": []},
+                                   message=f"未找到匹配 '{query}' 的记忆。")
+
+        return success_response(data={"matched": len(matched), "entries": matched})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/read.py
+++ b/backend/mcp/tools/memory/read.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""读取 Agent 的长期记忆（MEMORY.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_memory",
+        description="读取 Agent 的长期记忆（MEMORY.md）",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """读取 Agent 的长期记忆"""
+    from backend.services.hermes_service import hermes_service
+    try:
+        data = hermes_service.read_memory()
+        return success_response(data=data.get("memory", "无记忆内容"))
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/read_agents_md.py
+++ b/backend/mcp/tools/memory/read_agents_md.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""读取项目级指令文件（AGENTS.md / CLAUDE.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_agents_md",
+        description="读取项目级指令文件（AGENTS.md / CLAUDE.md）",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "自定义文件路径（可选，默认自动发现）"}
+            }
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """read_agents_md handler"""
+    import os as _os
+
+    try:
+        custom_path = args.get("path", "")
+        if custom_path:
+            if not _os.path.isfile(custom_path):
+                return error_response(
+                    message=f"文件不存在: {custom_path}\n建议：\n1. 检查路径拼写是否正确\n2. 使用 list_directory 确认文件位置",
+                    code="FILE_NOT_FOUND",
+                )
+            try:
+                with open(custom_path, "r", encoding="utf-8", errors="replace") as f:
+                    content = f.read()
+                return success_response(
+                    data={"content": content, "path": custom_path, "chars": len(content)},
+                    message=f"AGENTS.md ({custom_path}, {len(content)} 字符)\n{'='*50}\n{content}",
+                )
+            except Exception as e:
+                return error_response(message=f"读取文件失败: {e}", code="READ_ERROR")
+        else:
+            # 按顺序查找：./AGENTS.md → ./CLAUDE.md → ~/.hermes/AGENTS.md
+            search_paths = [
+                ("./AGENTS.md", "AGENTS.md"),
+                ("./CLAUDE.md", "CLAUDE.md"),
+            ]
+            try:
+                from backend.config import get_hermes_home
+                hermes_home = get_hermes_home()
+                search_paths.append((str(hermes_home / "AGENTS.md"), "~/.hermes/AGENTS.md"))
+            except Exception:
+                pass
+
+            for fpath, label in search_paths:
+                if _os.path.isfile(fpath):
+                    try:
+                        with open(fpath, "r", encoding="utf-8", errors="replace") as f:
+                            content = f.read()
+                        return success_response(
+                            data={"content": content, "path": fpath, "label": label, "chars": len(content)},
+                            message=f"{label} ({fpath}, {len(content)} 字符)\n{'='*50}\n{content}",
+                        )
+                    except Exception as e:
+                        return error_response(message=f"读取 {label} 失败: {e}", code="READ_ERROR")
+
+            return success_response(
+                message="未找到 AGENTS.md，使用 write_agents_md 创建。\n\n查找路径（按顺序）：\n1. ./AGENTS.md\n2. ./CLAUDE.md\n3. ~/.hermes/AGENTS.md"
+            )
+    except Exception as e:
+        return error_response(message=f"读取 AGENTS.md 失败: {e}", code="READ_ERROR")

--- a/backend/mcp/tools/memory/read_learnings.py
+++ b/backend/mcp/tools/memory/read_learnings.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""读取 Agent 学习记录（从历史经验中学习）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_learnings",
+        description="读取 Agent 学习记录（从历史经验中学习）",
+        schema={
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "default": 20, "description": "返回条数"}
+            }
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """读取 Agent 学习记录"""
+    import os as _os
+    try:
+        from backend.config import get_hermes_home
+        learnings_path = get_hermes_home() / "learnings.md"
+    except Exception:
+        learnings_path = _os.path.expanduser("~/.hermes/learnings.md")
+
+    if not _os.path.isfile(learnings_path):
+        return success_response(data=None, message="暂无学习记录。使用 add_learning 工具记录工具使用中的发现和经验。")
+
+    try:
+        with open(learnings_path, "r", encoding="utf-8", errors="replace") as f:
+            full_content = f.read()
+        if not full_content.strip():
+            return success_response(data=None, message="暂无学习记录。使用 add_learning 工具记录工具使用中的发现和经验。")
+
+        # 按条目分割（## 开头为条目分隔符）
+        entries = []
+        current_entry = []
+        for line in full_content.split("\n"):
+            if line.startswith("## ") and current_entry:
+                entries.append("\n".join(current_entry))
+                current_entry = [line]
+            else:
+                current_entry.append(line)
+        if current_entry:
+            entries.append("\n".join(current_entry))
+
+        # 按时间倒序（最新在前）
+        entries = entries[::-1]
+        limit = int(args.get("limit", 20))
+        selected = entries[:limit]
+
+        return success_response(data={
+            "total": len(entries),
+            "displayed": len(selected),
+            "entries": selected,
+        })
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/read_soul.py
+++ b/backend/mcp/tools/memory/read_soul.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""读取 Agent 人格定义（SOUL.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_soul",
+        description="读取 Agent 人格定义（SOUL.md）",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """读取 Agent 人格定义"""
+    try:
+        from backend.config import get_hermes_home
+        soul_path = get_hermes_home() / "SOUL.md"
+        if soul_path.exists():
+            content = soul_path.read_text(encoding="utf-8")
+            return success_response(data={"content": content, "length": len(content)})
+        else:
+            return success_response(data=None, message="SOUL.md 尚未创建。使用 write_soul 工具创建 Agent 人格定义。")
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/read_user.py
+++ b/backend/mcp/tools/memory/read_user.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""读取用户画像（USER.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="read_user_profile",
+        description="读取用户画像（USER.md）",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """读取用户画像"""
+    from backend.services.hermes_service import hermes_service
+    try:
+        data = hermes_service.read_memory()
+        return success_response(data=data.get("user", "无用户画像"))
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/store_external.py
+++ b/backend/mcp/tools/memory/store_external.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""存储记忆到外部记忆提供者"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="store_memory",
+        description="存储记忆到外部记忆提供者",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "记忆内容"},
+                "tags": {"type": "array", "items": {"type": "string"}, "description": "标签列表（可选）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """存储记忆到外部记忆提供者"""
+    content = args.get("content", "")
+    if not content:
+        return error_response("请提供记忆内容。")
+    tags = args.get("tags", [])
+    try:
+        # 存储到本地 learnings.md 作为默认后端
+        from datetime import datetime
+        ts = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+        tag_str = ", ".join(tags) if tags else "untagged"
+        entry = f"\n## [{ts}] {tag_str}\n- **内容**: {content}\n"
+
+        from backend.config import get_hermes_home
+        memory_file = get_hermes_home() / "external_memory.md"
+        memory_file.parent.mkdir(parents=True, exist_ok=True)
+
+        existing = ""
+        if memory_file.exists():
+            existing = memory_file.read_text(encoding="utf-8")
+        memory_file.write_text(existing + entry, encoding="utf-8")
+
+        return success_response(message=f"记忆已存储。\n标签: {tag_str}\n内容: {content[:100]}\n存储位置: external_memory.md")
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/write.py
+++ b/backend/mcp/tools/memory/write.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""写入/更新 Agent 的长期记忆"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="write_memory",
+        description="写入/更新 Agent 的长期记忆",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "要保存的记忆内容（Markdown 格式）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """写入/更新 Agent 的长期记忆"""
+    from backend.services.hermes_service import hermes_service
+    try:
+        result = hermes_service.update_memory(memory=args["content"])
+        return success_response(message=result.get("message", "操作完成"))
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/write_agents_md.py
+++ b/backend/mcp/tools/memory/write_agents_md.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""写入项目级指令文件（AGENTS.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="write_agents_md",
+        description="写入项目级指令文件（AGENTS.md）",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "项目指令内容（Markdown 格式）"},
+                "path": {"type": "string", "description": "写入路径（默认 ~/.hermes/AGENTS.md）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """write_agents_md handler"""
+    import os as _os
+
+    try:
+        content = args.get("content", "")
+        if not content:
+            return error_response(
+                message="请提供项目指令内容\n建议：\n1. 在参数 content 中输入项目级指令文本（Markdown 格式）\n2. 内容示例：编码规范、项目结构说明、常用命令等\n3. 可选参数 path 指定写入路径（默认 ~/.hermes/AGENTS.md）",
+                code="INVALID_ARGS",
+            )
+
+        custom_path = args.get("path", "")
+        if custom_path:
+            target_path = custom_path
+        else:
+            try:
+                from backend.config import get_hermes_home
+                target_path = str(get_hermes_home() / "AGENTS.md")
+            except Exception:
+                target_path = _os.path.expanduser("~/.hermes/AGENTS.md")
+
+        _os.makedirs(_os.path.dirname(target_path), exist_ok=True)
+        with open(target_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        return success_response(
+            data={"path": target_path, "chars": len(content)},
+            message=f"AGENTS.md 已写入: {target_path} ({len(content)} 字符)",
+        )
+    except Exception as e:
+        return error_response(
+            message=f"写入 AGENTS.md 失败: {e}\n建议：\n1. 检查目标目录的写入权限\n2. 确认磁盘空间充足\n3. 尝试使用 path 参数指定其他写入路径",
+            code="WRITE_ERROR",
+        )

--- a/backend/mcp/tools/memory/write_soul.py
+++ b/backend/mcp/tools/memory/write_soul.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""写入 Agent 人格定义（SOUL.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="write_soul",
+        description="写入 Agent 人格定义（SOUL.md）",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "人格定义内容（Markdown 格式）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """写入 Agent 人格定义"""
+    content = args.get("content", "")
+    if not content:
+        return error_response("请提供人格定义内容")
+    try:
+        from backend.config import get_hermes_home
+        soul_path = get_hermes_home() / "SOUL.md"
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text(content, encoding="utf-8")
+        return success_response(message=f"SOUL.md 已更新 ({len(content)} 字符)")
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/memory/write_user.py
+++ b/backend/mcp/tools/memory/write_user.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""写入/更新用户画像（USER.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="write_user_profile",
+        description="写入/更新用户画像（USER.md）",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "用户画像内容（Markdown 格式）"}
+            },
+            "required": ["content"]
+        },
+        handler=handle,
+        tags=["memory"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """写入/更新用户画像"""
+    from backend.services.hermes_service import hermes_service
+    try:
+        result = hermes_service.update_memory(user=args["content"])
+        return success_response(message=result.get("message", "操作完成"))
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/add_message.py
+++ b/backend/mcp/tools/session/add_message.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""向指定会话添加一条消息"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="add_message",
+        description="向指定会话添加一条消息",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID"},
+                "role": {"type": "string", "description": "角色（user/assistant/system）"},
+                "content": {"type": "string", "description": "消息内容"}
+            },
+            "required": ["session_id", "role", "content"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """向指定会话添加一条消息"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        result = hermes_service.add_session_message(
+            session_id=args.get("session_id", ""),
+            role=args.get("role", ""),
+            content=args.get("content", ""),
+        )
+        return success_response(
+            data={"session_id": args.get("session_id", "")},
+            message=result.get("message", "操作完成"),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/compress.py
+++ b/backend/mcp/tools/session/compress.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""压缩会话历史（保留最近3轮+最早1轮，中间由摘要替代）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="compress_session",
+        description="压缩会话历史（保留最近3轮+最早1轮，中间由摘要替代）",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID"},
+                "keep_recent": {"type": "integer", "default": 3, "description": "保留最近 N 轮"},
+                "keep_first": {"type": "integer", "default": 1, "description": "保留最早 N 轮"},
+                "summary_max_chars": {"type": "integer", "default": 500, "description": "摘要最大字符数"}
+            },
+            "required": ["session_id"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """compress_session handler"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        session_id = args.get("session_id", "")
+        if not session_id:
+            return error_response(
+                message="请提供会话 ID。\n建议：\n1. 使用 list_sessions 获取会话 ID\n2. 确认 session_id 参数拼写正确",
+                code="INVALID_ARGS",
+            )
+
+        keep_recent = int(args.get("keep_recent", 3))
+        keep_first = int(args.get("keep_first", 1))
+        summary_max = int(args.get("summary_max_chars", 500))
+
+        # 从 hermes_service 获取消息
+        messages = hermes_service.get_session_messages(session_id)
+        if not messages:
+            return error_response(
+                message=f"会话 {session_id} 没有消息。\n建议：\n1. 确认会话 ID 正确\n2. 使用 list_sessions 查看可用会话",
+                code="NO_MESSAGES",
+            )
+
+        total = len(messages)
+        if total <= (keep_recent + keep_first):
+            return success_response(
+                message=f"会话只有 {total} 条消息，无需压缩（阈值: {keep_recent + keep_first}）"
+            )
+
+        # 保留最早 N 条
+        first_msgs = messages[:keep_first]
+        # 保留最近 N 条
+        recent_msgs = messages[-keep_recent:]
+        # 中间部分生成摘要
+        middle_msgs = messages[keep_first:-keep_recent]
+
+        # 简单摘要：提取每条消息的前 80 字符
+        summary_parts = []
+        for m in middle_msgs:
+            role = m.get("role", "?")
+            content = m.get("content", "")
+            preview = content[:80].replace("\n", " ")
+            summary_parts.append(f"[{role}] {preview}")
+
+        summary = " | ".join(summary_parts)
+        if len(summary) > summary_max:
+            summary = summary[:summary_max] + "..."
+
+        # 计算压缩率
+        original_chars = sum(len(m.get("content", "")) for m in messages)
+        compressed_chars = sum(len(m.get("content", "")) for m in first_msgs) + len(summary) + sum(len(m.get("content", "")) for m in recent_msgs)
+        ratio = (1 - compressed_chars / max(original_chars, 1)) * 100
+
+        # 保存摘要到会话元数据（通过 hermes_service）
+        try:
+            hermes_service.update_session_summary(session_id, summary)
+        except Exception:
+            pass  # 如果方法不存在，跳过
+
+        result = f"""会话压缩完成
+原始: {total} 条消息 ({original_chars} 字符)
+压缩后: {keep_first} + 摘要 + {keep_recent} 条 ({compressed_chars} 字符)
+压缩率: {ratio:.1f}%
+
+--- 最早 {keep_first} 条 ---
+""" + "\n".join(f"[{m.get('role','?')}] {m.get('content','')[:100]}" for m in first_msgs) + f"""
+
+--- 摘要 ({len(middle_msgs)} 条) ---
+{summary}
+
+--- 最近 {keep_recent} 条 ---
+""" + "\n".join(f"[{m.get('role','?')}] {m.get('content','')[:100]}" for m in recent_msgs)
+
+        return success_response(
+            data={
+                "original_messages": total,
+                "compressed_messages": keep_first + keep_recent,
+                "middle_summary_count": len(middle_msgs),
+                "compression_ratio": round(ratio, 1),
+            },
+            message=result,
+        )
+    except Exception as e:
+        return error_response(message=f"压缩会话失败: {e}", code="COMPRESS_ERROR")

--- a/backend/mcp/tools/session/create.py
+++ b/backend/mcp/tools/session/create.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""创建一个新的会话"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="create_session",
+        description="创建一个新的会话",
+        schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "会话标题"},
+                "model": {"type": "string", "description": "使用的模型名称"},
+                "source": {"type": "string", "default": "mcp", "description": "来源（mcp/api/web）"}
+            }
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """创建一个新的会话"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        result = hermes_service.create_session(
+            title=args.get("title", ""),
+            model=args.get("model", ""),
+            source=args.get("source", "mcp"),
+        )
+        session = result.get("session", {})
+        session_id = session.get("id", "")
+        return success_response(
+            data={"session": session},
+            message=f"会话创建成功\nID: {session_id}\n标题: {session.get('title', '')}\n来源: {session.get('source', '')}",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/delete.py
+++ b/backend/mcp/tools/session/delete.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""删除指定会话及其所有消息"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="delete_session",
+        description="删除指定会话及其所有消息",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "要删除的会话 ID"}
+            },
+            "required": ["session_id"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """删除指定会话及其所有消息"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        success = hermes_service.delete_session(args["session_id"])
+        if success:
+            return success_response(
+                data={"session_id": args["session_id"]},
+                message=f"会话 {args['session_id']} 已删除",
+            )
+        else:
+            return error_response(
+                message=f"删除失败：会话 {args['session_id']} 不存在",
+                code="NOT_FOUND",
+            )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/get_messages.py
+++ b/backend/mcp/tools/session/get_messages.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""获取指定会话的消息历史"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_session_messages",
+        description="获取指定会话的消息历史",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID"},
+                "limit": {"type": "integer", "default": 50, "description": "返回的最大消息数"}
+            },
+            "required": ["session_id"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """获取指定会话的消息历史"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        messages = hermes_service.get_session_messages(args["session_id"])
+        limit = args.get("limit", 50)
+        result = messages[-limit:]
+        if not result:
+            return success_response(
+                data={"messages": [], "session_id": args["session_id"]},
+                message=f"会话 {args['session_id']} 没有消息记录",
+            )
+        lines = []
+        for msg in result:
+            role = msg.get("role", "?")
+            content = str(msg.get("content", ""))[:200]
+            lines.append(f"[{role}] {content}")
+        return success_response(
+            data={"messages": result, "session_id": args["session_id"]},
+            message="\n".join(lines),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/list.py
+++ b/backend/mcp/tools/session/list.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""列出最近的会话列表"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_sessions",
+        description="列出最近的会话列表",
+        schema={
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "default": 20, "description": "返回的最大会话数"}
+            }
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """列出最近的会话列表"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        sessions = hermes_service.list_sessions()
+        limit = args.get("limit", 20)
+        result = sessions[:limit]
+        if not result:
+            return success_response(message="当前没有会话记录")
+        lines = []
+        for s in result:
+            lines.append(
+                f"- [{s.get('id', '?')}] {s.get('title', s.get('source', '?'))} | "
+                f"{s.get('model', '?')} | {s.get('created_at', '?')}"
+            )
+        return success_response(
+            data={"sessions": result, "total": len(sessions)},
+            message=f"共 {len(sessions)} 个会话:\n" + "\n".join(lines),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/search.py
+++ b/backend/mcp/tools/session/search.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""搜索会话（按标题或模型名模糊匹配）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="search_sessions",
+        description="搜索会话（按标题或模型名模糊匹配）",
+        schema={
+            "type": "object",
+            "properties": {
+                "keyword": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 10, "description": "返回的最大数量"}
+            },
+            "required": ["keyword"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """搜索会话（按标题或模型名模糊匹配）"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        keyword = args["keyword"].lower()
+        limit = args.get("limit", 10)
+        sessions = hermes_service.list_sessions()
+        matched = [
+            s for s in sessions
+            if keyword in str(s.get("title", "")).lower()
+            or keyword in str(s.get("model", "")).lower()
+            or keyword in str(s.get("id", "")).lower()
+        ]
+        result = matched[:limit]
+        if not result:
+            return success_response(
+                data={"matched": [], "total": 0},
+                message=f"没有找到包含 '{args['keyword']}' 的会话",
+            )
+        lines = []
+        for s in result:
+            lines.append(
+                f"- [{s.get('id', '?')}] {s.get('title', '?')} | {s.get('model', '?')}"
+            )
+        return success_response(
+            data={"sessions": result, "total": len(matched)},
+            message=f"找到 {len(matched)} 个匹配会话:\n" + "\n".join(lines),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/session/search_messages.py
+++ b/backend/mcp/tools/session/search_messages.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""全文搜索所有会话消息内容（SQLite FTS5）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="search_messages",
+        description="全文搜索所有会话消息内容（SQLite FTS5）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "session_id": {"type": "string", "description": "限定会话 ID（可选）"},
+                "limit": {"type": "integer", "default": 20, "description": "最大结果数"}
+            },
+            "required": ["query"]
+        },
+        handler=handle,
+        tags=["session"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """全文搜索所有会话消息内容（SQLite FTS5）"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        query = args.get("query", "")
+        session_id = args.get("session_id")
+        limit = int(args.get("limit", 20))
+        if not query:
+            return error_response(
+                message="请提供搜索关键词",
+                code="INVALID_ARGS",
+            )
+
+        results = hermes_service.search_messages(query, session_id, limit)
+        if not results:
+            return success_response(
+                data={"results": [], "total": 0},
+                message=f"未找到匹配 '{query}' 的消息",
+            )
+        output = [f"搜索: {query} | 找到 {len(results)} 条结果\n{'='*50}"]
+        for r in results:
+            content_preview = r["content"][:150].replace("\n", " ")
+            output.append(f"[{r['role']}] ({r['session_id'][:12]}...) {content_preview}")
+        return success_response(
+            data={"results": results, "total": len(results)},
+            message="\n".join(output),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/create.py
+++ b/backend/mcp/tools/skill/create.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""创建一个新技能"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="create_skill",
+        description="创建一个新技能",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "技能名称（英文、数字、下划线）"},
+                "content": {"type": "string", "description": "技能内容（Markdown 格式）"}
+            },
+            "required": ["name"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """创建一个新技能"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        result = hermes_service.create_skill(
+            name=args["name"],
+            content=args.get("content", ""),
+        )
+        if not result.get("success"):
+            return error_response(
+                message=(
+                    f"{result.get('message', '创建失败')}\n"
+                    f"建议：\n"
+                    f"1. 检查技能名是否已存在，使用 list_skills 查看\n"
+                    f"2. 如需更新已有技能，使用 update_skill\n"
+                    f"3. 使用不同的技能名称"
+                ),
+                code="CREATE_FAILED",
+            )
+        return success_response(
+            data={"name": args["name"]},
+            message=result.get("message", "操作完成"),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/delete.py
+++ b/backend/mcp/tools/skill/delete.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""删除指定技能"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="delete_skill",
+        description="删除指定技能",
+        schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {"type": "string", "description": "要删除的技能名称"}
+            },
+            "required": ["skill_name"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """删除指定技能"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        result = hermes_service.delete_skill(args["skill_name"])
+        return success_response(
+            data={"skill_name": args["skill_name"]},
+            message=result.get("message", "操作完成"),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/get_content.py
+++ b/backend/mcp/tools/skill/get_content.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""获取指定技能的详细内容"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_skill_content",
+        description="获取指定技能的详细内容",
+        schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {"type": "string", "description": "技能名称"}
+            },
+            "required": ["skill_name"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """获取指定技能的详细内容"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        skill = hermes_service.get_skill(args["skill_name"])
+        if skill is None:
+            return error_response(
+                message=f"技能 '{args['skill_name']}' 不存在",
+                code="NOT_FOUND",
+            )
+        return success_response(
+            data={"skill": skill},
+            message=skill.get("content", ""),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/install_hub.py
+++ b/backend/mcp/tools/skill/install_hub.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""从在线市场安装技能到本地"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="install_skill_hub",
+        description="从在线市场安装技能到本地",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "技能名称（如 python-debug）"},
+                "source": {"type": "string", "description": "来源 URL 或市场名称（默认 skills.sh）"}
+            },
+            "required": ["name"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """从在线市场安装技能到本地"""
+    from backend.services.hermes_service import hermes_service
+
+    skill_name = args.get("name", "")
+    if not skill_name:
+        return error_response(
+            message="请提供技能名称",
+            code="INVALID_ARGS",
+        )
+    source = args.get("source", "")
+
+    try:
+        import urllib.request
+        import urllib.parse
+        import json
+        import ssl as _ssl
+
+        if not source:
+            source = f"https://skills.sh/api/v1/skills/{urllib.parse.quote(skill_name)}"
+
+        ctx = _ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = _ssl.CERT_NONE
+        req = urllib.request.Request(source, headers={"Accept": "application/json", "User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=15, context=ctx) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        content = data.get("content", "")
+        if not content:
+            return error_response(
+                message=f"技能 '{skill_name}' 内容为空",
+                code="EMPTY_CONTENT",
+            )
+
+        # 使用 hermes_service 创建技能
+        desc = data.get("description", f"从市场安装: {skill_name}")
+        tags = data.get("tags", ["hub"])
+        result = hermes_service.create_skill(skill_name, content, desc, tags)
+
+        if result.get("success"):
+            return success_response(
+                data={"name": skill_name, "description": desc, "tags": tags},
+                message=f"技能 '{skill_name}' 安装成功！\n描述: {desc}\n标签: {', '.join(tags)}\n使用 get_skill_content('{skill_name}') 查看内容",
+            )
+        else:
+            return error_response(
+                message=f"安装失败: {result.get('message', '未知错误')}\n建议：\n1. 技能可能已存在，使用 update_skill 更新\n2. 检查技能名称",
+                code="INSTALL_FAILED",
+            )
+    except Exception as e:
+        # 降级：通过搜索 API 获取信息，创建模板技能
+        try:
+            import urllib.request
+            import urllib.parse
+            import json
+            import ssl as _ssl
+
+            ctx = _ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = _ssl.CERT_NONE
+            search_url = f"https://skills.sh/api/search?q={urllib.parse.quote(skill_name)}&limit=1"
+            req = urllib.request.Request(search_url, headers={"Accept": "application/json", "User-Agent": "Mozilla/5.0"})
+            with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+                search_data = json.loads(resp.read().decode("utf-8"))
+
+            skills_list = search_data.get("skills", [])
+            if not skills_list:
+                return error_response(
+                    message=f"技能 '{skill_name}' 未在市场中找到",
+                    code="NOT_FOUND",
+                )
+
+            matched = skills_list[0]
+            matched_name = matched.get("name", skill_name)
+            matched_source = matched.get("source", "")
+            matched_installs = matched.get("installs", 0)
+
+            # 创建模板技能
+            template_content = (
+                f"# {matched_name}\n\n"
+                f"> 来源: skills.sh ({matched_source})\n"
+                f"> 安装次数: {matched_installs}\n\n"
+                f"## 说明\n\n"
+                f"此技能从 skills.sh 市场安装（降级模式）。\n"
+                f"完整内容请访问: https://skills.sh/s/{matched_name}\n\n"
+                f"## 使用\n\n"
+                f"请根据技能名称 '{matched_name}' 的用途进行配置和使用。"
+            )
+            desc = f"从 skills.sh 安装 (降级): {matched_name} ({matched_installs} 安装)"
+            tags = ["hub", "skills-sh"]
+            result = hermes_service.create_skill(skill_name, template_content, desc, tags)
+
+            if result.get("success"):
+                return success_response(
+                    data={"name": skill_name, "description": desc, "tags": tags, "fallback": True},
+                    message=f"技能 '{skill_name}' 安装成功（降级模式）！\n来源: {matched_source}\n安装次数: {matched_installs}\n描述: {desc}\n使用 get_skill_content('{skill_name}') 查看内容",
+                )
+            else:
+                return error_response(
+                    message=f"安装失败: {result.get('message', '未知错误')}",
+                    code="INSTALL_FAILED",
+                )
+        except Exception as e2:
+            return error_response(
+                message=f"在线市场暂不可用: {e2}\n建议：\n1. 使用 create_skill 手动创建技能\n2. 稍后重试\n3. 使用 search_skills_hub 先搜索",
+                code="HUB_UNAVAILABLE",
+            )

--- a/backend/mcp/tools/skill/list.py
+++ b/backend/mcp/tools/skill/list.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""列出所有可用的技能"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_skills",
+        description="列出所有可用的技能",
+        schema={
+            "type": "object",
+            "properties": {}
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """列出所有可用的技能"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        # 传递当前可用工具列表用于条件激活
+        try:
+            from backend.mcp_server import _get_tools
+            all_tools = _get_tools()
+            available_tool_names = [t["name"] for t in all_tools]
+            result = hermes_service.list_skills(available_tool_names)
+        except Exception:
+            result = hermes_service.list_skills()
+
+        if not result:
+            return success_response(
+                data={"skills": [], "total": 0},
+                message="当前没有可用技能。使用 create_skill 创建新技能。",
+            )
+        output = [f"可用技能 ({len(result)} 个)\n{'='*50}"]
+        for s in result:
+            desc = s.get("description", "无描述")
+            tags = ", ".join(s.get("tags", []))
+            line = f"  {s['name']}"
+            if desc:
+                line += f" - {desc[:60]}"
+            if tags:
+                line += f" [{tags}]"
+            output.append(line)
+        return success_response(
+            data={"skills": result, "total": len(result)},
+            message="\n".join(output),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/search_hub.py
+++ b/backend/mcp/tools/skill/search_hub.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""搜索在线技能市场（skills.sh）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="search_skills_hub",
+        description="搜索在线技能市场（skills.sh）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 10, "description": "最大结果数"}
+            },
+            "required": ["query"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """搜索在线技能市场（skills.sh）"""
+    from backend.services.hermes_service import hermes_service
+
+    query = args.get("query", "")
+    if not query:
+        return error_response(
+            message="请提供搜索关键词",
+            code="INVALID_ARGS",
+        )
+    limit = int(args.get("limit", 10))
+
+    try:
+        import urllib.request
+        import urllib.parse
+        import json
+        url = f"https://skills.sh/api/search?q={urllib.parse.quote(query)}&limit={limit}"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        if not data:
+            return success_response(
+                data={"skills": [], "total": 0},
+                message=f"未找到匹配 '{query}' 的技能",
+            )
+
+        # 兼容 API 返回列表或字典格式
+        if isinstance(data, dict):
+            data = data.get("results", data.get("skills", data.get("items", [])))
+        if not isinstance(data, list):
+            data = []
+
+        if not data:
+            return success_response(
+                data={"skills": [], "total": 0},
+                message=f"未找到匹配 '{query}' 的技能",
+            )
+
+        output = [f"搜索: {query} | 找到 {len(data)} 个技能\n{'='*50}"]
+        for skill in data[:limit]:
+            name = skill.get("name", "?")
+            desc = skill.get("description", "无描述")[:80]
+            author = skill.get("author", "")
+            installs = skill.get("installs", 0)
+            output.append(f"  {name} (by {author}, {installs} 安装)")
+            output.append(f"    {desc}")
+
+        return success_response(
+            data={"skills": data[:limit], "total": len(data)},
+            message="\n".join(output),
+        )
+    except Exception as e:
+        # 降级：返回内置技能列表
+        try:
+            skills = hermes_service.list_skills()
+            matched = [
+                s for s in skills
+                if query.lower() in s.get("name", "").lower()
+                or query.lower() in s.get("description", "").lower()
+            ]
+            if matched:
+                output = [f"在线搜索不可用，显示本地匹配结果 ({len(matched)} 个)\n{'='*50}"]
+                for s in matched:
+                    output.append(f"  {s['name']}: {s.get('description', '无描述')[:80]}")
+                return success_response(
+                    data={"skills": matched, "total": len(matched), "fallback": True},
+                    message="\n".join(output),
+                )
+        except Exception:
+            pass
+        return error_response(str(e))

--- a/backend/mcp/tools/skill/suggest.py
+++ b/backend/mcp/tools/skill/suggest.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""分析会话中的工具调用模式，建议创建可复用技能"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="suggest_skill",
+        description="分析会话中的工具调用模式，建议创建可复用技能",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "要分析的会话 ID（可选，默认最近会话）"},
+                "min_calls": {"type": "integer", "default": 3, "description": "最少调用次数才触发建议"}
+            },
+            "required": []
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """suggest_skill handler"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        import re
+        session_id = args.get("session_id", "")
+        min_calls = int(args.get("min_calls", 3))
+
+        # 获取会话列表
+        sessions = hermes_service.list_sessions()
+        if not sessions:
+            return success_response(message="暂无会话数据，无法分析工具调用模式。")
+
+        # 使用指定会话或最近会话
+        target_id = session_id or sessions[0].get("id", "")
+        messages = hermes_service.get_session_messages(target_id)
+        if not messages:
+            return success_response(message=f"会话 {target_id} 没有消息。")
+
+        # 分析工具调用模式（从消息中提取 tool_call 模式）
+        tool_pattern = {}
+        for msg in messages:
+            content = msg.get("content", "")
+            # 简单匹配工具调用模式
+            tool_calls = re.findall(r'(?:调用|使用|执行)\s*(\w+)', content)
+            for t in tool_calls:
+                tool_pattern[t] = tool_pattern.get(t, 0) + 1
+
+        # 也从 eval_service 获取真实调用数据
+        try:
+            from backend.services.eval_service import eval_service
+            tool_stats = eval_service.get_tool_stats()
+            for stat in tool_stats:
+                tool_name = stat.get("tool", "")
+                count = stat.get("calls", 0)
+                if count >= min_calls:
+                    tool_pattern[tool_name] = max(tool_pattern.get(tool_name, 0), count)
+        except Exception:
+            pass
+
+        if not tool_pattern:
+            return success_response(
+                message="未发现重复的工具调用模式。建议：\n1. 多使用工具后再次分析\n2. 降低 min_calls 阈值"
+            )
+
+        # 生成技能建议
+        suggestions = []
+        for tool, count in sorted(tool_pattern.items(), key=lambda x: -x[1]):
+            if count >= min_calls:
+                suggestions.append(f"  - {tool}: 调用 {count} 次")
+
+        if not suggestions:
+            current = "\n".join(f"  - {t}: {c} 次" for t, c in sorted(tool_pattern.items(), key=lambda x: -x[1])[:5])
+            return success_response(message=f"未发现调用次数 >= {min_calls} 的工具模式。当前模式：\n{current}")
+
+        # 生成技能草案
+        skill_name = f"auto-{target_id[:8]}"
+        nl = "\n"
+        draft = f"""# 建议技能: {skill_name}
+
+## 触发条件
+以下工具被频繁调用：
+{nl.join(suggestions)}
+
+## 建议操作
+1. 审查上述工具调用是否构成可复用工作流
+2. 如果是，使用 create_skill 创建技能
+3. 技能内容应包含：触发条件、执行步骤、预期输出
+
+## 草案内容
+```markdown
+# {skill_name}
+## 描述
+自动生成的技能（基于会话 {target_id[:12]} 的工具调用模式）
+
+## 触发条件
+当需要频繁使用以下工具时激活：
+{nl.join(suggestions)}
+
+## 执行步骤
+1. 按照工具调用顺序执行
+2. 检查每步输出是否符合预期
+3. 记录结果到学习记录
+```
+
+使用 create_skill 创建此技能，或调整内容后创建。"""
+
+        return success_response(
+            data={"skill_name": skill_name, "suggestions": suggestions, "tool_pattern": tool_pattern},
+            message=draft,
+        )
+    except Exception as e:
+        return error_response(message=f"技能建议分析失败: {e}", code="SUGGEST_ERROR")

--- a/backend/mcp/tools/skill/update.py
+++ b/backend/mcp/tools/skill/update.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""更新指定技能的内容"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="update_skill",
+        description="更新指定技能的内容",
+        schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {"type": "string", "description": "技能名称"},
+                "content": {"type": "string", "description": "新的技能内容（Markdown 格式）"}
+            },
+            "required": ["skill_name", "content"]
+        },
+        handler=handle,
+        tags=["skill"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """更新指定技能的内容"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        result = hermes_service.update_skill(
+            name=args["skill_name"],
+            content=args["content"],
+        )
+        return success_response(
+            data={"skill_name": args["skill_name"]},
+            message=result.get("message", "操作完成"),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/system/add_mcp_server.py
+++ b/backend/mcp/tools/system/add_mcp_server.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""添加外部 MCP 服务器（自动发现工具并聚合）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="add_mcp_server",
+        description="添加外部 MCP 服务器（自动发现工具并聚合）",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "服务器名称（英文，如 github）"},
+                "url": {"type": "string", "description": "MCP 服务器 URL（如 http://localhost:3001/mcp）"},
+                "prefix": {"type": "string", "description": "工具名前缀（默认 mcp_{name}_）"}
+            },
+            "required": ["name", "url"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """add_mcp_server handler"""
+    try:
+        from backend.services.mcp_client_service import mcp_client_service
+
+        server_name = args.get("name", "")
+        url = args.get("url", "")
+        prefix = args.get("prefix", "")
+
+        result = mcp_client_service.add_server(server_name, url, prefix)
+        if not result.get("success"):
+            return error_response(
+                message=f"{result.get('message', '添加失败')}\n建议：\n1. 检查服务器名称是否已存在（使用 list_mcp_servers 查看已添加的服务器）\n2. 确认 URL 格式正确且服务器可访问\n3. 检查服务器名称和 URL 是否拼写正确",
+                code="ADD_SERVER_ERROR",
+            )
+
+        prefix_display = mcp_client_service._servers[server_name].get('prefix', '')
+        return success_response(
+            message=f"已添加 MCP 服务器 '{server_name}'，发现 {result.get('tools_count', 0)} 个工具（前缀: {prefix_display}）"
+        )
+    except Exception as e:
+        return error_response(message=f"添加 MCP 服务器失败: {e}", code="ADD_SERVER_ERROR")

--- a/backend/mcp/tools/system/create_cron.py
+++ b/backend/mcp/tools/system/create_cron.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""创建一个定时任务"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="create_cron_job",
+        description="创建一个定时任务",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "任务名称"},
+                "schedule": {"type": "string", "description": "Cron 表达式，如 '0 9 * * *'"},
+                "command": {"type": "string", "description": "要执行的命令或任务描述"}
+            },
+            "required": ["name", "schedule", "command"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """create_cron_job handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+
+        result = hermes_service.create_cron_job({
+            "name": args["name"],
+            "schedule": args["schedule"],
+            "command": args["command"],
+        })
+        return success_response(result.get("message", "操作完成"))
+    except Exception as e:
+        return error_response(f"创建定时任务失败: {e}")

--- a/backend/mcp/tools/system/delegate_task.py
+++ b/backend/mcp/tools/system/delegate_task.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""创建子 Agent 执行独立任务（并行工作）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="delegate_task",
+        description="创建子 Agent 执行独立任务（并行工作）",
+        schema={
+            "type": "object",
+            "properties": {
+                "task": {"type": "string", "description": "任务描述"},
+                "tools": {"type": "array", "items": {"type": "string"}, "description": "允许使用的工具列表（可选，默认全部）"},
+                "timeout": {"type": "integer", "default": 120, "description": "超时秒数"}
+            },
+            "required": ["task"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """delegate_task handler"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        task_desc = args.get("task", "")
+        if not task_desc:
+            return error_response(
+                message="请提供任务描述。\n建议：\n1. 清晰描述任务目标和预期输出\n2. 列出关键约束条件\n3. 指定交付格式",
+                code="INVALID_ARGS",
+            )
+
+        allowed_tools = args.get("tools", [])
+        timeout = int(args.get("timeout", 120))
+
+        # 生成子 Agent ID
+        import uuid
+        agent_id = f"agent_{uuid.uuid4().hex[:8]}"
+
+        # 记录任务到会话
+        try:
+            hermes_service.create_session(agent_id, f"[子Agent] {task_desc[:50]}")
+            hermes_service.add_session_message(agent_id, "system", f"任务: {task_desc}\n允许工具: {allowed_tools or '全部'}\n超时: {timeout}s")
+        except Exception:
+            pass
+
+        result = f"""子 Agent 已创建: {agent_id}
+
+任务: {task_desc[:200]}
+允许工具: {len(allowed_tools) if allowed_tools else '全部'} 个
+超时: {timeout}s
+
+使用说明：
+1. 子 Agent 在独立上下文中执行任务
+2. 可通过 get_session_messages('{agent_id}') 查看进度
+3. 结果会自动记录到会话中
+4. 使用 list_sessions 查看所有子 Agent 状态"""
+        return success_response(message=result)
+    except Exception as e:
+        return error_response(message=f"创建子 Agent 失败: {e}", code="DELEGATE_ERROR")

--- a/backend/mcp/tools/system/delete_cron.py
+++ b/backend/mcp/tools/system/delete_cron.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""删除指定的定时任务"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="delete_cron_job",
+        description="删除指定的定时任务",
+        schema={
+            "type": "object",
+            "properties": {
+                "job_id": {"type": "string", "description": "定时任务 ID"}
+            },
+            "required": ["job_id"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """delete_cron_job handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+
+        result = hermes_service.delete_cron_job(args["job_id"])
+        return success_response(result.get("message", "操作完成"))
+    except Exception as e:
+        return error_response(f"删除定时任务失败: {e}")

--- a/backend/mcp/tools/system/get_config.py
+++ b/backend/mcp/tools/system/get_config.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""获取当前系统配置"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_config",
+        description="获取当前系统配置",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """get_config handler"""
+    try:
+        import json
+        from backend.config import get_config
+
+        config = get_config()
+        # 脱敏
+        sensitive = {"api_key", "token", "password", "secret"}
+        safe = {}
+        for k, v in config.items():
+            if any(s in k.lower() for s in sensitive):
+                safe[k] = "****"
+            else:
+                safe[k] = v
+        result = json.dumps(safe, ensure_ascii=False, indent=2)
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"获取配置失败: {e}")

--- a/backend/mcp/tools/system/get_dashboard.py
+++ b/backend/mcp/tools/system/get_dashboard.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""获取仪表盘摘要信息"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_dashboard_summary",
+        description="获取仪表盘摘要信息",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """get_dashboard_summary handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+
+        sessions = hermes_service.list_sessions()
+        tools = hermes_service.list_tools()
+        skills = hermes_service.list_skills()
+        active = [s for s in sessions if s.get("status") == "active"]
+        result = (
+            f"仪表盘摘要:\n"
+            f"- 总会话数: {len(sessions)}\n"
+            f"- 活跃会话: {len(active)}\n"
+            f"- 可用工具: {len(tools)}\n"
+            f"- 技能数: {len(skills)}"
+        )
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"获取仪表盘摘要失败: {e}")

--- a/backend/mcp/tools/system/get_logs.py
+++ b/backend/mcp/tools/system/get_logs.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""获取操作日志（按来源过滤）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_logs",
+        description="获取操作日志（按来源过滤）",
+        schema={
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "default": 20, "description": "返回的最大日志数"},
+                "source": {"type": "string", "description": "来源过滤（mcp/user/system）"}
+            }
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """get_logs handler"""
+    try:
+        from backend.routers.logs import _load_logs
+
+        logs = _load_logs()
+        source = args.get("source")
+        if source:
+            logs = [l for l in logs if l.get("source") == source]
+        limit = args.get("limit", 20)
+        logs = logs[:limit]
+        if not logs:
+            return success_response("当前没有日志记录")
+        lines = []
+        for log in logs:
+            lines.append(
+                f"- [{log.get('source', '?')}] {log.get('action', '?')} | {log.get('timestamp', '?')}"
+            )
+        result = f"共 {len(logs)} 条日志:\n" + "\n".join(lines)
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"获取日志失败: {e}")

--- a/backend/mcp/tools/system/get_system_status.py
+++ b/backend/mcp/tools/system/get_system_status.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""获取 Hermes Agent 系统状态"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="get_system_status",
+        description="获取 Hermes Agent 系统状态",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """get_system_status handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+        from backend.version import __version__
+
+        status = hermes_service.get_mcp_status()
+        result = (
+            f"Hermes Agent 系统状态:\n"
+            f"- MCP 服务: {status.get('status', 'unknown')}\n"
+            f"- Hermes 可用: {'是' if hermes_service.hermes_available else '否'}\n"
+            f"- 版本: {__version__}"
+        )
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"获取系统状态失败: {e}")

--- a/backend/mcp/tools/system/list_cron.py
+++ b/backend/mcp/tools/system/list_cron.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""列出所有定时任务"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_cron_jobs",
+        description="列出所有定时任务",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """list_cron_jobs handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+
+        jobs = hermes_service.list_cron_jobs()
+        if not jobs:
+            return success_response("当前没有定时任务")
+        lines = []
+        for j in jobs:
+            status = "✅" if j.get("status") == "active" else "⏸️"
+            lines.append(
+                f"{status} [{j.get('id', '?')}] {j.get('name', '?')} | "
+                f"{j.get('schedule', '?')} | {j.get('command', '?')}"
+            )
+        result = f"共 {len(jobs)} 个定时任务:\n" + "\n".join(lines)
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"列出定时任务失败: {e}")

--- a/backend/mcp/tools/system/list_mcp_servers.py
+++ b/backend/mcp/tools/system/list_mcp_servers.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""列出所有已连接的外部 MCP 服务器"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_mcp_servers",
+        description="列出所有已连接的外部 MCP 服务器",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """list_mcp_servers handler"""
+    try:
+        from backend.services.mcp_client_service import mcp_client_service
+
+        servers = mcp_client_service.list_servers()
+        if not servers:
+            return success_response(
+                message="当前没有连接外部 MCP 服务器。使用 add_mcp_server 添加。"
+            )
+
+        output = [f"已连接 {len(servers)} 个外部 MCP 服务器\n{'='*50}"]
+        for s in servers:
+            output.append(f"  {s['name']} ({s['status']})")
+            output.append(f"    URL: {s['url']}")
+            output.append(f"    工具: {s['tools_count']} 个")
+            output.append(f"    前缀: {s['prefix']}")
+            if s.get("last_check"):
+                output.append(f"    最后检查: {s['last_check']}")
+
+        return success_response(
+            data={"servers": servers, "total": len(servers)},
+            message="\n".join(output),
+        )
+    except Exception as e:
+        return error_response(message=f"列出 MCP 服务器失败: {e}", code="LIST_SERVERS_ERROR")

--- a/backend/mcp/tools/system/list_tools.py
+++ b/backend/mcp/tools/system/list_tools.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""列出所有可用的工具及其状态"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_tools",
+        description="列出所有可用的工具及其状态",
+        schema={"type": "object", "properties": {}},
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """list_tools handler"""
+    try:
+        from backend.services.hermes_service import hermes_service
+
+        tools = hermes_service.list_tools()
+        if not tools:
+            return success_response("当前没有可用工具")
+        lines = []
+        for t in tools:
+            status = "✅" if t.get("status") == "active" else "❌"
+            lines.append(f"{status} {t.get('name', '?')}: {t.get('description', '无描述')}")
+        result = f"共 {len(tools)} 个工具:\n" + "\n".join(lines)
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"列出工具失败: {e}")

--- a/backend/mcp/tools/system/log_conversation.py
+++ b/backend/mcp/tools/system/log_conversation.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""记录对话消息到会话（Trae 调用此工具记录与用户的对话）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="log_conversation",
+        description="记录对话消息到会话（Trae 调用此工具记录与用户的对话）",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID（可选，不传则自动使用最近活跃会话）"},
+                "role": {"type": "string", "description": "消息角色: user / assistant / system", "enum": ["user", "assistant", "system"]},
+                "content": {"type": "string", "description": "消息内容"},
+                "summary": {"type": "string", "description": "对话摘要（可选）"}
+            },
+            "required": ["role", "content"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """log_conversation handler"""
+    from backend.services.hermes_service import hermes_service
+
+    try:
+        role = args.get("role", "user")
+        content = args.get("content", "")
+        session_id = args.get("session_id", "")
+        summary = args.get("summary", "")
+
+        # 如果没有指定 session_id，使用最近活跃会话
+        if not session_id:
+            sessions = hermes_service.list_sessions()
+            active = [s for s in sessions if s.get("status") == "active"]
+            if active:
+                session_id = active[0].get("id") or active[0].get("session_id", "")
+            elif sessions:
+                session_id = sessions[0].get("id") or sessions[0].get("session_id", "")
+
+        if not session_id:
+            # 自动创建会话
+            result = hermes_service.create_session(title=summary or "Trae 对话", source="trae")
+            session_id = result.get("session", {}).get("id", "")
+
+        if not session_id:
+            return error_response(message="无法获取或创建会话", code="SESSION_ERROR")
+
+        hermes_service.add_session_message(session_id, role, content)
+        try:
+            from backend.routers.logs import add_log
+            add_log("记录对话", session_id[:16], f"[{role}] {content[:100]}", "info", "trae")
+        except Exception:
+            pass
+        return success_response(message=f"对话已记录到会话 {session_id[:16]}")
+    except Exception as e:
+        return error_response(message=f"记录对话失败: {e}", code="LOG_ERROR")

--- a/backend/mcp/tools/system/refresh_mcp_servers.py
+++ b/backend/mcp/tools/system/refresh_mcp_servers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""刷新所有外部 MCP 服务器的工具列表"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="refresh_mcp_servers",
+        description="刷新所有外部 MCP 服务器的工具列表",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """refresh_mcp_servers handler"""
+    try:
+        from backend.services.mcp_client_service import mcp_client_service
+
+        result = mcp_client_service.refresh_all()
+        return success_response(message=result.get("message", "刷新完成"))
+    except Exception as e:
+        return error_response(message=f"刷新 MCP 服务器失败: {e}", code="REFRESH_ERROR")

--- a/backend/mcp/tools/system/register_webhook.py
+++ b/backend/mcp/tools/system/register_webhook.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""注册消息推送 Webhook（Telegram/飞书/Slack/Discord）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="register_webhook",
+        description="注册消息推送 Webhook（Telegram/飞书/Slack/Discord）",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "通道名称"},
+                "url": {"type": "string", "description": "Webhook URL"},
+                "platform": {"type": "string", "description": "平台类型（telegram/feishu/slack/discord/custom）"},
+                "secret": {"type": "string", "description": "密钥（可选）"}
+            },
+            "required": ["name", "url", "platform"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """register_webhook handler"""
+    try:
+        wname = args.get("name", "")
+        wurl = args.get("url", "")
+        platform = args.get("platform", "custom")
+        secret = args.get("secret", "")
+
+        if not wname or not wurl:
+            return error_response(
+                message="请提供通道名称和 Webhook URL。\n建议：\n1. name: 自定义通道名（如 'my-telegram'）\n2. url: Webhook 地址\n3. platform: telegram/feishu/slack/discord/custom",
+                code="INVALID_ARGS",
+            )
+
+        from backend.config import get_hermes_home
+        import json
+
+        webhooks_file = get_hermes_home() / "webhooks.json"
+        webhooks = {}
+        if webhooks_file.exists():
+            webhooks = json.loads(webhooks_file.read_text(encoding="utf-8"))
+        webhooks[wname] = {"url": wurl, "platform": platform, "secret": secret}
+        webhooks_file.write_text(json.dumps(webhooks, indent=2, ensure_ascii=False), encoding="utf-8")
+
+        return success_response(
+            message=f"Webhook 通道 '{wname}' 已注册。\n平台: {platform}\nURL: {wurl}\n使用 send_notification 发送消息。"
+        )
+    except Exception as e:
+        return error_response(message=f"注册 Webhook 失败: {e}", code="WEBHOOK_ERROR")

--- a/backend/mcp/tools/system/remove_mcp_server.py
+++ b/backend/mcp/tools/system/remove_mcp_server.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""移除外部 MCP 服务器"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="remove_mcp_server",
+        description="移除外部 MCP 服务器",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "服务器名称"}
+            },
+            "required": ["name"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """remove_mcp_server handler"""
+    try:
+        from backend.services.mcp_client_service import mcp_client_service
+
+        server_name = args.get("name", "")
+        result = mcp_client_service.remove_server(server_name)
+        if not result.get("success"):
+            return error_response(
+                message=f"{result.get('message', '移除失败')}\n建议：\n1. 使用 list_mcp_servers 确认服务器名称是否正确\n2. 确认该服务器当前处于已连接状态\n3. 服务器名称区分大小写，请检查拼写",
+                code="REMOVE_SERVER_ERROR",
+            )
+        return success_response(message=f"已移除 MCP 服务器 '{server_name}'")
+    except Exception as e:
+        return error_response(message=f"移除 MCP 服务器失败: {e}", code="REMOVE_SERVER_ERROR")

--- a/backend/mcp/tools/system/screenshot.py
+++ b/backend/mcp/tools/system/screenshot.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""截取网页截图并保存到本地（使用 Playwright 无头浏览器）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="capture_screenshot",
+        description="截取网页截图并保存到本地（使用 Playwright 无头浏览器）",
+        schema={
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "要截图的网页 URL"},
+                "width": {"type": "integer", "default": 1280, "description": "视口宽度（像素）"},
+                "height": {"type": "integer", "default": 720, "description": "视口高度（像素）"},
+                "full_page": {"type": "boolean", "default": False, "description": "是否截取完整页面（长截图）"},
+            },
+            "required": ["url"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """capture_screenshot handler"""
+    url = args.get("url", "")
+    width = int(args.get("width", 1280))
+    height = int(args.get("height", 720))
+    full_page = args.get("full_page", False)
+
+    if not url:
+        return error_response(
+            "请提供要截图的网页 URL",
+            code="INVALID_ARGS",
+        )
+
+    try:
+        import uuid
+        import os
+        from playwright.sync_api import sync_playwright
+
+        filename = f"screenshot_{uuid.uuid4().hex[:8]}.png"
+        # 保存到 hermes home 的 screenshots 目录
+        from backend.config import get_hermes_home
+        hermes_home = get_hermes_home()
+        screenshot_dir = hermes_home / "screenshots"
+        screenshot_dir.mkdir(parents=True, exist_ok=True)
+        filepath = screenshot_dir / filename
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page(viewport={"width": width, "height": height})
+            page.goto(url, wait_until="networkidle", timeout=30000)
+            page.screenshot(path=str(filepath), full_page=full_page)
+            browser.close()
+
+        result = f"截图已保存: {filepath}\nURL: {url}\n尺寸: {width}x{height}\n完整页面: {'是' if full_page else '否'}"
+        return success_response(result)
+    except ImportError:
+        return error_response(
+            "Playwright 未安装，请运行: pip install playwright && playwright install chromium",
+            code="MISSING_DEP",
+        )
+    except Exception as e:
+        return error_response(
+            f"截图失败: {e}\n建议：\n1. 检查 URL 是否正确且可访问\n2. 确认 Playwright 和 Chromium 已正确安装\n3. 检查网络连接是否正常",
+            code="SCREENSHOT_ERROR",
+        )

--- a/backend/mcp/tools/system/send_notification.py
+++ b/backend/mcp/tools/system/send_notification.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""发送通知消息（支持配置的 Webhook 通道）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="send_notification",
+        description="发送通知消息（支持配置的 Webhook 通道）",
+        schema={
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "通知内容"},
+                "channel": {"type": "string", "description": "通道名称（默认 default）"},
+                "title": {"type": "string", "description": "通知标题（可选）"}
+            },
+            "required": ["message"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """send_notification handler"""
+    try:
+        message = args.get("message", "")
+        if not message:
+            return error_response(message="请提供通知内容。", code="INVALID_ARGS")
+        channel = args.get("channel", "default")
+        title = args.get("title", "Hermes 通知")
+
+        from backend.config import get_hermes_home
+        import json, urllib.request
+
+        webhooks_file = get_hermes_home() / "webhooks.json"
+        if not webhooks_file.exists():
+            return error_response(
+                message="未注册任何 Webhook 通道。请先使用 register_webhook 注册。",
+                code="NO_WEBHOOK",
+            )
+
+        webhooks = json.loads(webhooks_file.read_text(encoding="utf-8"))
+        target = webhooks.get(channel) or webhooks.get("default")
+        if not target:
+            available = ", ".join(webhooks.keys())
+            return error_response(
+                message=f"通道 '{channel}' 不存在。可用通道: {available}",
+                code="CHANNEL_NOT_FOUND",
+            )
+
+        wurl = target["url"]
+        platform = target.get("platform", "custom")
+
+        # 根据平台格式化 payload
+        if platform == "feishu":
+            payload = json.dumps({"msg_type": "text", "content": {"text": f"{title}\n{message}"}}).encode("utf-8")
+        elif platform == "slack":
+            payload = json.dumps({"text": f"*{title}*\n{message}"}).encode("utf-8")
+        elif platform == "discord":
+            payload = json.dumps({"content": f"**{title}**\n{message}"}).encode("utf-8")
+        elif platform == "telegram":
+            payload = json.dumps({"text": f"*{title}*\n{message}", "parse_mode": "Markdown"}).encode("utf-8")
+        else:
+            payload = json.dumps({"title": title, "message": message}).encode("utf-8")
+
+        req = urllib.request.Request(wurl, data=payload, headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read().decode("utf-8")
+
+        return success_response(
+            message=f"通知已发送到 '{channel}' ({platform})。\n标题: {title}\n内容: {message[:100]}"
+        )
+    except Exception as e:
+        return error_response(
+            message=f"发送通知失败: {e}\n建议：\n1. 检查 Webhook URL 是否正确\n2. 确认网络连接\n3. 检查平台密钥配置",
+            code="NOTIFY_ERROR",
+        )

--- a/backend/mcp/tools/system/shell_execute.py
+++ b/backend/mcp/tools/system/shell_execute.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""执行 shell 命令并返回输出（有超时和输出大小限制）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="shell_execute",
+        description="执行 shell 命令并返回输出（有超时和输出大小限制）",
+        schema={
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "要执行的命令"},
+                "timeout": {"type": "integer", "default": 30, "description": "超时秒数（最大120）"},
+                "cwd": {"type": "string", "description": "工作目录"}
+            },
+            "required": ["command"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """shell_execute handler"""
+    import subprocess as _subprocess
+    import os as _os
+
+    command = args.get("command", "")
+    timeout = min(int(args.get("timeout", 30)), 120)
+    cwd = args.get("cwd", "")
+
+    if not command:
+        return error_response(
+            "请提供命令",
+            code="INVALID_ARGS",
+        )
+
+    try:
+        actual_cwd = cwd or _os.getcwd()
+        result = _subprocess.run(
+            command, shell=True, capture_output=True, text=True,
+            timeout=timeout, cwd=actual_cwd,
+            env={**_subprocess.os.environ, "PAGER": "cat"}
+        )
+        output = result.stdout or ""
+        error = result.stderr or ""
+        exit_code = result.returncode
+
+        # 截断过长输出
+        max_output = 10000
+        truncated_output = False
+        truncated_error = False
+        if len(output) > max_output:
+            output = output[:max_output]
+            truncated_output = True
+        if len(error) > max_output:
+            error = error[:max_output]
+            truncated_error = True
+
+        # 构建输出部分
+        parts = [f"命令: {command}"]
+        parts.append(f"工作目录: {actual_cwd}")
+        parts.append(f"退出码: {exit_code}")
+
+        if output:
+            # 长输出格式化
+            output_lines = output.split("\n")
+            total_lines = len(output_lines)
+            if total_lines > 500:
+                display_lines = output_lines[:500]
+                output = "\n".join(display_lines)
+                output += f"\n\n... (共 {total_lines} 行，显示第 1-500 行)"
+            parts.append(f"\n--- stdout ---\n{output}")
+            if truncated_output:
+                parts.append(f"\n[输出已截断，原始 stdout 共 {len(result.stdout)} 字符]")
+
+        if error:
+            parts.append(f"\n--- stderr ---\n{error}")
+            if truncated_error:
+                parts.append(f"\n[错误已截断，原始 stderr 共 {len(result.stderr)} 字符]")
+
+        # 错误信息增强
+        if exit_code == 127:
+            cmd_name = command.strip().split()[0] if command.strip() else "未知"
+            parts.append(f"\n⚠️ 命令 '{cmd_name}' 不存在")
+            parts.append("建议：")
+            parts.append(f"1. 检查命令拼写是否正确（常见拼写错误：'sl' → 'ls'，'cd..' → 'cd ..'）")
+            parts.append(f"2. 使用 'which {cmd_name}' 或 'command -v {cmd_name}' 确认命令是否已安装")
+            parts.append(f"3. 如果需要安装，尝试：apt install {cmd_name} / brew install {cmd_name} / pip install {cmd_name}")
+            parts.append(f"4. 如果是 Python 包，尝试：pip install $(echo {cmd_name} | tr '-' '_')")
+        elif exit_code == 126:
+            parts.append("\n⚠️ 权限不足，无法执行命令")
+            parts.append("建议：")
+            parts.append("1. 使用 sudo 重新执行命令（如 sudo apt update）")
+            parts.append("2. 检查文件权限：ls -la <命令路径>")
+            parts.append("3. 如果是脚本文件，添加执行权限：chmod +x <文件路径>")
+            parts.append("4. 确认当前用户是否在正确的用户组中")
+        elif exit_code != 0:
+            parts.append(f"\n⚠️ 命令执行失败（退出码 {exit_code}）")
+            if error:
+                error_lines = [l.strip() for l in error.strip().split("\n") if l.strip()]
+                if error_lines:
+                    parts.append(f"错误摘要: {error_lines[-1]}")
+            parts.append("建议：")
+            parts.append("1. 检查命令参数是否正确")
+            parts.append("2. 查看上方 stderr 输出中的详细错误信息")
+            parts.append("3. 尝试使用 --help 或 -h 查看命令帮助")
+            parts.append("4. 如果是编译/构建错误，检查依赖是否完整安装")
+
+        return success_response("\n".join(parts))
+    except _subprocess.TimeoutExpired:
+        return error_response(
+            f"命令执行超时（{timeout}秒）\n建议：\n1. 将命令拆分为多个较短的子命令分步执行\n2. 增加 timeout 参数值（最大支持 120 秒）\n3. 如果是长时间运行的任务，考虑使用 nohup 或 screen 在后台执行",
+            code="TIMEOUT",
+        )
+    except Exception as e:
+        return error_response(
+            f"命令执行失败: {e}\n建议：\n1. 检查命令语法是否正确，尤其是引号、管道符和分号的使用\n2. 确认命令所需的依赖和程序已安装（使用 which 或 command -v 检查）\n3. 查看 stderr 输出中的具体错误信息以定位问题",
+            code="EXEC_ERROR",
+        )

--- a/backend/mcp/tools/system/update_config.py
+++ b/backend/mcp/tools/system/update_config.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""更新系统配置"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="update_config",
+        description="更新系统配置",
+        schema={
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "number", "description": "模型温度（0-2）"},
+                "log_level": {"type": "string", "description": "日志级别（DEBUG/INFO/WARNING/ERROR）"}
+            }
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """update_config handler"""
+    try:
+        import yaml
+        from backend.config import get_hermes_home, reload_config
+
+        hermes_home = get_hermes_home()
+        config_path = hermes_home / "config.yaml"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            except Exception:
+                pass
+        existing.update(args)
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(yaml.dump(existing, allow_unicode=True, default_flow_style=False), encoding="utf-8")
+        reload_config()  # 清除缓存，使 get_config 读取最新配置
+        result = f"配置已更新: {', '.join(args.keys())}"
+        return success_response(result)
+    except Exception as e:
+        return error_response(f"更新配置失败: {e}")

--- a/backend/mcp/tools/system/web_fetch.py
+++ b/backend/mcp/tools/system/web_fetch.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""抓取网页内容并返回纯文本"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="web_fetch",
+        description="抓取网页内容并返回纯文本",
+        schema={
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "网页 URL"},
+                "max_length": {"type": "integer", "default": 5000, "description": "最大返回字符数"}
+            },
+            "required": ["url"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """web_fetch handler"""
+    url = args.get("url", "")
+    max_length = int(args.get("max_length", 5000))
+
+    if not url:
+        return error_response(
+            "请提供 URL",
+            code="INVALID_ARGS",
+        )
+
+    try:
+        import urllib.request as _ur
+        import re as _re
+
+        req = _ur.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with _ur.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+        # 移除 script/style 标签
+        html = _re.sub(r'<script[^>]*>.*?</script>', '', html, flags=_re.DOTALL | _re.IGNORECASE)
+        html = _re.sub(r'<style[^>]*>.*?</style>', '', html, flags=_re.DOTALL | _re.IGNORECASE)
+        # 移除 HTML 标签
+        text = _re.sub(r'<[^>]+>', ' ', html)
+        # 清理空白
+        text = _re.sub(r'\s+', ' ', text).strip()
+        if len(text) > max_length:
+            text = text[:max_length] + f"\n... (内容已截断，共 {len(text)} 字符)"
+        result = f"URL: {url}\n长度: {len(text)} 字符\n{'='*50}\n{text}"
+        return success_response(result)
+    except Exception as e:
+        return error_response(
+            f"抓取网页失败: {e}\n建议：\n1. 检查 URL 是否正确且可访问（在浏览器中打开确认）\n2. 某些网站可能拒绝非浏览器请求，尝试其他网站\n3. 检查网络连接是否正常，确认目标服务器未宕机",
+            code="FETCH_ERROR",
+        )

--- a/backend/mcp/tools/system/web_search.py
+++ b/backend/mcp/tools/system/web_search.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""搜索网页内容（使用 DuckDuckGo）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="web_search",
+        description="搜索网页内容（使用 DuckDuckGo）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "max_results": {"type": "integer", "default": 5, "description": "最大结果数"}
+            },
+            "required": ["query"]
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def _fallback_search(query: str, max_results: int) -> str:
+    """降级搜索：使用 requests + DuckDuckGo HTML"""
+    import urllib.parse as _up
+    import urllib.request as _ur
+    import ssl as _ssl
+    import re as _re
+
+    url = f"https://html.duckduckgo.com/html/?q={_up.quote(query)}"
+    req = _ur.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    ctx = _ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = _ssl.CERT_NONE
+    with _ur.urlopen(req, timeout=10, context=ctx) as resp:
+        html = resp.read().decode("utf-8", errors="replace")
+    # 提取搜索结果
+    results = _re.findall(
+        r'class="result__a"[^>]*>(.*?)</a>.*?class="result__snippet"[^>]*>(.*?)</a>',
+        html, _re.DOTALL,
+    )
+    if not results:
+        return f"未找到 '{query}' 的搜索结果"
+    output = []
+    for i, (title, snippet) in enumerate(results[:max_results]):
+        clean_title = _re.sub(r'<[^>]+>', '', title).strip()
+        clean_snippet = _re.sub(r'<[^>]+>', '', snippet).strip()
+        output.append(f"{i+1}. {clean_title}\n   {clean_snippet}")
+    return f"搜索: {query}\n{'='*50}\n\n" + "\n\n".join(output)
+
+
+def handle(args: dict) -> dict:
+    """web_search handler"""
+    query = args.get("query", "")
+    max_results = int(args.get("max_results", 5))
+
+    if not query:
+        return error_response(
+            "请提供搜索关键词",
+            code="INVALID_ARGS",
+        )
+
+    try:
+        from duckduckgo_search import DDGS
+
+        results = []
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=max_results):
+                results.append(
+                    f"标题: {r.get('title', '')}\n链接: {r.get('href', '')}\n摘要: {r.get('body', '')}"
+                )
+        if not results:
+            return success_response(f"未找到 '{query}' 的搜索结果")
+        result = f"搜索: {query}\n{'='*50}\n\n" + "\n\n---\n\n".join(results)
+        return success_response(result)
+    except ImportError:
+        # 降级：使用 requests + DuckDuckGo HTML
+        try:
+            result = _fallback_search(query, max_results)
+            return success_response(result)
+        except Exception as e:
+            return error_response(
+                f"搜索失败: {e}\n建议：\n1. 尝试使用英文关键词重新搜索，可能获得更多结果\n2. 简化关键词，避免过于复杂的查询\n3. 如果持续失败，可能是网络连接问题，请检查网络状态",
+                code="SEARCH_ERROR",
+            )
+    except Exception as e:
+        # DDGS 库存在但调用失败，尝试降级
+        try:
+            result = _fallback_search(query, max_results)
+            return success_response(result)
+        except Exception as e2:
+            return error_response(
+                f"搜索失败: {e2}\n建议：\n1. 尝试使用英文关键词重新搜索，可能获得更多结果\n2. 简化关键词，避免过于复杂的查询\n3. 如果持续失败，可能是网络连接问题，请检查网络状态",
+                code="SEARCH_ERROR",
+            )


### PR DESCRIPTION
## Phase 1: 核心工具积木化

将 `mcp_server.py` 中的 53 个工具迁移为独立积木块模块，每个工具 = 1 个 Python 文件。

### 迁移统计

| 工具组 | 数量 | 目录 |
|--------|------|------|
| System | 21 | `backend/mcp/tools/system/` |
| Session | 8 | `backend/mcp/tools/session/` |
| Skill | 8 | `backend/mcp/tools/skill/` |
| Memory | 12 | `backend/mcp/tools/memory/` |
| File | 4 | `backend/mcp/tools/file/` |
| **合计** | **53** | |

### 新增文件
- 53 个工具模块文件（2,880 行）
- 每个文件包含 `register(reg)` + `handle(args)` 标准接口
- Schema 从 `_get_tools()` 精确提取
- Handler 逻辑从 `_call_tool()` 完整复制

### 集成测试
- ✅ 53/53 工具被 ToolRegistry 自动发现
- ✅ 所有工具 schema 与原定义一致
- ✅ 所有工具 handler 逻辑与原实现等价

### 关联 Issue

Closes #15, Closes #16, Closes #17, Closes #18, Closes #19