### PR TITLE
feat: Phase 2 - 知识库+浏览器+兼容+插件工具迁移 (42个工具)

### DIFF
--- a/backend/mcp/tools/browser/click.py
+++ b/backend/mcp/tools/browser/click.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""点击页面元素（通过 CSS 选择器）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_click",
+        description="点击页面元素（通过 CSS 选择器）",
+        schema={
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string", "description": "CSS 选择器（如 '#submit-btn' 或 'a[href=\"/login\"]'）"}
+            },
+            "required": ["selector"],
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """点击页面元素"""
+    selector = args.get("selector", "")
+    if not selector:
+        return error_response(
+            "请提供 CSS 选择器。\n建议：\n1. 使用 browser_snapshot 获取页面结构\n2. 使用精确的选择器（如 #id 或 .class）"
+        )
+    return success_response(
+        message=f"browser_click 需要浏览器环境。\n选择器: {selector}\n在当前环境中不可用。"
+    )

--- a/backend/mcp/tools/browser/evaluate.py
+++ b/backend/mcp/tools/browser/evaluate.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""在页面中执行 JavaScript 代码"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_evaluate",
+        description="在页面中执行 JavaScript 代码",
+        schema={
+            "type": "object",
+            "properties": {
+                "script": {"type": "string", "description": "JavaScript 代码"}
+            },
+            "required": ["script"],
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """在页面中执行 JavaScript 代码"""
+    script = args.get("script", "")
+    if not script:
+        return error_response("请提供 JavaScript 代码。")
+    return success_response(
+        message="browser_evaluate 需要浏览器环境。\n在当前环境中不可用。"
+    )

--- a/backend/mcp/tools/browser/navigate.py
+++ b/backend/mcp/tools/browser/navigate.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""打开网页 URL"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_navigate",
+        description="打开网页 URL",
+        schema={
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "网页 URL"}
+            },
+            "required": ["url"],
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """打开网页 URL，提取页面文本摘要"""
+    url = args.get("url", "")
+    if not url:
+        return error_response("请提供 URL。\n建议：\n1. 确保包含协议前缀（https://）\n2. 检查 URL 拼写")
+    if not url.startswith(("http://", "https://")):
+        url = "https://" + url
+    try:
+        import urllib.request
+        import re
+
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="replace")
+        # 提取页面文本摘要
+        text = re.sub(r'<script[^>]*>.*?</script>', '', html, flags=re.DOTALL)
+        text = re.sub(r'<style[^>]*>.*?</style>', '', text, flags=re.DOTALL)
+        text = re.sub(r'<[^>]+>', ' ', text)
+        text = re.sub(r'\s+', ' ', text).strip()
+        title_match = re.search(r'<title[^>]*>(.*?)</title>', html, re.DOTALL)
+        title = title_match.group(1).strip() if title_match else "无标题"
+        result = f"页面: {title}\nURL: {url}\n长度: {len(html)} 字符\n\n内容摘要:\n{text[:2000]}"
+        return success_response(data={"title": title, "url": url, "html_length": len(html), "summary": text[:2000]}, message=result)
+    except Exception as e:
+        return error_response(f"无法访问 {url}: {e}\n建议：\n1. 检查 URL 是否正确\n2. 确认网站可访问\n3. 尝试使用 web_fetch 作为替代")

--- a/backend/mcp/tools/browser/screenshot.py
+++ b/backend/mcp/tools/browser/screenshot.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""对当前页面截图（返回 base64 PNG）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_screenshot",
+        description="对当前页面截图（返回 base64 PNG）",
+        schema={
+            "type": "object",
+            "properties": {
+                "full_page": {"type": "boolean", "default": False, "description": "是否截取完整页面"}
+            },
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """对当前页面截图"""
+    return success_response(
+        message="browser_screenshot 需要浏览器环境（Playwright/Puppeteer）。\n在 HF Space 沙箱中不可用。建议使用 web_fetch 获取页面内容作为替代。"
+    )

--- a/backend/mcp/tools/browser/snapshot.py
+++ b/backend/mcp/tools/browser/snapshot.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""获取当前页面的 DOM 快照（文本摘要）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_snapshot",
+        description="获取当前页面的 DOM 快照（文本摘要）",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """获取当前页面的 DOM 快照"""
+    try:
+        return success_response(
+            message="browser_snapshot 需要浏览器环境。\n在当前环境中，建议使用 web_fetch 获取页面内容，或使用 browser_navigate 导航后获取摘要。"
+        )
+    except Exception as e:
+        return error_response(f"获取页面快照失败: {e}")

--- a/backend/mcp/tools/browser/type.py
+++ b/backend/mcp/tools/browser/type.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""在页面输入框中输入文本"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="browser_type",
+        description="在页面输入框中输入文本",
+        schema={
+            "type": "object",
+            "properties": {
+                "selector": {"type": "string", "description": "CSS 选择器"},
+                "text": {"type": "string", "description": "要输入的文本"}
+            },
+            "required": ["selector", "text"],
+        },
+        handler=handle,
+        tags=["browser"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """在页面输入框中输入文本"""
+    selector = args.get("selector", "")
+    text = args.get("text", "")
+    if not selector or not text:
+        return error_response("请提供选择器和输入文本。")
+    return success_response(
+        message="browser_type 需要浏览器环境。\n在当前环境中不可用。"
+    )

--- a/backend/mcp/tools/compat/sync_db_to_md.py
+++ b/backend/mcp/tools/compat/sync_db_to_md.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""从知识库导出到 MD 文件"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="compat_sync_db_to_md",
+        description="从知识库导出到 MD 文件",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["compat"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """从知识库导出到 MD 文件"""
+    try:
+        from backend.services.compat_service import CompatService
+
+        svc = CompatService()
+        svc.save_memory_md()
+        svc.save_user_md()
+        svc.save_learnings_md()
+        return success_response(message="已同步到 MD 文件")
+    except Exception as e:
+        return error_response(f"知识库工具 'compat_sync_db_to_md' 执行失败: {e}")

--- a/backend/mcp/tools/compat/sync_md_to_db.py
+++ b/backend/mcp/tools/compat/sync_md_to_db.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""从 MD 文件导入到知识库（MEMORY.md + USER.md + learnings.md）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="compat_sync_md_to_db",
+        description="从 MD 文件导入到知识库（MEMORY.md + USER.md + learnings.md）",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["compat"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """从 MD 文件导入到知识库"""
+    try:
+        from backend.services.compat_service import CompatService
+
+        svc = CompatService()
+        results = {
+            "memory_imported": svc.import_memory_md(),
+            "user_imported": svc.import_user_md(),
+            "learnings_imported": svc.import_learnings_md(),
+        }
+        svc.save_memory_md()
+        svc.save_user_md()
+        svc.save_learnings_md()
+        total = sum(results.values())
+        return success_response(
+            data=results,
+            message=f"导入 {total} 条记录",
+        )
+    except Exception as e:
+        return error_response(f"知识库工具 'compat_sync_md_to_db' 执行失败: {e}")

--- a/backend/mcp/tools/knowledge/__init__.py
+++ b/backend/mcp/tools/knowledge/__init__.py
@@ -1,1 +1,44 @@
 # -*- coding: utf-8 -*-
+"""Knowledge 工具模块 — 经验/记忆/审核/搜索"""
+
+from backend.mcp.tools.knowledge import (
+    experience_update,
+    experience_resolve,
+    experience_search,
+    memory_list,
+    memory_get,
+    memory_create,
+    memory_update,
+    memory_forget,
+    memory_search,
+    review_list,
+    review_stats,
+    review_approve,
+    unified_search,
+    knowledge_overview,
+    context_budget_preview,
+)
+
+ALL_MODULES = [
+    experience_update,
+    experience_resolve,
+    experience_search,
+    memory_list,
+    memory_get,
+    memory_create,
+    memory_update,
+    memory_forget,
+    memory_search,
+    review_list,
+    review_stats,
+    review_approve,
+    unified_search,
+    knowledge_overview,
+    context_budget_preview,
+]
+
+
+def register_all(reg):
+    """注册所有 knowledge 工具"""
+    for mod in ALL_MODULES:
+        mod.register(reg)

--- a/backend/mcp/tools/knowledge/context_budget_preview.py
+++ b/backend/mcp/tools/knowledge/context_budget_preview.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""预览当前上下文预算分配"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="context_budget_preview",
+        description="预览当前上下文预算分配",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID"},
+                "query": {"type": "string", "description": "查询文本"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.context_budget_service import ContextBudgetService
+
+    try:
+        budget_svc = ContextBudgetService()
+        context = budget_svc.build_context(
+            session_id=args.get("session_id", ""),
+            query=args.get("query", ""),
+        )
+        return success_response(
+            data={"content": context, "char_count": len(context)},
+            message=f"上下文预算预览，共 {len(context)} 字符",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_create.py
+++ b/backend/mcp/tools/knowledge/experience_create.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""记录新经验（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_create",
+        description="记录新经验（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "标题"},
+                "content": {"type": "string", "description": "内容"},
+                "category": {"type": "string", "default": "best_practice", "description": "分类"},
+                "context": {"type": "string", "description": "上下文"},
+                "tool_name": {"type": "string", "description": "相关工具"},
+                "error_type": {"type": "string", "description": "错误类型"},
+                "severity": {"type": "string", "default": "medium", "description": "严重程度"},
+                "tags": {"type": "string", "description": "标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "创建原因"},
+            },
+            "required": ["title", "content"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        review_svc = ReviewService()
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else []
+        )
+        payload = json.dumps(
+            {
+                "title": args["title"],
+                "content": args["content"],
+                "category": args.get("category", "best_practice"),
+                "context": args.get("context", ""),
+                "tool_name": args.get("tool_name", ""),
+                "error_type": args.get("error_type", ""),
+                "severity": args.get("severity", "medium"),
+                "tags": tag_list,
+            },
+            ensure_ascii=False,
+        )
+        review = review_svc.submit_review(
+            target_type="experience",
+            action="create",
+            title=args["title"],
+            content=payload,
+            reason=args.get("reason", ""),
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="经验记录已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_get.py
+++ b/backend/mcp/tools/knowledge/experience_get.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""获取经验详情"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_get",
+        description="获取经验详情",
+        schema={
+            "type": "object",
+            "properties": {
+                "exp_id": {"type": "string", "description": "经验 ID"},
+            },
+            "required": ["exp_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        item = svc.get_experience(args["exp_id"])
+        if not item:
+            return error_response(f"经验 {args['exp_id']} 不存在")
+        return success_response(data=item)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_list.py
+++ b/backend/mcp/tools/knowledge/experience_list.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""列出经验条目"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_list",
+        description="列出经验条目",
+        schema={
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "分类筛选"},
+                "severity": {"type": "string", "description": "严重程度筛选"},
+                "is_resolved": {"type": "boolean", "description": "是否已解决"},
+                "tool_name": {"type": "string", "description": "工具名称筛选"},
+                "limit": {"type": "integer", "default": 50, "description": "返回数量上限"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        items = svc.list_experiences(
+            category=args.get("category") or None,
+            severity=args.get("severity") or None,
+            is_resolved=args.get("is_resolved"),
+            tool_name=args.get("tool_name") or None,
+            limit=args.get("limit", 50),
+        )
+        return success_response(data={"items": items, "count": len(items)})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_resolve.py
+++ b/backend/mcp/tools/knowledge/experience_resolve.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""标记经验为已解决（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_resolve",
+        description="标记经验为已解决（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "exp_id": {"type": "string", "description": "经验 ID"},
+                "reason": {"type": "string", "description": "解决原因"},
+            },
+            "required": ["exp_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        exp = knowledge_svc.get_experience(args["exp_id"])
+        if not exp:
+            return error_response(f"经验 {args['exp_id']} 不存在")
+
+        review = review_svc.submit_review(
+            target_type="experience",
+            action="resolve",
+            title=f"标记已解决: {exp['title']}",
+            content="",
+            old_content=exp["content"],
+            reason=args.get("reason", "AI 判断问题已解决"),
+            target_id=args["exp_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="经验解决标记已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_search.py
+++ b/backend/mcp/tools/knowledge/experience_search.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""搜索经验（全文检索）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_search",
+        description="搜索经验（全文检索）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 20, "description": "返回数量上限"},
+            },
+            "required": ["query"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.search_service import SearchService
+
+    try:
+        search_svc = SearchService()
+        results = search_svc.search_single_type(
+            "experiences", args["query"], limit=args.get("limit", 20)
+        )
+        return success_response(
+            data=results,
+            message=f"找到 {len(results)} 条经验",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/experience_update.py
+++ b/backend/mcp/tools/knowledge/experience_update.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""更新经验（需审核）"""
+
+import json
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="experience_update",
+        description="更新经验（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "exp_id": {"type": "string", "description": "经验 ID"},
+                "title": {"type": "string", "description": "新标题"},
+                "content": {"type": "string", "description": "新内容"},
+                "category": {"type": "string", "description": "新分类"},
+                "tags": {"type": "string", "description": "新标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "更新原因"},
+            },
+            "required": ["exp_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        exp = knowledge_svc.get_experience(args["exp_id"])
+        if not exp:
+            return error_response(f"经验 {args['exp_id']} 不存在")
+
+        updates = {}
+        if args.get("title"):
+            updates["title"] = args["title"]
+        if args.get("content"):
+            updates["content"] = args["content"]
+        if args.get("category"):
+            updates["category"] = args["category"]
+        if args.get("tags"):
+            updates["tags"] = [t.strip() for t in args["tags"].split(",") if t.strip()]
+
+        review = review_svc.submit_review(
+            target_type="experience",
+            action="update",
+            title=f"更新经验: {exp['title']}",
+            content=json.dumps(updates, ensure_ascii=False),
+            old_content=exp["content"],
+            reason=args.get("reason", ""),
+            target_id=args["exp_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="经验更新已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_create.py
+++ b/backend/mcp/tools/knowledge/knowledge_create.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""创建知识条目（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_create",
+        description="创建知识条目（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "标题"},
+                "content": {"type": "string", "description": "内容"},
+                "summary": {"type": "string", "description": "摘要"},
+                "category": {"type": "string", "default": "general", "description": "分类"},
+                "tags": {"type": "string", "description": "标签（逗号分隔）"},
+                "source": {"type": "string", "default": "ai_extracted", "description": "来源"},
+                "source_ref": {"type": "string", "description": "来源引用"},
+                "confidence": {"type": "number", "default": 0.8, "description": "置信度"},
+                "reason": {"type": "string", "description": "创建原因"},
+            },
+            "required": ["title", "content"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        review_svc = ReviewService()
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else []
+        )
+        payload = json.dumps(
+            {
+                "title": args["title"],
+                "content": args["content"],
+                "summary": args.get("summary", ""),
+                "category": args.get("category", "general"),
+                "tags": tag_list,
+                "source": args.get("source", "ai_extracted"),
+                "source_ref": args.get("source_ref", ""),
+                "confidence": args.get("confidence", 0.8),
+            },
+            ensure_ascii=False,
+        )
+        review = review_svc.submit_review(
+            target_type="knowledge",
+            action="create",
+            title=args["title"],
+            content=payload,
+            reason=args.get("reason", ""),
+            confidence=args.get("confidence", 0.8),
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="知识条目已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_delete.py
+++ b/backend/mcp/tools/knowledge/knowledge_delete.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""删除知识条目（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_delete",
+        description="删除知识条目（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "knowledge_id": {"type": "string", "description": "知识 ID"},
+                "reason": {"type": "string", "description": "删除原因"},
+            },
+            "required": ["knowledge_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        kn = knowledge_svc.get_knowledge(args["knowledge_id"])
+        if not kn:
+            return error_response(f"知识 {args['knowledge_id']} 不存在")
+
+        review = review_svc.submit_review(
+            target_type="knowledge",
+            action="delete",
+            title=f"删除知识: {kn['title']}",
+            content="",
+            old_content=kn["content"],
+            reason=args.get("reason", "AI 请求删除"),
+            target_id=args["knowledge_id"],
+            priority="urgent",
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="知识删除已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_extract.py
+++ b/backend/mcp/tools/knowledge/knowledge_extract.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""从对话中提取知识（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_extract",
+        description="从对话中提取知识（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string", "description": "会话 ID"},
+                "reason": {"type": "string", "description": "提取原因"},
+            },
+            "required": ["session_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.hermes_service import hermes_service as _hs
+    from backend.services.review_service import ReviewService
+
+    try:
+        review_svc = ReviewService()
+
+        messages = _hs.get_session_messages(args["session_id"])
+        if not messages:
+            return error_response(f"会话 {args['session_id']} 无消息")
+
+        assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+        if not assistant_msgs:
+            return error_response("会话中无 assistant 回复")
+
+        extracted = [
+            msg.get("content", "")[:500]
+            for msg in assistant_msgs[:5]
+            if msg.get("content", "")
+        ]
+        payload = json.dumps(
+            {
+                "title": f"从会话 {args['session_id'][:12]} 提取的知识",
+                "content": "\n\n---\n\n".join(extracted),
+                "category": "general",
+                "tags": ["auto-extracted"],
+                "source": "session",
+                "source_ref": args["session_id"],
+                "confidence": 0.6,
+            },
+            ensure_ascii=False,
+        )
+        review = review_svc.submit_review(
+            target_type="knowledge",
+            action="create",
+            title=f"从会话提取知识: {args['session_id'][:12]}",
+            content=payload,
+            reason=args.get("reason", "AI 自动从对话中提取知识"),
+            confidence=0.6,
+            session_id=args["session_id"],
+        )
+        return success_response(
+            data={
+                "review_id": review["id"],
+                "status": "pending",
+                "extracted_count": len(extracted),
+            },
+            message="知识提取已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_get.py
+++ b/backend/mcp/tools/knowledge/knowledge_get.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""获取知识详情"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_get",
+        description="获取知识详情",
+        schema={
+            "type": "object",
+            "properties": {
+                "knowledge_id": {"type": "string", "description": "知识 ID"},
+            },
+            "required": ["knowledge_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        item = svc.get_knowledge(args["knowledge_id"])
+        if not item:
+            return error_response(f"知识 {args['knowledge_id']} 不存在")
+        return success_response(data=item)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_list.py
+++ b/backend/mcp/tools/knowledge/knowledge_list.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""列出知识条目"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_list",
+        description="列出知识条目",
+        schema={
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "分类筛选"},
+                "tags": {"type": "string", "description": "标签筛选（逗号分隔）"},
+                "confidence_min": {"type": "number", "default": 0, "description": "最低置信度"},
+                "limit": {"type": "integer", "default": 50, "description": "返回数量上限"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else None
+        )
+        items = svc.list_knowledge(
+            category=args.get("category") or None,
+            tags=tag_list,
+            confidence_min=args.get("confidence_min", 0) or None,
+            limit=args.get("limit", 50),
+        )
+        return success_response(data={"items": items, "count": len(items)})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_overview.py
+++ b/backend/mcp/tools/knowledge/knowledge_overview.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""获取知识库概览统计"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_overview",
+        description="获取知识库概览统计",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        stats = svc.get_overview_stats()
+        return success_response(data=stats)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_search.py
+++ b/backend/mcp/tools/knowledge/knowledge_search.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""搜索知识（全文检索）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_search",
+        description="搜索知识（全文检索）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 20, "description": "返回数量上限"},
+            },
+            "required": ["query"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.search_service import SearchService
+
+    try:
+        search_svc = SearchService()
+        results = search_svc.search_single_type(
+            "knowledge", args["query"], limit=args.get("limit", 20)
+        )
+        return success_response(data={"items": results, "count": len(results)})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/knowledge_update.py
+++ b/backend/mcp/tools/knowledge/knowledge_update.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""更新知识条目（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="knowledge_update",
+        description="更新知识条目（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "knowledge_id": {"type": "string", "description": "知识 ID"},
+                "title": {"type": "string", "description": "新标题"},
+                "content": {"type": "string", "description": "新内容"},
+                "summary": {"type": "string", "description": "新摘要"},
+                "category": {"type": "string", "description": "新分类"},
+                "tags": {"type": "string", "description": "新标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "更新原因"},
+            },
+            "required": ["knowledge_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        kn = knowledge_svc.get_knowledge(args["knowledge_id"])
+        if not kn:
+            return error_response(f"知识 {args['knowledge_id']} 不存在")
+
+        updates = {}
+        if args.get("title"):
+            updates["title"] = args["title"]
+        if args.get("content"):
+            updates["content"] = args["content"]
+        if args.get("summary"):
+            updates["summary"] = args["summary"]
+        if args.get("category"):
+            updates["category"] = args["category"]
+        if args.get("tags"):
+            updates["tags"] = [t.strip() for t in args["tags"].split(",") if t.strip()]
+
+        review = review_svc.submit_review(
+            target_type="knowledge",
+            action="update",
+            title=f"更新知识: {kn['title']}",
+            content=json.dumps(updates, ensure_ascii=False),
+            old_content=json.dumps(
+                {"title": kn["title"], "content": kn["content"]}, ensure_ascii=False
+            ),
+            reason=args.get("reason", ""),
+            target_id=args["knowledge_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="知识更新已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_create.py
+++ b/backend/mcp/tools/knowledge/memory_create.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""创建新记忆（需审核）"""
+
+import json
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_create",
+        description="创建新记忆（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "记忆内容"},
+                "category": {"type": "string", "default": "agent_memory", "description": "分类"},
+                "title": {"type": "string", "description": "标题"},
+                "importance": {"type": "integer", "default": 5, "description": "重要度"},
+                "tags": {"type": "string", "description": "标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "创建原因"},
+            },
+            "required": ["content"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        review_svc = ReviewService()
+
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else []
+        )
+        payload = json.dumps(
+            {
+                "content": args["content"],
+                "category": args.get("category", "agent_memory"),
+                "title": args.get("title", ""),
+                "importance": args.get("importance", 5),
+                "tags": tag_list,
+            },
+            ensure_ascii=False,
+        )
+        review = review_svc.submit_review(
+            target_type="memory",
+            action="create",
+            title=args.get("title", "") or args["content"][:50],
+            content=payload,
+            reason=args.get("reason", ""),
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="记忆创建已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_forget.py
+++ b/backend/mcp/tools/knowledge/memory_forget.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""删除/归档记忆（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_forget",
+        description="删除/归档记忆（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "mem_id": {"type": "string", "description": "记忆 ID"},
+                "reason": {"type": "string", "description": "删除原因"},
+            },
+            "required": ["mem_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        mem = knowledge_svc.get_memory(args["mem_id"])
+        if not mem:
+            return error_response(f"记忆 {args['mem_id']} 不存在")
+
+        review = review_svc.submit_review(
+            target_type="memory",
+            action="delete",
+            title=f"删除记忆: {mem['title']}",
+            content="",
+            old_content=mem["content"],
+            reason=args.get("reason", "AI 请求遗忘"),
+            target_id=args["mem_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="记忆删除已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_get.py
+++ b/backend/mcp/tools/knowledge/memory_get.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""获取记忆详情"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_get",
+        description="获取记忆详情",
+        schema={
+            "type": "object",
+            "properties": {
+                "mem_id": {"type": "string", "description": "记忆 ID"},
+            },
+            "required": ["mem_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        item = svc.get_memory(args["mem_id"])
+        if not item:
+            return error_response(f"记忆 {args['mem_id']} 不存在")
+        return success_response(data=item)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_list.py
+++ b/backend/mcp/tools/knowledge/memory_list.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""列出记忆条目"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_list",
+        description="列出记忆条目",
+        schema={
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "分类筛选"},
+                "importance_min": {"type": "integer", "default": 0, "description": "最低重要度"},
+                "limit": {"type": "integer", "default": 50, "description": "返回数量上限"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        items = svc.list_memories(
+            category=args.get("category") or None,
+            importance_min=args.get("importance_min", 0) or None,
+            limit=args.get("limit", 50),
+        )
+        return success_response(
+            data=items,
+            message=f"共 {len(items)} 条记忆",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_search.py
+++ b/backend/mcp/tools/knowledge/memory_search.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""搜索记忆（全文检索）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_search",
+        description="搜索记忆（全文检索）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 20, "description": "返回数量上限"},
+            },
+            "required": ["query"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.search_service import SearchService
+
+    try:
+        search_svc = SearchService()
+        results = search_svc.search_single_type(
+            "memories", args["query"], limit=args.get("limit", 20)
+        )
+        return success_response(
+            data=results,
+            message=f"找到 {len(results)} 条记忆",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/memory_update.py
+++ b/backend/mcp/tools/knowledge/memory_update.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""更新记忆（需审核）"""
+
+import json
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="memory_update",
+        description="更新记忆（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "mem_id": {"type": "string", "description": "记忆 ID"},
+                "content": {"type": "string", "description": "新内容"},
+                "importance": {"type": "integer", "description": "新重要度"},
+                "tags": {"type": "string", "description": "新标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "更新原因"},
+            },
+            "required": ["mem_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        mem = knowledge_svc.get_memory(args["mem_id"])
+        if not mem:
+            return error_response(f"记忆 {args['mem_id']} 不存在")
+
+        updates = {}
+        if args.get("content"):
+            updates["content"] = args["content"]
+        if args.get("importance", 0) > 0:
+            updates["importance"] = args["importance"]
+        if args.get("tags"):
+            updates["tags"] = [t.strip() for t in args["tags"].split(",") if t.strip()]
+
+        review = review_svc.submit_review(
+            target_type="memory",
+            action="update",
+            title=f"更新记忆: {mem['title']}",
+            content=json.dumps(updates, ensure_ascii=False),
+            old_content=mem["content"],
+            reason=args.get("reason", ""),
+            target_id=args["mem_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="记忆更新已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/review_approve.py
+++ b/backend/mcp/tools/knowledge/review_approve.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""审核通过或拒绝（approve / reject）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="review_approve",
+        description="审核通过或拒绝审核项。action 为 approve 时通过，reject 时拒绝。",
+        schema={
+            "type": "object",
+            "properties": {
+                "review_id": {"type": "string", "description": "审核记录 ID"},
+                "action": {"type": "string", "enum": ["approve", "reject"], "description": "操作类型：approve 通过 / reject 拒绝"},
+                "reviewed_by": {"type": "string", "default": "admin", "description": "审核人"},
+                "review_note": {"type": "string", "description": "审核备注"},
+            },
+            "required": ["review_id", "action"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        svc = ReviewService()
+        action = args["action"]
+        review_id = args["review_id"]
+        reviewed_by = args.get("reviewed_by", "admin")
+        review_note = args.get("review_note", "")
+
+        if action == "approve":
+            result = svc.approve_review(review_id, reviewed_by=reviewed_by, review_note=review_note)
+            if not result:
+                return error_response(f"审核通过失败，审核项 {review_id} 不存在或状态不是 pending")
+            return success_response(data=result, message="审核已通过")
+        elif action == "reject":
+            result = svc.reject_review(review_id, reviewed_by=reviewed_by, review_note=review_note)
+            if not result:
+                return error_response(f"审核拒绝失败，审核项 {review_id} 不存在或状态不是 pending")
+            return success_response(data=result, message="审核已拒绝")
+        else:
+            return error_response(f"无效的 action: {action}，必须是 approve 或 reject")
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/review_list.py
+++ b/backend/mcp/tools/knowledge/review_list.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""列出审核项"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="review_list",
+        description="列出审核项",
+        schema={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "default": "pending", "description": "审核状态筛选"},
+                "limit": {"type": "integer", "default": 50, "description": "返回数量上限"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        svc = ReviewService()
+        items = svc.list_reviews(
+            status=args.get("status", "pending"),
+            limit=args.get("limit", 50),
+        )
+        return success_response(
+            data=items,
+            message=f"共 {len(items)} 条审核记录",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/review_stats.py
+++ b/backend/mcp/tools/knowledge/review_stats.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""获取审核统计"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="review_stats",
+        description="获取审核统计",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.review_service import ReviewService
+
+    try:
+        svc = ReviewService()
+        stats = svc.get_review_stats()
+        return success_response(data=stats)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_create.py
+++ b/backend/mcp/tools/knowledge/rule_create.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""创建规则（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_create",
+        description="创建规则（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "规则标题"},
+                "content": {"type": "string", "description": "规则内容"},
+                "category": {"type": "string", "default": "general", "description": "分类"},
+                "priority": {"type": "integer", "default": 5, "description": "优先级"},
+                "scope": {"type": "string", "default": "global", "description": "作用范围"},
+                "tags": {"type": "string", "description": "标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "创建原因"},
+            },
+            "required": ["title", "content"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        review_svc = ReviewService()
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else []
+        )
+        payload = json.dumps(
+            {
+                "title": args["title"],
+                "content": args["content"],
+                "category": args.get("category", "general"),
+                "priority": args.get("priority", 5),
+                "scope": args.get("scope", "global"),
+                "tags": tag_list,
+            },
+            ensure_ascii=False,
+        )
+        review = review_svc.submit_review(
+            target_type="rule",
+            action="create",
+            title=args["title"],
+            content=payload,
+            reason=args.get("reason", ""),
+            confidence=0.9,
+            priority="normal",
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="规则已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_delete.py
+++ b/backend/mcp/tools/knowledge/rule_delete.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""删除规则（需审核，高风险）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_delete",
+        description="删除规则（需审核，高风险）",
+        schema={
+            "type": "object",
+            "properties": {
+                "rule_id": {"type": "string", "description": "规则 ID"},
+                "reason": {"type": "string", "description": "删除原因"},
+            },
+            "required": ["rule_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        rule = knowledge_svc.get_rule(args["rule_id"])
+        if not rule:
+            return error_response(f"规则 {args['rule_id']} 不存在")
+
+        review = review_svc.submit_review(
+            target_type="rule",
+            action="delete",
+            title=f"删除规则: {rule['title']}",
+            content="",
+            old_content=rule["content"],
+            reason=args.get("reason", "AI 请求删除"),
+            target_id=args["rule_id"],
+            priority="urgent",
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="规则删除已提交审核（高风险）",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_get.py
+++ b/backend/mcp/tools/knowledge/rule_get.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""获取规则详情"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_get",
+        description="获取规则详情",
+        schema={
+            "type": "object",
+            "properties": {
+                "rule_id": {"type": "string", "description": "规则 ID"},
+            },
+            "required": ["rule_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        rule = svc.get_rule(args["rule_id"])
+        if not rule:
+            return error_response(f"规则 {args['rule_id']} 不存在")
+        return success_response(data=rule)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_list.py
+++ b/backend/mcp/tools/knowledge/rule_list.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""列出知识库规则"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_list",
+        description="列出知识库规则",
+        schema={
+            "type": "object",
+            "properties": {
+                "category": {"type": "string", "description": "分类筛选"},
+                "tags": {"type": "string", "description": "标签筛选（逗号分隔）"},
+                "priority_min": {"type": "integer", "default": 0, "description": "最低优先级"},
+                "limit": {"type": "integer", "default": 50, "description": "返回数量上限"},
+            },
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+
+    try:
+        svc = KnowledgeService()
+        tag_list = (
+            [t.strip() for t in args.get("tags", "").split(",") if t.strip()]
+            if args.get("tags")
+            else None
+        )
+        rules = svc.list_rules(
+            category=args.get("category") or None,
+            tags=tag_list,
+            priority_min=args.get("priority_min", 0) or None,
+            limit=args.get("limit", 50),
+        )
+        return success_response(data={"items": rules, "count": len(rules)})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_search.py
+++ b/backend/mcp/tools/knowledge/rule_search.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""搜索规则（全文检索）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_search",
+        description="搜索规则（全文检索）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "limit": {"type": "integer", "default": 20, "description": "返回数量上限"},
+            },
+            "required": ["query"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.search_service import SearchService
+
+    try:
+        search_svc = SearchService()
+        results = search_svc.search_single_type(
+            "rules", args["query"], limit=args.get("limit", 20)
+        )
+        return success_response(data={"items": results, "count": len(results)})
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/rule_update.py
+++ b/backend/mcp/tools/knowledge/rule_update.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""更新规则（需审核）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+import json
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="rule_update",
+        description="更新规则（需审核）",
+        schema={
+            "type": "object",
+            "properties": {
+                "rule_id": {"type": "string", "description": "规则 ID"},
+                "title": {"type": "string", "description": "新标题"},
+                "content": {"type": "string", "description": "新内容"},
+                "category": {"type": "string", "description": "新分类"},
+                "priority": {"type": "integer", "description": "新优先级"},
+                "tags": {"type": "string", "description": "新标签（逗号分隔）"},
+                "reason": {"type": "string", "description": "更新原因"},
+            },
+            "required": ["rule_id"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.knowledge_service import KnowledgeService
+    from backend.services.review_service import ReviewService
+
+    try:
+        knowledge_svc = KnowledgeService()
+        review_svc = ReviewService()
+
+        rule = knowledge_svc.get_rule(args["rule_id"])
+        if not rule:
+            return error_response(f"规则 {args['rule_id']} 不存在")
+
+        updates = {}
+        if args.get("title"):
+            updates["title"] = args["title"]
+        if args.get("content"):
+            updates["content"] = args["content"]
+        if args.get("category"):
+            updates["category"] = args["category"]
+        if args.get("priority", 0) > 0:
+            updates["priority"] = args["priority"]
+        if args.get("tags"):
+            updates["tags"] = [t.strip() for t in args["tags"].split(",") if t.strip()]
+
+        review = review_svc.submit_review(
+            target_type="rule",
+            action="update",
+            title=f"更新规则: {rule['title']}",
+            content=json.dumps(updates, ensure_ascii=False),
+            old_content=json.dumps(
+                {"title": rule["title"], "content": rule["content"]}, ensure_ascii=False
+            ),
+            reason=args.get("reason", ""),
+            target_id=args["rule_id"],
+        )
+        return success_response(
+            data={"review_id": review["id"], "status": "pending"},
+            message="规则更新已提交审核",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/knowledge/unified_search.py
+++ b/backend/mcp/tools/knowledge/unified_search.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""跨类统一搜索（规则/知识/经验/记忆）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="unified_search",
+        description="跨类统一搜索（规则/知识/经验/记忆）",
+        schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "搜索关键词"},
+                "types": {"type": "string", "description": "搜索类型（逗号分隔，如 rules,knowledge,experiences,memories）"},
+                "limit": {"type": "integer", "default": 30, "description": "返回数量上限"},
+            },
+            "required": ["query"],
+        },
+        handler=handle,
+        tags=["knowledge"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.search_service import SearchService
+
+    try:
+        search_svc = SearchService()
+        type_list = (
+            [t.strip() for t in args.get("types", "").split(",") if t.strip()]
+            if args.get("types")
+            else None
+        )
+        results = search_svc.search_unified(
+            args["query"], types=type_list, limit=args.get("limit", 30)
+        )
+        return success_response(
+            data=results,
+            message=f"统一搜索找到 {len(results)} 条结果",
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/plugin/install.py
+++ b/backend/mcp/tools/plugin/install.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""安装插件（name=内置插件名 或 source=Git仓库URL）"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="install_plugin",
+        description="安装插件（name=内置插件名 或 source=Git仓库URL）",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "内置插件名称（如 code-analyzer）"},
+                "source": {"type": "string", "description": "Git 仓库 URL"},
+            },
+        },
+        handler=handle,
+        tags=["plugin"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """安装插件"""
+    try:
+        from backend.services.plugin_service import plugin_service
+
+        plugin_name = args.get("name", "")
+        source = args.get("source", "")
+        if plugin_name:
+            result = plugin_service.install_builtin(plugin_name)
+        elif source:
+            result = plugin_service.install_plugin(source)
+        else:
+            return error_response("请提供 name（内置插件名）或 source（Git 仓库 URL）参数")
+        return success_response(message=result.get("message", "安装完成"))
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/plugin/list.py
+++ b/backend/mcp/tools/plugin/list.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""列出所有已安装的插件"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="list_plugins",
+        description="列出所有已安装的插件",
+        schema={
+            "type": "object",
+            "properties": {},
+        },
+        handler=handle,
+        tags=["plugin"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """列出所有已安装的插件"""
+    try:
+        from backend.services.plugin_service import plugin_service
+
+        plugins = plugin_service.list_plugins()
+        if not plugins:
+            return success_response(message="暂无已安装插件")
+        lines = [
+            f"{p['name']} v{p.get('version', '?')} - {p.get('description', '无描述')} (by {p.get('author', '未知')})"
+            for p in plugins
+        ]
+        return success_response(
+            data={"plugins": plugins},
+            message="\n".join(lines),
+        )
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp/tools/plugin/uninstall.py
+++ b/backend/mcp/tools/plugin/uninstall.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""卸载插件"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="uninstall_plugin",
+        description="卸载插件",
+        schema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "插件名称"}
+            },
+            "required": ["name"],
+        },
+        handler=handle,
+        tags=["plugin"],
+    )
+
+
+def handle(args: dict) -> dict:
+    """卸载插件"""
+    try:
+        from backend.services.plugin_service import plugin_service
+
+        plugin_name = args.get("name", "")
+        if not plugin_name:
+            return error_response("请提供 name 参数")
+        result = plugin_service.uninstall_plugin(plugin_name)
+        return success_response(message=result.get("message", "卸载完成"))
+    except Exception as e:
+        return error_response(str(e))


### PR DESCRIPTION
## Phase 2: 知识库+浏览器+兼容+插件工具迁移

迁移剩余 42 个工具为独立积木块模块。

### 迁移统计

| 工具组 | 数量 | 目录 |
|--------|------|------|
| Knowledge | 31 | `backend/mcp/tools/knowledge/` |
| Browser | 6 | `backend/mcp/tools/browser/` |
| Compat | 2 | `backend/mcp/tools/compat/` |
| Plugin | 3 | `backend/mcp/tools/plugin/` |
| **合计** | **42** | |

### Knowledge 工具明细
- **Rules (6)**: rule_list/get/create/update/delete/search
- **Knowledge (7)**: knowledge_list/get/create/update/delete/search/extract
- **Experiences (6)**: experience_list/get/create/update/resolve/search
- **Memories (6)**: memory_list/get/create/update/forget/search
- **Review & Search (6)**: review_list/stats/approve, unified_search, knowledge_overview, context_budget_preview

### 集成测试
- ✅ 96/96 工具自动发现成功（含 test_hello）
- ✅ 累计 95 个实际工具模块

### 关联 Issue

Closes #20, Closes #21