### PR TITLE
fix(build): Fix regex to remove <script defer> tags in build_full_html

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,8 +160,8 @@ def build_full_html():
         f'<style>\n{css}\n</style>'
     )
 
-    # Remove all <script src=...> tags
-    html = re.sub(r'<script\s+src="[^"]*"></script>', '', html)
+    # Remove all <script src=...> tags (with optional attributes like defer, type, etc.)
+    html = re.sub(r'<script\s+[^>]*src="[^"]*"[^>]*></script>', '', html)
 
     # Insert all JS inline before </body>
     html = html.replace('</body>', f'<script>\n{all_js}\n</script>\n</body>')


### PR DESCRIPTION
Root cause: regex did not match <script defer> tags. 0 removed → 39 removed. This was the real reason HF Spaces showed blank page.