### PR TITLE
feat: Phase 2 - 规则分类体系 + 规则守卫 + Agent 权限系统 (v15.2)

### DIFF
--- a/backend/data/changelog.py
+++ b/backend/data/changelog.py
@@ -2,6 +2,22 @@
 # Regenerate with: python3 scripts/gen_changelog.py
 CHANGELOG_FALLBACK=[
   {
+    "version": "v15.2",
+    "date": "2026-05-04 22:00",
+    "title": "feat: v15.2 - 规则分类体系 + 规则守卫 + Agent 权限系统 (Phase 2)",
+    "changes": [
+      "feat: 扩展规则分类体系 — 8 种精细化分类 (safety/output_control/behavior/workflow/domain/coding/general/priority)，支持向后兼容旧分类名",
+      "feat: context_budget_service 按分类权重精细分配预算 (safety 1.5x, priority 1.3x, behavior 1.2x 等)",
+      "feat: 新增 RuleGuardService — 工具调用前自动检查规则合规性 (safety 硬拦截 + behavior 软警告 + 工具级 scope 精确匹配)",
+      "feat: 新增 RuleGuardMiddleware — 集成到 MCP 中间件管道 (Logging → RuleGuard → ErrorHandling → AutoLearn)",
+      "feat: 新增 PermissionService — 基于角色的 Agent 权限系统 (coder/researcher/general/admin 四种角色)",
+      "feat: 权限控制覆盖工具访问 (标签白名单 + 高风险工具白名单 + 禁止列表)、规则读写权限、数据删除权限",
+      "feat: 新增 check_permission MCP 工具 — Agent 可主动查询自身权限",
+      "feat: Context 新增 agent_id 字段，pipeline.execute 传递 agent_id 到中间件链",
+      "Version bump: 15.1 -> 15.2 (minor - Phase 2 rule guard + permissions)"
+    ]
+  },
+  {
     "version": "v15.1",
     "date": "2026-05-04 20:39",
     "title": "release: v15.1 - 自进化系统 + session 修复",

--- a/backend/mcp/middleware.py
+++ b/backend/mcp/middleware.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-"""MCP 工具调用中间件管道"""
+"""MCP 工具调用中间件管道
+
+v2: 新增 RuleGuardMiddleware — 工具调用前自动检查规则合规性
+"""
 
 import asyncio, time, logging, json
 from typing import Any, Callable, Dict, List, Optional
@@ -12,6 +15,7 @@ class Context:
     tool_name: str
     arguments: dict
     session_id: Optional[str] = None
+    agent_id: Optional[str] = None
     result: Any = None
     error: Optional[Exception] = None
     start_time: float = 0.0
@@ -29,8 +33,8 @@ class MCPMiddlewarePipeline:
     def add(self, step: MiddlewareStep): self._steps.append(step); return self
     def insert(self, index: int, step: MiddlewareStep): self._steps.insert(index, step)
     def remove(self, step_class: type): self._steps = [s for s in self._steps if not isinstance(s, step_class)]
-    async def execute(self, tool_name: str, arguments: dict, session_id: str = None, registry=None) -> Any:
-        ctx = Context(tool_name=tool_name, arguments=arguments, session_id=session_id, start_time=time.time())
+    async def execute(self, tool_name: str, arguments: dict, session_id: str = None, registry=None, agent_id: str = None) -> Any:
+        ctx = Context(tool_name=tool_name, arguments=arguments, session_id=session_id, agent_id=agent_id, start_time=time.time())
         async def build_chain(index: int):
             if index >= len(self._steps):
                 result = registry.call(ctx.tool_name, ctx.arguments)
@@ -65,6 +69,80 @@ class SessionTrackingMiddleware(MiddlewareStep):
     async def process(self, ctx: Context, next_fn: Callable, next_index: int) -> Context:
         if ctx.session_id: ctx.metadata["session_id"] = ctx.session_id
         return await next_fn(next_index)
+
+class RuleGuardMiddleware(MiddlewareStep):
+    """规则守卫 + 权限检查中间件
+
+    1. 权限检查：基于 Agent 角色检查工具访问权限
+    2. safety 类规则：硬性拦截，阻止执行
+    3. behavior 类规则：软性警告，附加到结果中提醒 Agent
+    4. 工具级 scope 规则：精确匹配特定工具
+    """
+    def __init__(self, guard_service=None):
+        self._guard_service = guard_service
+
+    @property
+    def guard(self):
+        if self._guard_service is None:
+            try:
+                from backend.services.rule_guard_service import rule_guard_service
+                self._guard_service = rule_guard_service
+                logger.info("RuleGuardMiddleware: guard_service lazy-initialized")
+            except Exception as e:
+                logger.warning(f"RuleGuardMiddleware: failed to init: {e}")
+                return None
+        return self._guard_service
+
+    async def process(self, ctx: Context, next_fn: Callable, next_index: int) -> Context:
+        # --- Step 1: 权限检查 ---
+        if ctx.agent_id:
+            try:
+                from backend.services.permission_service import permission_service
+                perm_allowed, perm_reason = permission_service.check_tool_permission(
+                    ctx.tool_name, agent_id=ctx.agent_id
+                )
+                if not perm_allowed:
+                    logger.warning(f"🔒 Permission 拒绝: {ctx.tool_name} (agent={ctx.agent_id}) — {perm_reason}")
+                    raise ValueError(f"[权限拒绝] {perm_reason}")
+            except ValueError:
+                raise
+            except Exception as e:
+                logger.warning(f"Permission check failed: {e}")
+
+        # --- Step 2: 规则守卫检查 ---
+        guard = self.guard
+        if guard is None:
+            return await next_fn(next_index)
+
+        try:
+            allowed, block_reason, warnings = guard.check_tool_call(
+                ctx.tool_name, ctx.arguments, ctx.agent_id or ""
+            )
+        except Exception as e:
+            logger.warning(f"RuleGuard check failed: {e}")
+            return await next_fn(next_index)
+
+        # 硬性拦截
+        if not allowed:
+            logger.warning(f"🛡️ RuleGuard 拦截: {ctx.tool_name} — {block_reason}")
+            raise ValueError(f"[规则守卫] {block_reason}")
+
+        # 软性警告 — 执行工具但附加警告信息
+        if warnings:
+            ctx.metadata["rule_warnings"] = warnings
+            logger.info(f"⚠️ RuleGuard 警告: {ctx.tool_name} — {len(warnings)} 条")
+
+        result = await next_fn(next_index)
+
+        # 如果有警告，将警告附加到结果中
+        if warnings and isinstance(result, dict) and result.get("success"):
+            existing_data = result.get("data", {})
+            if isinstance(existing_data, dict):
+                existing_data["_rule_warnings"] = warnings
+            else:
+                result["_rule_warnings"] = warnings
+
+        return result
 
 class AutoLearnMiddleware(MiddlewareStep):
     """自动学习中间件 — 成功和失败调用都触发学习"""

--- a/backend/mcp/tools/system/check_permission.py
+++ b/backend/mcp/tools/system/check_permission.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""查询 Agent 权限 — 查看当前角色的工具和数据访问权限"""
+
+from backend.mcp.tools._base import register_tool, success_response, error_response
+
+
+def register(reg):
+    register_tool(
+        reg,
+        name="check_permission",
+        description="查询 Agent 权限 — 查看当前角色的工具和数据访问权限",
+        schema={
+            "type": "object",
+            "properties": {
+                "tool_name": {
+                    "type": "string",
+                    "description": "要检查的工具名称（可选，不填则返回完整权限摘要）",
+                },
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent ID（可选，默认当前 Agent）",
+                },
+            },
+        },
+        handler=handle,
+        tags=["system"],
+    )
+
+
+def handle(args: dict) -> dict:
+    from backend.services.permission_service import permission_service
+
+    try:
+        agent_id = args.get("agent_id", "")
+        tool_name = args.get("tool_name", "")
+
+        if tool_name:
+            # 检查特定工具的权限
+            allowed, reason = permission_service.check_tool_permission(
+                tool_name, agent_id=agent_id
+            )
+            return success_response(
+                data={
+                    "tool": tool_name,
+                    "allowed": allowed,
+                    "reason": reason if not allowed else "权限允许",
+                }
+            )
+        else:
+            # 返回完整权限摘要
+            role = "general"
+            if agent_id:
+                try:
+                    from backend.services.agent_identity import agent_identity_manager
+                    agent = agent_identity_manager.get_agent(agent_id)
+                    if agent:
+                        role = agent.get("role", "general")
+                except Exception:
+                    pass
+
+            summary = permission_service.get_permission_summary(role)
+            return success_response(data=summary)
+    except Exception as e:
+        return error_response(str(e))

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from backend.mcp.registry import registry
 from backend.mcp.middleware import (
     AutoLearnMiddleware, MCPMiddlewarePipeline, LoggingMiddleware, ErrorHandlingMiddleware,
+    RuleGuardMiddleware,
 )
 
 logger = logging.getLogger("hermes-mcp")
@@ -28,6 +29,7 @@ USE_TOOL_REGISTRY = True
 
 _pipeline = MCPMiddlewarePipeline()
 _pipeline.add(LoggingMiddleware())
+_pipeline.add(RuleGuardMiddleware())
 _pipeline.add(ErrorHandlingMiddleware())
 _pipeline.add(AutoLearnMiddleware(auto_learner="lazy"))
 registry.discover()
@@ -183,7 +185,7 @@ async def _call_tool(name: str, arguments: Dict[str, Any]) -> str:
         except ValueError: raise
         except Exception as e: raise ValueError(f"调用外部工具 '{name}' 失败: {e}")
     try:
-        result = await _pipeline.execute(tool_name=name, arguments=arguments, registry=registry)
+        result = await _pipeline.execute(tool_name=name, arguments=arguments, registry=registry, agent_id=agent_id)
         if isinstance(result, dict): return json.dumps(result, ensure_ascii=False, indent=2)
         return str(result) if result is not None else ""
     except ValueError: raise

--- a/backend/services/context_budget_service.py
+++ b/backend/services/context_budget_service.py
@@ -1,26 +1,120 @@
-"""上下文预算服务 — 根据 token 预算从知识库中选取最重要的内容注入 AI 上下文"""
+# -*- coding: utf-8 -*-
+"""上下文预算服务 — 根据 token 预算从知识库中选取最重要的内容注入 AI 上下文
+
+v2: 扩展规则分类体系，支持按分类精细分配预算
+"""
 
 import sqlite3
+import logging
 from typing import List, Dict, Any, Optional
 from backend.db import get_knowledge_db
+
+logger = logging.getLogger("hermes-mcp")
+
+# ============================================================
+# 规则分类体系 v2 — 精细化分类
+# ============================================================
+RULE_CATEGORIES = {
+    # --- 安全类（最高优先级，始终注入） ---
+    "safety": {
+        "label": "安全规则",
+        "icon": "🛡️",
+        "description": "涉及安全、隐私、数据保护的硬性规则",
+        "budget_weight": 1.5,  # 预算权重倍数
+    },
+    "output_control": {
+        "label": "输出控制",
+        "icon": "📝",
+        "description": "控制输出格式、语言、风格的规则",
+        "budget_weight": 1.0,
+    },
+    # --- 行为类 ---
+    "behavior": {
+        "label": "行为规范",
+        "icon": "🎭",
+        "description": "Agent 行为准则、交互礼仪、沟通方式",
+        "budget_weight": 1.2,
+    },
+    "workflow": {
+        "label": "工作流程",
+        "icon": "🔄",
+        "description": "标准操作流程、步骤规范",
+        "budget_weight": 0.8,
+    },
+    # --- 知识类 ---
+    "domain": {
+        "label": "领域知识",
+        "icon": "📖",
+        "description": "特定领域的专业知识和约束",
+        "budget_weight": 0.7,
+    },
+    "coding": {
+        "label": "编码规范",
+        "icon": "💻",
+        "description": "代码风格、编程最佳实践",
+        "budget_weight": 0.9,
+    },
+    # --- 通用 ---
+    "general": {
+        "label": "通用规则",
+        "icon": "📋",
+        "description": "不属于以上分类的通用规则",
+        "budget_weight": 0.5,
+    },
+    "priority": {
+        "label": "优先规则",
+        "icon": "⭐",
+        "description": "用户明确标记的高优先级规则",
+        "budget_weight": 1.3,
+    },
+}
+
+# 向后兼容：旧分类名映射到新分类
+CATEGORY_ALIAS_MAP = {
+    "format": "output_control",
+    "safety_critical": "safety",
+    "data_handling": "safety",
+    "best_practice": "coding",
+}
+
+
+def resolve_category(category: str) -> str:
+    """将旧分类名映射到新分类名"""
+    return CATEGORY_ALIAS_MAP.get(category, category)
+
 
 class ContextBudgetService:
     def __init__(self):
         self.conn = get_knowledge_db()
+
     def get_budget(self) -> dict:
         row = self.conn.execute("SELECT * FROM context_budget WHERE id = 1").fetchone()
-        if not row: return self._default_budget()
+        if not row:
+            return self._default_budget()
         return dict(row)
+
     def update_budget(self, **kwargs) -> dict:
         sets, params = [], []
         for k, v in kwargs.items():
-            if v is not None: sets.append(f"{k} = ?"); params.append(v)
+            if v is not None:
+                sets.append(f"{k} = ?")
+                params.append(v)
         if sets:
-            sets.append("updated_at = datetime('now')"); params.append(1)
-            self.conn.execute(f"UPDATE context_budget SET {', '.join(sets)} WHERE id = ?", params)
+            sets.append("updated_at = datetime('now')")
+            params.append(1)
+            self.conn.execute(
+                f"UPDATE context_budget SET {', '.join(sets)} WHERE id = ?", params
+            )
             self.conn.commit()
         return self.get_budget()
-    def build_context(self, session_id: str = "", query: str = "", max_tokens: int = None, agent_id: str = "") -> str:
+
+    def build_context(
+        self,
+        session_id: str = "",
+        query: str = "",
+        max_tokens: int = None,
+        agent_id: str = "",
+    ) -> str:
         budget = self.get_budget()
         total = max_tokens or budget["total_budget"]
         role_overrides = self._get_role_budget_overrides(agent_id)
@@ -29,18 +123,125 @@ class ContextBudgetService:
         exp_pct = role_overrides.get("experience_pct", budget["experience_pct"])
         mem_pct = role_overrides.get("memory_pct", budget["memory_pct"])
         char_budget = total * 2
+
         sections = []
-        rules = self._get_top_content("rules", "priority DESC, updated_at DESC", int(char_budget * rules_pct / 100))
-        if rules: sections.append(f"## 📋 当前生效规则\n\n{rules}")
-        knowledge = self._get_top_content("knowledge", "confidence DESC, updated_at DESC", int(char_budget * knowledge_pct / 100))
-        if knowledge: sections.append(f"## 📚 相关知识\n\n{knowledge}")
-        experiences = self._get_top_content("experiences", "is_resolved ASC, severity DESC, updated_at DESC", int(char_budget * exp_pct / 100), extra_where="AND is_resolved = 0")
-        if experiences: sections.append(f"## 💡 相关经验（未解决）\n\n{experiences}")
-        memories = self._get_top_content("memories", "importance DESC, updated_at DESC", int(char_budget * mem_pct / 100), extra_where="AND (expires_at = '' OR expires_at > datetime('now'))")
-        if memories: sections.append(f"## 🧠 相关记忆\n\n{memories}")
-        if not sections: return ""
-        return f"<!-- 知识库上下文（预算 {total} tokens）-->\n\n" + "\n\n".join(sections)
-    def _get_top_content(self, table: str, order_by: str, max_chars: int, extra_where: str = "") -> str:
+
+        # --- 规则：按分类精细分配预算 ---
+        rules_text = self._build_rules_context(char_budget * rules_pct / 100, agent_id)
+        if rules_text:
+            sections.append(f"## 📋 当前生效规则\n\n{rules_text}")
+
+        knowledge = self._get_top_content(
+            "knowledge",
+            "confidence DESC, updated_at DESC",
+            int(char_budget * knowledge_pct / 100),
+        )
+        if knowledge:
+            sections.append(f"## 📚 相关知识\n\n{knowledge}")
+
+        experiences = self._get_top_content(
+            "experiences",
+            "is_resolved ASC, severity DESC, updated_at DESC",
+            int(char_budget * exp_pct / 100),
+            extra_where="AND is_resolved = 0",
+        )
+        if experiences:
+            sections.append(f"## 💡 相关经验（未解决）\n\n{experiences}")
+
+        memories = self._get_top_content(
+            "memories",
+            "importance DESC, updated_at DESC",
+            int(char_budget * mem_pct / 100),
+            extra_where="AND (expires_at = '' OR expires_at > datetime('now'))",
+        )
+        if memories:
+            sections.append(f"## 🧠 相关记忆\n\n{memories}")
+
+        if not sections:
+            return ""
+        return (
+            f"<!-- 知识库上下文（预算 {total} tokens）-->\n\n"
+            + "\n\n".join(sections)
+        )
+
+    def _build_rules_context(self, total_chars: int, agent_id: str = "") -> str:
+        """按分类精细分配规则预算，高权重分类获得更多空间"""
+        # 获取所有活跃规则
+        cursor = self.conn.execute(
+            "SELECT title, content, category, priority FROM rules "
+            "WHERE is_active = 1 ORDER BY priority DESC, updated_at DESC"
+        )
+        all_rules = [dict(row) for row in cursor.fetchall()]
+
+        if not all_rules:
+            return ""
+
+        # 按分类分组，解析旧分类名
+        category_rules: Dict[str, list] = {}
+        for rule in all_rules:
+            cat = resolve_category(rule.get("category", "general"))
+            if cat not in category_rules:
+                category_rules[cat] = []
+            category_rules[cat].append(rule)
+
+        # 计算每个分类的预算分配
+        total_weight = sum(
+            RULE_CATEGORIES.get(cat, RULE_CATEGORIES["general"])["budget_weight"]
+            * len(rules)
+            for cat, rules in category_rules.items()
+        )
+
+        if total_weight == 0:
+            return ""
+
+        sections = []
+        used_chars = 0
+
+        # 按权重降序排列分类
+        sorted_cats = sorted(
+            category_rules.keys(),
+            key=lambda c: RULE_CATEGORIES.get(c, RULE_CATEGORIES["general"])[
+                "budget_weight"
+            ],
+            reverse=True,
+        )
+
+        for cat in sorted_cats:
+            cat_info = RULE_CATEGORIES.get(cat, RULE_CATEGORIES["general"])
+            rules = category_rules[cat]
+            cat_weight = cat_info["budget_weight"] * len(rules)
+            cat_budget = int(total_chars * cat_weight / total_weight)
+
+            cat_parts = []
+            cat_used = 0
+            for rule in rules:
+                entry = f"### {rule['title']}\n\n{rule['content']}"
+                if cat_used + len(entry) > cat_budget:
+                    remaining = cat_budget - cat_used
+                    if remaining > 50:
+                        truncated = entry[:remaining]
+                        last_nl = truncated.rfind("\n")
+                        if last_nl > remaining * 0.5:
+                            truncated = truncated[:last_nl]
+                        cat_parts.append(truncated + "\n\n...")
+                    break
+                cat_parts.append(entry)
+                cat_used += len(entry)
+
+            if cat_parts:
+                cat_text = "\n\n---\n\n".join(cat_parts)
+                sections.append(f"### {cat_info['icon']} {cat_info['label']}\n\n{cat_text}")
+                used_chars += cat_used
+
+        return "\n\n---\n\n".join(sections)
+
+    def _get_top_content(
+        self,
+        table: str,
+        order_by: str,
+        max_chars: int,
+        extra_where: str = "",
+    ) -> str:
         sql = f"SELECT title, content FROM {table} WHERE is_active = 1 {extra_where} ORDER BY {order_by}"
         cursor = self.conn.execute(sql)
         result_parts, total_chars = [], 0
@@ -52,27 +253,59 @@ class ContextBudgetService:
                 if remaining > 50:
                     truncated = entry[:remaining]
                     last_nl = truncated.rfind("\n")
-                    if last_nl > remaining * 0.5: truncated = truncated[:last_nl]
+                    if last_nl > remaining * 0.5:
+                        truncated = truncated[:last_nl]
                     result_parts.append(truncated + "\n\n...")
                 break
             result_parts.append(entry)
             total_chars += len(entry)
         return "\n\n---\n\n".join(result_parts)
+
     def _default_budget(self) -> dict:
-        return {"id": 1, "total_budget": 4000, "rules_pct": 15, "knowledge_pct": 25, "experience_pct": 15, "memory_pct": 20, "session_pct": 25, "updated_at": ""}
+        return {
+            "id": 1,
+            "total_budget": 4000,
+            "rules_pct": 15,
+            "knowledge_pct": 25,
+            "experience_pct": 15,
+            "memory_pct": 20,
+            "session_pct": 25,
+            "updated_at": "",
+        }
+
     def _get_role_budget_overrides(self, agent_id: str) -> dict:
-        if not agent_id: return {}
+        if not agent_id:
+            return {}
         ROLE_BUDGETS = {
-            "coder": {"rules_pct": 20, "knowledge_pct": 20, "experience_pct": 20, "memory_pct": 10},
-            "researcher": {"rules_pct": 10, "knowledge_pct": 35, "experience_pct": 10, "memory_pct": 15},
-            "general": {"rules_pct": 15, "knowledge_pct": 25, "experience_pct": 15, "memory_pct": 20},
+            "coder": {
+                "rules_pct": 20,
+                "knowledge_pct": 20,
+                "experience_pct": 20,
+                "memory_pct": 10,
+            },
+            "researcher": {
+                "rules_pct": 10,
+                "knowledge_pct": 35,
+                "experience_pct": 10,
+                "memory_pct": 15,
+            },
+            "general": {
+                "rules_pct": 15,
+                "knowledge_pct": 25,
+                "experience_pct": 15,
+                "memory_pct": 20,
+            },
         }
         try:
             from backend.services.agent_identity import agent_identity_manager
+
             agent = agent_identity_manager.get_agent(agent_id)
-            if agent: return ROLE_BUDGETS.get(agent.get("role", "general"), {})
-        except Exception: pass
+            if agent:
+                return ROLE_BUDGETS.get(agent.get("role", "general"), {})
+        except Exception:
+            pass
         return {}
+
 
 def inject_knowledge_context(session_id: str = "", query: str = "") -> str:
     svc = ContextBudgetService()

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+"""Agent 权限服务 — 基于角色的访问控制
+
+不同角色的 Agent 对工具和数据有不同的访问权限：
+- coder: 可执行 shell、GitHub 操作，侧重代码相关
+- researcher: 可搜索网络、管理知识，侧重研究相关
+- general: 通用权限，部分高风险操作受限
+- admin: 管理员权限（预留）
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Set
+from backend.db import get_knowledge_db
+
+logger = logging.getLogger("hermes-mcp")
+
+# ============================================================
+# 角色权限定义
+# ============================================================
+ROLE_PERMISSIONS = {
+    "coder": {
+        "label": "代码实践记录者",
+        # 允许的工具标签
+        "allowed_tool_tags": {"knowledge", "memory", "session", "feedback", "skill", "file", "browser", "system", "plugin", "compat"},
+        # 允许的高风险工具
+        "allowed_high_risk_tools": {
+            "shell_execute", "safe_shell_execute",
+            "github_operations",
+            "db_query",
+            "document_parse", "document_convert",
+            "batch_operations",
+        },
+        # 禁止的工具（即使标签允许）
+        "denied_tools": set(),
+        # 允许的规则分类（可查看/引用）
+        "allowed_rule_categories": {"safety", "coding", "workflow", "behavior", "output_control", "general", "priority", "domain"},
+        # 可写入的规则分类（可创建/修改）
+        "writable_rule_categories": {"coding", "workflow", "general", "output_control"},
+        # 知识操作权限
+        "can_delete_knowledge": False,
+        "can_delete_memory": False,
+        # 额外说明
+        "description": "可执行代码相关操作，不可删除知识和记忆",
+    },
+    "researcher": {
+        "label": "知识采集记录者",
+        "allowed_tool_tags": {"knowledge", "memory", "session", "feedback", "skill", "file", "system", "plugin", "compat"},
+        "allowed_high_risk_tools": {
+            "web_fetch", "web_search",
+            "document_parse", "document_convert",
+            "data_analyze", "data_visualize",
+        },
+        "denied_tools": {"shell_execute", "safe_shell_execute", "github_operations"},
+        "allowed_rule_categories": {"safety", "behavior", "output_control", "general", "priority", "domain", "workflow"},
+        "writable_rule_categories": {"behavior", "output_control", "general", "domain"},
+        "can_delete_knowledge": False,
+        "can_delete_memory": False,
+        "description": "可搜索网络和管理知识，不可执行 shell 或 GitHub 操作",
+    },
+    "general": {
+        "label": "通用助手",
+        "allowed_tool_tags": {"knowledge", "memory", "session", "feedback", "skill", "file", "compat"},
+        "allowed_high_risk_tools": {
+            "web_search",
+            "document_parse",
+        },
+        "denied_tools": {
+            "shell_execute", "safe_shell_execute",
+            "github_operations",
+            "db_query", "db_manage_connections",
+            "email_operations",
+            "batch_operations",
+            "delegate_task",
+        },
+        "allowed_rule_categories": {"safety", "behavior", "output_control", "general", "priority"},
+        "writable_rule_categories": {"general", "output_control"},
+        "can_delete_knowledge": False,
+        "can_delete_memory": False,
+        "description": "基础权限，大部分高风险操作受限",
+    },
+    "admin": {
+        "label": "管理员",
+        "allowed_tool_tags": {"knowledge", "memory", "session", "feedback", "skill", "file", "browser", "system", "plugin", "compat"},
+        "allowed_high_risk_tools": {
+            "shell_execute", "safe_shell_execute",
+            "web_fetch", "web_search",
+            "github_operations",
+            "db_query", "db_manage_connections",
+            "email_operations",
+            "document_parse", "document_convert",
+            "batch_operations",
+            "delegate_task",
+            "data_analyze", "data_visualize",
+        },
+        "denied_tools": set(),
+        "allowed_rule_categories": {"safety", "coding", "workflow", "behavior", "output_control", "general", "priority", "domain"},
+        "writable_rule_categories": {"safety", "coding", "workflow", "behavior", "output_control", "general", "priority", "domain"},
+        "can_delete_knowledge": True,
+        "can_delete_memory": True,
+        "description": "完全权限，可执行所有操作",
+    },
+}
+
+# 工具名 → 标签映射（用于权限检查）
+TOOL_TAG_MAP = {
+    # knowledge 组
+    "knowledge_search": "knowledge", "knowledge_create": "knowledge", "knowledge_get": "knowledge",
+    "knowledge_list": "knowledge", "knowledge_update": "knowledge", "knowledge_delete": "knowledge",
+    "knowledge_overview": "knowledge", "knowledge_extract": "knowledge", "knowledge_auto_update": "knowledge",
+    "rule_search": "knowledge", "rule_create": "knowledge", "rule_get": "knowledge",
+    "rule_list": "knowledge", "rule_update": "knowledge", "rule_delete": "knowledge",
+    "experience_create": "knowledge", "experience_get": "knowledge", "experience_list": "knowledge",
+    "experience_search": "knowledge", "experience_resolve": "knowledge", "experience_update": "knowledge",
+    "experience_to_rule": "knowledge",
+    "memory_create": "knowledge", "memory_get": "knowledge", "memory_list": "knowledge",
+    "memory_search": "knowledge", "memory_forget": "knowledge", "memory_update": "knowledge",
+    "auto_review": "knowledge", "batch_review": "knowledge", "configure_review_policy": "knowledge",
+    "auto_cleanup_knowledge": "knowledge", "auto_resolve_experience": "knowledge",
+    "context_budget_preview": "knowledge",
+    # session 组
+    "create_session": "session", "list_sessions": "session", "get_session_messages": "session",
+    "search_sessions": "session", "search_messages": "session", "delete_session": "session",
+    "add_message": "session", "compress_session": "session",
+    # feedback 组
+    "submit_feedback": "feedback", "submit_conversation": "feedback",
+    # skill 组
+    "create_skill": "skill", "delete_skill": "skill", "get_skill_content": "skill",
+    "update_skill": "skill", "list_skills": "skill", "search_skills_hub": "skill",
+    "install_skill_hub": "skill", "suggest_skill": "skill",
+    "auto_create_skill_from_pattern": "skill", "auto_optimize_skill": "skill",
+    "evaluate_skill": "skill",
+    # file 组
+    "read_file": "file", "write_file": "file", "list_directory": "file", "search_files": "file",
+    # browser 组
+    "browser_navigate": "browser", "browser_click": "browser", "browser_type": "browser",
+    "browser_screenshot": "browser", "browser_snapshot": "browser", "browser_evaluate": "browser",
+    # system 组
+    "shell_execute": "system", "safe_shell_execute": "system",
+    "web_fetch": "system", "web_search": "system",
+    "github_operations": "system",
+    "db_query": "system", "db_manage_connections": "system",
+    "email_operations": "system",
+    "document_parse": "system", "document_convert": "system",
+    "batch_operations": "system", "delegate_task": "system",
+    "data_analyze": "system", "data_visualize": "system",
+    "add_mcp_server": "system", "remove_mcp_server": "system", "list_mcp_servers": "system",
+    "refresh_mcp_servers": "system",
+    "get_config": "system", "update_config": "system",
+    "get_dashboard": "system", "get_logs": "system", "get_system_status": "system",
+    "list_tools": "system", "list_cron": "system", "create_cron": "system", "delete_cron": "system",
+    "log_conversation": "system", "audit_trail": "system", "change_tracker": "system",
+    "register_webhook": "system", "capture_screenshot": "system", "send_notification": "system",
+    "test_hello": "system",
+    # plugin 组
+    "install_plugin": "plugin", "list_plugins": "plugin", "uninstall_plugin": "plugin",
+    # compat 组
+    "read_memory": "compat", "write_memory": "compat", "read_soul": "compat", "write_soul": "compat",
+    "read_user_profile": "compat", "write_user_profile": "compat",
+    "read_agents_md": "compat", "write_agents_md": "compat",
+    "read_learnings": "compat", "add_learning": "compat", "query_memory": "compat", "store_memory": "compat",
+    "unified_search": "compat", "compat_sync_db_to_md": "compat", "compat_sync_md_to_db": "compat",
+}
+
+
+class PermissionService:
+    """Agent 权限服务"""
+
+    def __init__(self):
+        self.conn = get_knowledge_db()
+        self._custom_permissions: Dict[str, dict] = {}
+
+    def get_role_permissions(self, role: str) -> dict:
+        """获取角色的权限定义"""
+        return ROLE_PERMISSIONS.get(role, ROLE_PERMISSIONS["general"])
+
+    def check_tool_permission(
+        self, tool_name: str, agent_id: str = "", role: str = ""
+    ) -> tuple:
+        """检查 Agent 是否有权限调用某工具
+
+        Returns:
+            (allowed: bool, reason: str)
+        """
+        if not role and agent_id:
+            role = self._infer_role(agent_id)
+
+        perms = self.get_role_permissions(role)
+
+        # 1. 检查明确禁止的工具
+        if tool_name in perms["denied_tools"]:
+            return False, f"角色 '{perms['label']}' 无权使用工具 '{tool_name}'"
+
+        # 2. 检查高风险工具白名单
+        from backend.services.rule_guard_service import RuleGuardService
+        guard = RuleGuardService()
+        if tool_name in guard.HIGH_RISK_TOOLS or tool_name in guard.MEDIUM_RISK_TOOLS:
+            if tool_name not in perms["allowed_high_risk_tools"]:
+                return False, f"角色 '{perms['label']}' 无权使用高风险工具 '{tool_name}'"
+
+        # 3. 检查工具标签
+        tool_tag = TOOL_TAG_MAP.get(tool_name, "system")
+        if tool_tag not in perms["allowed_tool_tags"]:
+            return False, f"角色 '{perms['label']}' 无权访问 '{tool_tag}' 类工具"
+
+        # 4. 检查自定义权限覆盖
+        custom = self._get_custom_permission(agent_id)
+        if custom:
+            if tool_name in custom.get("denied_tools", set()):
+                return False, f"Agent '{agent_id}' 被自定义规则禁止使用 '{tool_name}'"
+            if tool_name in custom.get("extra_allowed_tools", set()):
+                return True, ""
+
+        return True, ""
+
+    def check_rule_permission(
+        self, category: str, action: str = "read", agent_id: str = "", role: str = ""
+    ) -> tuple:
+        """检查 Agent 是否有权限操作某分类的规则
+
+        Args:
+            category: 规则分类
+            action: "read" 或 "write"
+        Returns:
+            (allowed: bool, reason: str)
+        """
+        if not role and agent_id:
+            role = self._infer_role(agent_id)
+
+        perms = self.get_role_permissions(role)
+
+        if action == "read":
+            if category in perms["allowed_rule_categories"]:
+                return True, ""
+            return False, f"角色 '{perms['label']}' 无权查看 '{category}' 类规则"
+
+        if action == "write":
+            if category in perms["writable_rule_categories"]:
+                return True, ""
+            return False, f"角色 '{perms['label']}' 无权修改 '{category}' 类规则"
+
+        return False, f"未知操作类型: {action}"
+
+    def check_data_permission(
+        self, data_type: str, action: str, agent_id: str = "", role: str = ""
+    ) -> tuple:
+        """检查数据操作权限（删除知识/记忆等）
+
+        Args:
+            data_type: "knowledge" / "memory" / "experience"
+            action: "read" / "create" / "update" / "delete"
+        """
+        if not role and agent_id:
+            role = self._infer_role(agent_id)
+
+        perms = self.get_role_permissions(role)
+
+        if action == "delete":
+            if data_type == "knowledge" and not perms["can_delete_knowledge"]:
+                return False, f"角色 '{perms['label']}' 无权删除知识"
+            if data_type == "memory" and not perms["can_delete_memory"]:
+                return False, f"角色 '{perms['label']}' 无权删除记忆"
+
+        return True, ""
+
+    def _infer_role(self, agent_id: str) -> str:
+        """从 agent_id 推断角色"""
+        try:
+            from backend.services.agent_identity import agent_identity_manager
+            agent = agent_identity_manager.get_agent(agent_id)
+            if agent:
+                return agent.get("role", "general")
+        except Exception:
+            pass
+        return "general"
+
+    def _get_custom_permission(self, agent_id: str) -> Optional[dict]:
+        """获取自定义权限覆盖"""
+        if not agent_id:
+            return None
+        return self._custom_permissions.get(agent_id)
+
+    def set_custom_permission(self, agent_id: str, permissions: dict):
+        """设置自定义权限覆盖（运行时，不持久化）"""
+        self._custom_permissions[agent_id] = permissions
+
+    def get_permission_summary(self, role: str) -> dict:
+        """获取角色权限摘要（用于展示）"""
+        perms = self.get_role_permissions(role)
+        return {
+            "role": role,
+            "label": perms["label"],
+            "description": perms["description"],
+            "allowed_tool_tags": list(perms["allowed_tool_tags"]),
+            "allowed_high_risk_tools": list(perms["allowed_high_risk_tools"]),
+            "denied_tools": list(perms["denied_tools"]),
+            "allowed_rule_categories": list(perms["allowed_rule_categories"]),
+            "writable_rule_categories": list(perms["writable_rule_categories"]),
+            "can_delete_knowledge": perms["can_delete_knowledge"],
+            "can_delete_memory": perms["can_delete_memory"],
+        }
+
+
+# 全局单例
+permission_service = PermissionService()

--- a/backend/services/rule_guard_service.py
+++ b/backend/services/rule_guard_service.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""规则守卫服务 — 检查工具调用是否违反安全规则
+
+在工具调用前自动检查：
+1. safety 类规则 — 硬性拦截
+2. behavior 类规则 — 软性警告（附加到结果中）
+3. 工具级 scope 规则 — 精确匹配
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+from backend.db import get_knowledge_db
+
+logger = logging.getLogger("hermes-mcp")
+
+
+class RuleGuardService:
+    """规则守卫 — 在工具调用前检查合规性"""
+
+    # 需要安全检查的高风险工具
+    HIGH_RISK_TOOLS = {
+        "shell_execute", "safe_shell_execute",
+        "web_fetch", "web_search",
+        "github_operations",
+        "db_query", "db_manage_connections",
+        "email_operations",
+        "document_parse", "document_convert",
+        "batch_operations",
+    }
+
+    # 中等风险工具
+    MEDIUM_RISK_TOOLS = {
+        "rule_create", "rule_update", "rule_delete",
+        "knowledge_create", "knowledge_update", "knowledge_delete",
+        "memory_create", "memory_forget",
+        "experience_create", "experience_update",
+        "delegate_task",
+        "create_cron", "delete_cron",
+    }
+
+    def __init__(self):
+        self.conn = get_knowledge_db()
+        self._cache: Optional[List[dict]] = None
+        self._cache_time: float = 0
+
+    def _get_active_rules(self) -> List[dict]:
+        """获取所有活跃规则（带简单缓存，30秒过期）"""
+        import time
+        now = time.time()
+        if self._cache is not None and (now - self._cache_time) < 30:
+            return self._cache
+        try:
+            cursor = self.conn.execute(
+                "SELECT id, title, content, category, priority, scope, scope_value, tags "
+                "FROM rules WHERE is_active = 1 ORDER BY priority DESC"
+            )
+            self._cache = [dict(row) for row in cursor.fetchall()]
+            self._cache_time = now
+            return self._cache
+        except Exception as e:
+            logger.warning(f"RuleGuard: failed to load rules: {e}")
+            return []
+
+    def check_tool_call(
+        self, tool_name: str, arguments: dict, agent_id: str = ""
+    ) -> Tuple[bool, str, List[str]]:
+        """检查工具调用是否合规
+
+        Returns:
+            (allowed, block_reason, warnings)
+            - allowed: 是否允许执行
+            - block_reason: 如果被拦截，说明原因
+            - warnings: 软性警告列表（不阻止执行，但提醒 Agent）
+        """
+        rules = self._get_active_rules()
+        if not rules:
+            return True, "", []
+
+        warnings = []
+
+        # 1. 检查 safety 类规则 — 硬性拦截
+        for rule in rules:
+            if rule.get("category") != "safety":
+                continue
+            match = self._match_rule(rule, tool_name, arguments)
+            if match:
+                logger.warning(
+                    f"RuleGuard: BLOCKED {tool_name} by safety rule '{rule['title']}'"
+                )
+                return False, f"安全规则拦截 [{rule['title']}]: {rule['content']}", warnings
+
+        # 2. 检查工具级 scope 规则
+        for rule in rules:
+            if rule.get("scope") != "tool":
+                continue
+            if rule.get("scope_value", "").lower() == tool_name.lower():
+                # 这是一个针对特定工具的规则，检查是否违反
+                match = self._match_rule_content(rule["content"], arguments)
+                if match:
+                    severity = rule.get("priority", 5)
+                    if severity >= 8:
+                        logger.warning(
+                            f"RuleGuard: BLOCKED {tool_name} by tool-scope rule '{rule['title']}'"
+                        )
+                        return False, f"工具规则拦截 [{rule['title']}]: {rule['content']}", warnings
+                    else:
+                        warnings.append(f"⚠️ [{rule['title']}]: {rule['content']}")
+
+        # 3. 检查 behavior 类规则 — 软性警告
+        if tool_name in self.HIGH_RISK_TOOLS or tool_name in self.MEDIUM_RISK_TOOLS:
+            for rule in rules:
+                if rule.get("category") != "behavior":
+                    continue
+                match = self._match_rule(rule, tool_name, arguments)
+                if match:
+                    warnings.append(f"💡 [{rule['title']}]: {rule['content']}")
+
+        return True, "", warnings
+
+    def _match_rule(self, rule: dict, tool_name: str, arguments: dict) -> bool:
+        """检查规则是否匹配当前工具调用"""
+        content = rule.get("content", "")
+        scope = rule.get("scope", "global")
+
+        # global scope — 检查所有工具调用
+        if scope == "global":
+            return self._match_rule_content(content, arguments)
+
+        # tool scope — 只检查匹配的工具
+        if scope == "tool":
+            if rule.get("scope_value", "").lower() != tool_name.lower():
+                return False
+            return self._match_rule_content(content, arguments)
+
+        return False
+
+    def _match_rule_content(self, content: str, arguments: dict) -> bool:
+        """检查规则内容是否与参数匹配
+
+        支持的规则语法：
+        - 纯文本描述：包含关键词即匹配
+        - FORBID:xxx — 参数中包含 xxx 则匹配（禁止模式）
+        - REQUIRE:xxx — 参数中不包含 xxx 则匹配（必须模式）
+        - REGEX:pattern — 正则匹配参数的 JSON 表示
+        """
+        if not content or not arguments:
+            return False
+
+        args_str = json.dumps(arguments, ensure_ascii=False).lower()
+
+        for line in content.split("\n"):
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("//"):
+                continue
+
+            # FORBID 模式
+            if line.upper().startswith("FORBID:"):
+                keyword = line[7:].strip().lower()
+                if keyword and keyword in args_str:
+                    return True
+
+            # REQUIRE 模式
+            elif line.upper().startswith("REQUIRE:"):
+                keyword = line[8:].strip().lower()
+                if keyword and keyword not in args_str:
+                    return True
+
+            # REGEX 模式
+            elif line.upper().startswith("REGEX:"):
+                pattern = line[6:].strip()
+                try:
+                    if re.search(pattern, args_str, re.IGNORECASE):
+                        return True
+                except re.error:
+                    pass
+
+            # 纯文本关键词匹配
+            else:
+                keyword = line.lower()
+                if len(keyword) >= 3 and keyword in args_str:
+                    return True
+
+        return False
+
+    def get_tool_risk_level(self, tool_name: str) -> str:
+        """获取工具风险等级"""
+        if tool_name in self.HIGH_RISK_TOOLS:
+            return "high"
+        if tool_name in self.MEDIUM_RISK_TOOLS:
+            return "medium"
+        return "low"
+
+
+# 全局单例
+rule_guard_service = RuleGuardService()

--- a/backend/version.py
+++ b/backend/version.py
@@ -18,7 +18,7 @@ import os
 # ============================================
 # 唯一版本号 - 修改这里即可
 # ============================================
-__version__ = os.environ.get("APP_VERSION", "15.1")
+__version__ = os.environ.get("APP_VERSION", "15.2")
 
 # 版本元信息
 __version_meta__ = {


### PR DESCRIPTION
## Phase 2: 规则分类体系 + 规则守卫 + Agent 权限系统

### 变更概览

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `backend/services/context_budget_service.py` | 修改 | 扩展规则分类体系，按分类权重精细分配预算 |
| `backend/services/rule_guard_service.py` | 新增 | 规则守卫服务 — 工具调用前自动检查规则合规性 |
| `backend/services/permission_service.py` | 新增 | Agent 权限服务 — 基于角色的访问控制 |
| `backend/mcp/middleware.py` | 修改 | 新增 RuleGuardMiddleware，集成权限检查 + 规则守卫 |
| `backend/mcp/tools/system/check_permission.py` | 新增 | 权限查询 MCP 工具 |
| `backend/mcp_server.py` | 修改 | 注册 RuleGuardMiddleware，传递 agent_id |
| `backend/version.py` | 修改 | 15.1 → 15.2 |
| `backend/data/changelog.py` | 修改 | 新增 v15.2 changelog |

### Phase 2.1: 扩展规则分类体系

- 从 5 种分类扩展到 **8 种精细化分类**：
  - `safety` (🛡️ 安全规则, 权重 1.5x)
  - `output_control` (📝 输出控制, 权重 1.0x)
  - `behavior` (🎭 行为规范, 权重 1.2x)
  - `workflow` (🔄 工作流程, 权重 0.8x)
  - `domain` (📖 领域知识, 权重 0.7x)
  - `coding` (💻 编码规范, 权重 0.9x)
  - `general` (📋 通用规则, 权重 0.5x)
  - `priority` (⭐ 优先规则, 权重 1.3x)
- **向后兼容**：旧分类名自动映射 (format→output_control, safety_critical→safety 等)
- context_budget_service 按分类权重精细分配预算

### Phase 2.2: 规则守卫 (RuleGuard)

- **RuleGuardService**：工具调用前自动检查规则合规性
  - safety 类规则 → 硬性拦截（阻止执行）
  - behavior 类规则 → 软性警告（附加到结果中）
  - 工具级 scope 规则 → 精确匹配特定工具
  - 支持 FORBID/REQUIRE/REGEX 三种规则语法
- **RuleGuardMiddleware**：集成到 MCP 中间件管道
  - 管道顺序：Logging → **RuleGuard** → ErrorHandling → AutoLearn

### Phase 2.3: Agent 权限系统

- **PermissionService**：基于角色的访问控制
  - `coder`: 可执行 shell/GitHub，侧重代码
  - `researcher`: 可搜索网络/管理知识，不可执行 shell
  - `general`: 基础权限，大部分高风险操作受限
  - `admin`: 完全权限（预留）
- 权限控制覆盖：工具访问、规则读写、数据删除
- **check_permission** MCP 工具：Agent 可主动查询权限

### 统计
- **+927 行** / -32 行
- 3 个新文件，5 个修改文件
- 1 个新 MCP 工具 (check_permission)