### PR TITLE
feat: Workspace V2 - iOS 桌面式卡片工作台 (v17.0.0)

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,7 +227,7 @@ def _validate_build(html: str) -> list:
         warnings.append(f"构建验证: {len(leading_space_keys)} 个 __m key 有前导空格: {leading_space_keys[:3]}")
 
     # 6. 关键全局变量存在性检查
-    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router", "HermesClient", "CardOverlay", "StatusBar", "Dock", "SpotlightSearch"]
+    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router", "HermesClient", "CardOverlay", "StatusBar", "Dock", "SpotlightSearch", "ContextMenuManager", "SkeletonLoader"]
     for var in required_globals:
         # 检查是否有 var XXX = 或 window.XXX = 的定义
         pattern = rf'(?:var\s+{var}\s*=|window\.{var}\s*=)'

--- a/app.py
+++ b/app.py
@@ -227,7 +227,7 @@ def _validate_build(html: str) -> list:
         warnings.append(f"构建验证: {len(leading_space_keys)} 个 __m key 有前导空格: {leading_space_keys[:3]}")
 
     # 6. 关键全局变量存在性检查
-    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router"]
+    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router", "HermesClient", "CardOverlay", "StatusBar", "Dock", "SpotlightSearch"]
     for var in required_globals:
         # 检查是否有 var XXX = 或 window.XXX = 的定义
         pattern = rf'(?:var\s+{var}\s*=|window\.{var}\s*=)'
@@ -294,7 +294,7 @@ def build_full_html():
 
     # 1. Core 模块（按固定依赖顺序）
     core_order = ["Logger.js", "Store.js", "Bus.js", "ErrorHandler.js",
-                  "APIClient.js", "constants.js", "Router.js", "init.js"]
+                  "HermesClient.js", "APIClient.js", "constants.js", "Router.js", "init.js"]
     core_js = [f"js/core/{f}" for f in core_order]
     # core 目录下可能还有其他文件，也一并加入
     for extra in _scan_dir("core", exclude=set(core_order)):

--- a/app.py
+++ b/app.py
@@ -227,7 +227,7 @@ def _validate_build(html: str) -> list:
         warnings.append(f"构建验证: {len(leading_space_keys)} 个 __m key 有前导空格: {leading_space_keys[:3]}")
 
     # 6. 关键全局变量存在性检查
-    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router", "HermesClient", "CardOverlay", "StatusBar", "Dock", "SpotlightSearch", "ContextMenuManager", "SkeletonLoader"]
+    required_globals = ["SSEManager", "Components", "API", "Store", "Bus", "Router", "HermesClient", "CardOverlay", "StatusBar", "Dock", "SpotlightSearch", "ContextMenuManager", "SkeletonLoader", "ResponsiveManager"]
     for var in required_globals:
         # 检查是否有 var XXX = 或 window.XXX = 的定义
         pattern = rf'(?:var\s+{var}\s*=|window\.{var}\s*=)'
@@ -264,7 +264,7 @@ def build_full_html():
     logger.info(f"build_full_html: frontend_dir={frontend_dir}, exists={frontend_dir.exists()}")
 
     # Load ALL CSS files and inline them
-    css_files = ["css/style.css", "css/dark-theme.css", "css/knowledge.css", "css/workspace.css"]
+    css_files = ["css/style.css", "css/dark-theme.css", "css/knowledge.css", "css/workspace.css", "css/workspace-mobile.css"]
     all_css = ""
     for css_path in css_files:
         full_path = frontend_dir / css_path

--- a/frontend/css/workspace-mobile.css
+++ b/frontend/css/workspace-mobile.css
@@ -1,0 +1,268 @@
+/* ==========================================================================
+   Hermes Workspace V2 — Mobile Responsive Extensions
+   Extends workspace.css with comprehensive mobile adaptations.
+   ========================================================================== */
+
+/* ==========================================================================
+   1. StatusBar — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .ws-statusbar__clock {
+        display: none;
+    }
+
+    .ws-statusbar__title {
+        font-size: 14px;
+    }
+
+    .ws-statusbar {
+        padding: 0 12px;
+        height: 32px;
+    }
+}
+
+@media (max-width: 480px) {
+    .ws-statusbar__search-text {
+        display: none; /* Hide search text, keep icon */
+    }
+}
+
+/* ==========================================================================
+   2. Dock — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .ws-dock {
+        padding: 6px 12px;
+        gap: 8px;
+    }
+
+    .ws-dock__item {
+        width: 48px;
+        height: 48px;
+        font-size: 20px;
+    }
+
+    .ws-dock__tooltip {
+        display: none; /* No tooltips on touch */
+    }
+}
+
+@media (max-width: 480px) {
+    .ws-dock {
+        padding: 4px 8px;
+        gap: 4px;
+        bottom: 8px;
+    }
+
+    .ws-dock__item {
+        width: 44px;
+        height: 44px;
+        font-size: 18px;
+    }
+
+    .ws-dock__item-label {
+        display: none;
+    }
+}
+
+/* ==========================================================================
+   3. Card — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .ws-card {
+        border-radius: 12px;
+    }
+
+    .ws-card__header {
+        padding: 8px 10px;
+    }
+
+    .ws-card__body {
+        padding: 8px 10px;
+    }
+
+    .ws-card__actions {
+        gap: 4px;
+    }
+
+    .ws-card__action-btn {
+        width: 28px;
+        height: 28px;
+        font-size: 14px;
+    }
+}
+
+@media (max-width: 480px) {
+    .ws-card__footer {
+        display: none; /* Hide footer on mobile */
+    }
+
+    .ws-card__expand {
+        display: none; /* No inline expand on mobile */
+    }
+}
+
+/* ==========================================================================
+   4. CardOverlay — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .card-overlay {
+        padding: 0;
+    }
+
+    .card-overlay-content {
+        border-radius: 0;
+        max-width: 100%;
+        height: 100%;
+    }
+
+    .card-overlay-header {
+        padding: 12px 16px;
+    }
+}
+
+@media (max-width: 480px) {
+    .card-overlay-backdrop {
+        background: rgba(0, 0, 0, 0.5);
+    }
+}
+
+/* ==========================================================================
+   5. SpotlightSearch — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 480px) {
+    .spotlight-search {
+        padding: 16px;
+    }
+
+    .spotlight-search__input {
+        font-size: 16px; /* Prevent iOS zoom on focus */
+    }
+
+    .spotlight-search__results {
+        max-height: 60vh;
+    }
+}
+
+/* ==========================================================================
+   6. Desktop Tabs — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .ws-tabs {
+        gap: 4px;
+        padding: 4px 8px;
+    }
+
+    .ws-tabs__item {
+        padding: 6px 12px;
+        font-size: 13px;
+    }
+}
+
+/* ==========================================================================
+   7. Card Store — Mobile Adaptations
+   ========================================================================== */
+
+@media (max-width: 768px) {
+    .ws-store {
+        max-width: 100%;
+        border-radius: 16px 16px 0 0;
+    }
+
+    .ws-store__grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 8px;
+    }
+}
+
+/* ==========================================================================
+   8. Safe Area Insets — Notched Phones
+   ========================================================================== */
+
+.ws-statusbar {
+    padding-top: env(safe-area-inset-top);
+}
+
+.ws-dock {
+    padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* ==========================================================================
+   9. Touch Optimizations
+   ========================================================================== */
+
+@media (hover: none) and (pointer: coarse) {
+    /* Larger touch targets for better tap accuracy */
+    .ws-card__action-btn {
+        min-width: 36px;
+        min-height: 36px;
+    }
+
+    .ws-tabs__item {
+        min-height: 36px;
+    }
+
+    .ws-layout-switcher__btn {
+        width: 36px;
+        height: 36px;
+    }
+
+    /* Disable hover transform effects on touch devices */
+    .ws-card:hover {
+        transform: none;
+    }
+
+    .ws-dock__item:hover {
+        transform: none;
+    }
+
+    /* Enlarged resize handles for touch dragging */
+    .ws-card__resize {
+        width: 24px;
+        height: 24px;
+    }
+}
+
+/* ==========================================================================
+   10. Pull-to-Refresh Indicator
+   ========================================================================== */
+
+.rsp-pull-indicator {
+    position: fixed;
+    top: -50px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--bg-secondary);
+    border: 2px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: top 0.3s ease;
+    z-index: 9999;
+}
+
+.rsp-pull-indicator--visible {
+    top: 60px;
+}
+
+.rsp-pull-indicator__arrow {
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 10px solid var(--accent);
+    transition: transform 0.3s ease;
+}
+
+.rsp-pull-indicator--refreshing .rsp-pull-indicator__arrow {
+    transform: rotate(180deg);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,331 +1,137 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hermes Agent</title>
-    <!-- 资源预加载 -->
-    <link rel="preload" href="/css/style.css" as="style">
-    <link rel="preload" href="/js/app.js" as="script">
-    <!-- CDN 预连接（可选） -->
-    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
-    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js" defer></script>
-    <link rel="stylesheet" href="/css/style.css">
-    <link rel="stylesheet" href="/css/dark-theme.css">
-    <link rel="stylesheet" href="/css/knowledge.css">
-    <link rel="stylesheet" href="/css/workspace.css">
-    <link rel="manifest" href="/manifest.json">
-    <meta name="theme-color" content="#0071e3">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hermes Workspace v17 - 卡片工作台</title>
+
+<!-- CSS -->
+<link rel="stylesheet" href="css/style.css">
+<link rel="stylesheet" href="css/workspace.css">
+<link rel="stylesheet" href="css/card-overlay.css">
+
+<!-- Favicon -->
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏠</text></svg>">
 </head>
 <body>
 
-<!-- Toast 通知容器 -->
-<div id="toastContainer" class="toast-container"></div>
+  <!-- Toast 通知容器 -->
+  <div id="toastContainer" class="toast-container"></div>
 
-<!-- 模态框 -->
-<div id="modalOverlay" class="modal-overlay">
-    <div class="modal">
-        <div class="modal-header">
-            <h2 id="modalTitle">标题</h2>
-            <button id="modalClose" class="modal-close">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
-            </button>
-        </div>
-        <div id="modalBody" class="modal-body"></div>
-        <div id="modalFooter" class="modal-footer"></div>
-    </div>
-</div>
+  <!-- 模态框 -->
+  <div id="modalOverlay" class="modal-overlay">
+    <div class="modal-content" id="modalContent"></div>
+  </div>
 
-<!-- 移动端侧边栏遮罩 -->
-<div id="sidebarOverlay" class="sidebar-overlay"></div>
+  <!-- 卡片放大覆盖层 -->
+  <div id="cardOverlay"></div>
 
-<!-- 侧边栏 -->
-<aside id="sidebar" class="sidebar">
-    <div class="sidebar-brand">
-        <div class="icon">H</div>
-        <span>Hermes</span>
-    </div>
+  <!-- 工作台主容器 -->
+  <div id="workspaceContainer"></div>
 
-    <div class="sidebar-search">
-        <input type="text" id="globalSearch" placeholder="搜索...  ⌘K">
-    </div>
+  <!-- ==================== Scripts ==================== -->
 
-        <nav class="sidebar-nav">
-        <div class="nav-section">
-            <div class="nav-section-title">概览</div>
-            <a class="nav-item active" data-page="workspace" href="#workspace" data-tooltip="iOS 桌面式自由工作台">
-                <span class="nav-icon" data-icon="layout"></span>
-                <span>工作台</span>
-            </a>
-            <a class="nav-item" data-page="dashboard" href="#dashboard" data-tooltip="系统运行状态总览">
-                <span class="nav-icon" data-icon="chart"></span>
-                <span>仪表盘</span>
-            </a>
-            <a class="nav-item" data-page="knowledge" href="#knowledge" data-tooltip="管理 AI 的知识、规则和经验">
-                <span class="nav-icon" data-icon="bookOpen"></span>
-                <span>知识库</span>
-            </a>
-        </div>
+  <!-- 1. Core 基础模块 -->
+  <script src="js/core/Logger.js"></script>
+  <script src="js/core/Store.js"></script>
+  <script src="js/core/Bus.js"></script>
+  <script src="js/core/ErrorHandler.js"></script>
+  <script src="js/core/constants.js"></script>
+  <script src="js/core/Router.js"></script>
+  <script src="js/core/init.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">对话</div>
-            <a class="nav-item" data-page="sessions" href="#sessions">
-                <span class="nav-icon" data-icon="messageCircle"></span>
-                <span>会话管理</span>
-            </a>
-            
-        </div>
+  <!-- 2. HermesClient 统一通信层（新增） -->
+  <script src="js/core/HermesClient.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">能力</div>
-            <a class="nav-item" data-page="marketplace" href="#marketplace" data-tooltip="浏览和安装 MCP 服务、技能和插件">
-                <span class="nav-icon" data-icon="store"></span>
-                <span>功能商店</span>
-            </a>
-            <a class="nav-item" data-page="agents" href="#agents" data-tooltip="管理 AI 助手的配置和状态">
-                <span class="nav-icon" data-icon="bot"></span>
-                <span>AI 助手</span>
-            </a>
-            <a class="nav-item" data-page="agents_behavior" href="#agents_behavior" data-tooltip="定义 AI 助手的性格和行为方式">
-                <span class="nav-icon" data-icon="smile"></span>
-                <span>性格设置</span>
-            </a>
-        </div>
+  <!-- 3. APIClient（保留 - 向后兼容） -->
+  <script src="js/core/APIClient.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">数据</div>
-            <a class="nav-item" data-page="memory" href="#memory" data-tooltip="查看和管理 AI 的长期记忆">
-                <span class="nav-icon" data-icon="brain"></span>
-                <span>记忆管理</span>
-            </a>
-            <a class="nav-item" data-page="cron" href="#cron" data-tooltip="设置自动执行的计划任务">
-                <span class="nav-icon" data-icon="clock"></span>
-                <span>定时任务</span>
-            </a>
-        </div>
+  <!-- 4. SSE（保留 - 向后兼容） -->
+  <script src="js/utils/sse.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">运维</div>
-            <a class="nav-item" data-page="ops_center" href="#ops_center" data-tooltip="实时监控运行状态和资源使用">
-                <span class="nav-icon" data-icon="activity"></span>
-                <span>运维中心</span>
-                <span class="nav-badge" id="opsCenterBadge"></span>
-            </a>
-            <a class="nav-item" data-page="logs" href="#logs">
-                <span class="nav-icon" data-icon="fileText"></span>
-                <span>操作日志</span>
-            </a>
-        </div>
+  <!-- 5. API 端点定义（保留 - 向后兼容，window.API 会被 HermesClient 覆盖） -->
+  <script src="js/api.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">系统</div>
-            <a class="nav-item" data-page="sync" href="#sync" data-tooltip="数据备份与恢复管理">
-                <span class="nav-icon" data-icon="refreshCw"></span>
-                <span>备份恢复</span>
-            </a>
-            <a class="nav-item" data-page="config" href="#config">
-                <span class="nav-icon" data-icon="settings"></span>
-                <span>系统配置</span>
-            </a>
-            <a class="nav-item" data-page="trash" href="#trash">
-                <span class="nav-icon" data-icon="trash"></span>
-                <span>回收站</span>
-            </a>
-        </div>
+  <!-- 6. Services 服务层 -->
+  <script src="js/services/OpsSyncService.js"></script>
+  <script src="js/services/AlertChecker.js"></script>
+  <script src="js/services/AlertNotifier.js"></script>
 
-        <div class="nav-section">
-            <div class="nav-section-title">工具</div>
-            
-        </div>
+  <!-- 7. Utilities 工具层 -->
+  <script src="js/i18n.js"></script>
+  <script src="js/utils/utils.js"></script>
 
-        <div class="nav-section nav-section-footer">
-            <a class="nav-item" onclick="window.open('/docs','_blank')">
-                <span class="nav-icon" data-icon="book"></span>
-                <span>API 文档</span>
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="nav-external-icon"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"/></svg>
-            </a>
-            
-        </div>
-    </nav>
+  <!-- 8. Components 组件层 -->
+  <script src="js/components/icons.js"></script>
+  <script src="js/components/utils.js"></script>
+  <script src="js/components/config.js"></script>
+  <script src="js/components/colors.js"></script>
+  <script src="js/components/feedback.js"></script>
+  <script src="js/components/layout.js"></script>
+  <script src="js/components/form.js"></script>
+  <script src="js/components/data-display.js"></script>
+  <script src="js/components/onboarding.js"></script>
+  <script src="js/components/index.js"></script>
 
-    <div class="sidebar-footer">
-        <div class="status">
-            <span class="status-dot" id="statusDot"></span>
-            <span id="statusText">连接中...</span>
-        </div>
-    </div>
-</aside>
+  <!-- 9. Pages 页面模块（保留） -->
+  <script src="js/pages/register.js"></script>
 
-<!-- 主内容 -->
-<div class="main">
-    <header class="header">
-        <div class="header-left">
-            <button id="mobileMenuBtn" class="mobile-menu-btn">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
-            </button>
-            <h1 id="pageTitle" class="header-title">仪表盘</h1>
-        </div>
-        <div class="header-actions">
-            <button id="refreshBtn" class="btn btn-ghost btn-sm" title="刷新">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15"/></svg>
-                <span>刷新</span>
-            </button>
-        </div>
-    </header>
+  <!-- 10. Workspace Core 工作台核心 -->
+  <script src="js/workspace/core/StateManager.js"></script>
+  <script src="js/workspace/core/DataService.js"></script>
+  <script src="js/workspace/core/LayoutEngine.js"></script>
+  <script src="js/workspace/core/DragManager.js"></script>
+  <script src="js/workspace/core/ResizeManager.js"></script>
+  <script src="js/workspace/core/ZIndexManager.js"></script>
+  <script src="js/workspace/core/CardManager.js"></script>
+  <script src="js/workspace/core/GestureManager.js"></script>
+  <script src="js/workspace/core/DesktopManager.js"></script>
+  <script src="js/workspace/core/WidgetRegistry.js"></script>
 
-    <div class="content" id="contentBody">
-        <!-- 页面内容由 JS 动态渲染 -->
-    </div>
-</div>
+  <!-- 11. CardOverlay 卡片放大系统（新增） -->
+  <script src="js/workspace/core/CardOverlay.js"></script>
 
-<!-- 主题切换按钮 -->
-<button id="themeToggle" class="theme-toggle" title="切换深色模式" data-icon="moon"></button>
+  <!-- 12. Workspace Widgets 工作台组件 -->
+  <script src="js/workspace/widgets/dashboard.js"></script>
+  <script src="js/workspace/widgets/knowledge.js"></script>
+  <script src="js/workspace/widgets/sessions.js"></script>
+  <script src="js/workspace/widgets/mcp-status.js"></script>
+  <script src="js/workspace/widgets/memo.js"></script>
+  <script src="js/workspace/widgets/todo.js"></script>
+  <script src="js/workspace/widgets/metrics.js"></script>
+  <script src="js/workspace/widgets/alerts.js"></script>
+  <script src="js/workspace/widgets/memory.js"></script>
+  <script src="js/workspace/widgets/rules.js"></script>
+  <script src="js/workspace/widgets/experiences.js"></script>
+  <script src="js/workspace/widgets/cron-tasks.js"></script>
+  <script src="js/workspace/widgets/logs.js"></script>
+  <script src="js/workspace/widgets/recycle-bin.js"></script>
+  <script src="js/workspace/widgets/config.js"></script>
+  <script src="js/workspace/widgets/store.js"></script>
+  <script src="js/workspace/widgets/ai-assistant.js"></script>
+  <script src="js/workspace/widgets/ops-center.js"></script>
 
-<!-- Scripts -->
-<!-- V2 Core Layer -->
-<script src="/js/core/Logger.js" defer></script>
-<script src="/js/core/Store.js" defer></script>
-<script src="/js/core/Bus.js" defer></script>
-<script src="/js/core/ErrorHandler.js" defer></script>
-<script src="/js/core/APIClient.js" defer></script>
-<script src="/js/core/constants.js" defer></script>
-<script src="/js/core/Router.js" defer></script>
-<script src="/js/core/init.js" defer></script>
-<!-- V2 Services -->
-<script src="/js/services/OpsSyncService.js" defer></script>
-<script src="/js/services/AlertChecker.js" defer></script>
-<script src="/js/services/AlertNotifier.js" defer></script>
-<!-- Utilities & Base -->
-<script src="/js/i18n.js" defer></script>
-<script src="/js/utils/sse.js" defer></script>
-<script src="/js/utils/export-progress.js" defer></script>
-<script src="/js/utils/confirm-dialog.js" defer></script>
-<script src="/js/api.js" defer></script>
-<!-- V2 Components (modular) -->
-<script src="/js/components/icons.js" defer></script>
-<script src="/js/components/utils.js" defer></script>
-<script src="/js/constants/config.js" defer></script>
-<script src="/js/constants/colors.js" defer></script>
-<script src="/js/components/feedback.js" defer></script>
-<script src="/js/components/layout.js" defer></script>
-<script src="/js/components/form.js" defer></script>
-<script src="/js/components/data-display.js" defer></script>
-<script src="/js/components/onboarding.js" defer></script>
-<script src="/js/components/index.js" defer></script>
-<!-- V2 Page Modules (register.js entry points) -->
-<script src="/js/pages/dashboard/register.js" defer></script>
-<script src="/js/pages/knowledge/register.js" defer></script>
-<script src="/js/pages/sessions/register.js" defer></script>
-<script src="/js/pages/memory/register.js" defer></script>
-<script src="/js/pages/cron/register.js" defer></script>
-<script src="/js/pages/agents_behavior/register.js" defer></script>
-<script src="/js/pages/config/register.js" defer></script>
-<script src="/js/pages/trash/register.js" defer></script>
-<script src="/js/pages/agents/register.js" defer></script>
-<script src="/js/pages/marketplace/register.js" defer></script>
-<script src="/js/pages/logs/register.js" defer></script>
-<script src="/js/pages/sync/register.js" defer></script>
-<script src="/js/pages/ops-center/register.js" defer></script>
-<script src="/js/pages/about/register.js" defer></script>
-<!-- Workspace Module (P0-P3: Full Workspace) -->
-<script src="/js/workspace/core/StateManager.js" defer></script>
-<script src="/js/workspace/core/DataService.js" defer></script>
-<script src="/js/workspace/core/LayoutEngine.js" defer></script>
-<script src="/js/workspace/core/DragManager.js" defer></script>
-<script src="/js/workspace/core/ResizeManager.js" defer></script>
-<script src="/js/workspace/core/ZIndexManager.js" defer></script>
-<script src="/js/workspace/core/CardManager.js" defer></script>
-<script src="/js/workspace/core/GestureManager.js" defer></script>
-<script src="/js/workspace/core/DesktopManager.js" defer></script>
-<script src="/js/workspace/core/WidgetRegistry.js" defer></script>
-<script src="/js/workspace/widgets/entries/KnowledgeEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/entries/RulesEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/entries/ExperienceEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/entries/MemoryEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/entries/ReviewEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/entries/SessionsEntryWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/KnowledgeListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/RulesListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/ExperienceListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/MemoryListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/ReviewListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/SessionRecentWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/CronListWidget.js" defer></script>
-<script src="/js/workspace/widgets/data/AgentListWidget.js" defer></script>
-<script src="/js/workspace/widgets/stats/ReviewStatWidget.js" defer></script>
-<script src="/js/workspace/widgets/stats/DashboardStatsWidget.js" defer></script>
-<script src="/js/workspace/widgets/stats/McpStatusWidget.js" defer></script>
-<script src="/js/workspace/widgets/stats/KnowledgeGraphWidget.js" defer></script>
-<script src="/js/workspace/widgets/stats/OpsMetricsWidget.js" defer></script>
-<script src="/js/workspace/widgets/functions/QuickCreateWidget.js" defer></script>
-<script src="/js/workspace/widgets/functions/GlobalSearchWidget.js" defer></script>
-<script src="/js/workspace/widgets/functions/SessionSearchWidget.js" defer></script>
-<script src="/js/workspace/widgets/shortcuts/MemoWidget.js" defer></script>
-<script src="/js/workspace/widgets/shortcuts/TodoWidget.js" defer></script>
-<script src="/js/workspace/components/CardWidget.js" defer></script>
-<script src="/js/workspace/components/LayoutSwitcher.js" defer></script>
-<script src="/js/workspace/components/DesktopContainer.js" defer></script>
-<script src="/js/workspace/components/DesktopTabs.js" defer></script>
-<script src="/js/workspace/components/CardStore.js" defer></script>
-<script src="/js/workspace/pages/WorkspacePage.js" defer></script>
-<script src="/js/app.js" defer></script>
+  <!-- 13. Workspace Components 工作台 UI 组件 -->
+  <script src="js/workspace/components/CardWidget.js"></script>
+  <script src="js/workspace/components/LayoutSwitcher.js"></script>
+  <script src="js/workspace/components/DesktopContainer.js"></script>
+  <script src="js/workspace/components/DesktopTabs.js"></script>
+  <script src="js/workspace/components/CardStore.js"></script>
 
-<!-- 全局错误边界：用户友好提示 -->
-<script>
-(function() {
-    function _friendlyError(msg) {
-        const map = {
-            'Failed to fetch': '网络连接失败，请检查网络后重试',
-            'NetworkError': '网络连接失败，请检查网络后重试',
-            'Load failed': '资源加载失败，请刷新页面重试',
-            'Timeout': '请求超时，服务器可能繁忙，请稍后重试',
-            '500': '服务器内部错误，请稍后重试',
-            '502': '服务暂时不可用，请稍后重试',
-            '503': '服务暂时不可用，请稍后重试',
-        };
-        for (const [key, friendly] of Object.entries(map)) {
-            if (msg && msg.includes(key)) return friendly;
-        }
-        return '操作出现问题，请稍后重试';
-    }
+  <!-- 14. StatusBar 状态栏（新增） -->
+  <script src="js/workspace/components/StatusBar.js"></script>
 
-    window.onerror = function(msg, url, line, col, err) {
-        if (typeof Logger !== 'undefined') Logger.error('[Global]', msg, url, line, col);
-        else console.error('[JS Error]', msg, url, line, col, err);
-        var content = document.getElementById('contentBody');
-        if (content && !content.querySelector('.js-error-boundary')) {
-            var friendly = _friendlyError(msg);
-            content.innerHTML = '<div class="js-error-boundary">' +
-                '<div class="error-icon">' + (typeof Components !== 'undefined' ? Components.icon('alertTriangle', 40) : '⚠️') + '</div>' +
-                '<div class="error-title">出了点问题</div>' +
-                '<div class="error-desc">' + friendly + '</div>' +
-                '<button class="btn btn-primary" onclick="location.reload()">刷新页面</button>' +
-                '</div>';
-        }
-        return true;
-    };
-    window.addEventListener('unhandledrejection', function(e) {
-        if (typeof Logger !== 'undefined') Logger.error('[Promise]', e.reason);
-        else console.error('[Promise Error]', e.reason);
-    });
-})();
-</script>
+  <!-- 15. Dock 栏（新增） -->
+  <script src="js/workspace/components/Dock.js"></script>
 
-<!-- V7-24: Service Worker 注册 -->
-<script>
-if ('serviceWorker' in navigator) {
-    window.addEventListener('load', function () {
-        navigator.serviceWorker.register('/sw.js').then(function (reg) {
-            console.log('[SW] Registered:', reg.scope);
-        }).catch(function (err) {
-            console.warn('[SW] Registration failed:', err);
-        });
-    });
-}
-</script>
+  <!-- 16. SpotlightSearch 聚焦搜索（新增） -->
+  <script src="js/workspace/components/SpotlightSearch.js"></script>
+
+  <!-- 17. WorkspacePage 工作台主页面 -->
+  <script src="js/workspace/pages/WorkspacePage.js"></script>
+
+  <!-- 18. App 入口 -->
+  <script src="js/app.js"></script>
 
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,382 +1,292 @@
 /**
- * Hermes Agent 管理面板 - 主应用 (Mac 极简风格)
- * 路由管理、页面切换、全局事件绑定
+ * Hermes Workspace v17 - App Entry Point (Rewrite)
+ *
+ * 重写说明：
+ * - 删除路由切换逻辑（navigateTo、handleRoute、pages 映射、Router 集成）
+ * - 删除侧边栏逻辑（toggleSidebar、updateNavActive、openMobileSidebar、closeMobileSidebar）
+ * - 删除全局搜索的页面跳转逻辑（handleGlobalSearch 中的 searchMap）
+ * - 保留主题切换（initTheme、applyTheme）
+ * - 保留 Toast/Modal 初始化
+ * - 保留新手引导
+ * - 新增 HermesClient.connect() 替代 SSEManager.connect()
+ * - 新增 StatusBar.render() 初始化
+ * - 新增 Dock.render() 初始化
+ * - 新增 WorkspacePage.render() 作为主界面
+ * - 保留 SSE 事件处理（改为 HermesClient.on）
+ * - 保留热更新检查
+ * - 保留全局快捷键（Cmd+K -> SpotlightSearch）
  */
+(function () {
+    'use strict';
 
-const App = (() => {
-    // 直接引用全局 Page 变量（const 声明的全局变量不会挂到 window 上）
-    const pages = {
-        workspace: WorkspacePage,
-        dashboard: DashboardPage,
-        knowledge: KnowledgePage,
-        sessions: SessionsPage,
-    about: AboutPage,
-        marketplace: MarketplacePage,
-        memory: MemoryPage,
-        cron: CronPage,
-        agents: AgentsPage,
-        agents_behavior: AgentsBehaviorPage,
-        config: ConfigPage,
-        trash: TrashPage,
-            sync: SyncPage,
-        ops_center: OpsCenterPage,
-                logs: LogsPage,
-    };
+    // ==================== 主题管理 ====================
 
-    const pageTitles = {
-        workspace: '工作台',
-        dashboard: '仪表盘',
-        knowledge: '知识库',
-        sessions: '会话管理',
-    about: '关于',
-        marketplace: '功能商店',
-        memory: '记忆管理',
-        cron: '定时任务',
-        agents: 'AI 助手',
-        agents_behavior: '性格设置',
-        config: '系统配置',
-        trash: '回收站',
-            sync: '备份恢复',
-        ops_center: '运维中心',
-                logs: '操作日志',
-    };
-
-    let _currentPage = null;
-
-    function init() {
-        // 全局错误边界 - 增强版
-        Components.Toast.init();
-        Components.Modal.init();
-        bindGlobalEvents();
-        initTheme();
-        replaceNavIcons();
-
-        // 初始化 Workspace 基础设施（P0）
-        if (typeof StateManager !== 'undefined') StateManager.init();
-        if (typeof DataService !== 'undefined') DataService.init();
-
-        // 新手引导（首次访问）
-        if (typeof Components !== 'undefined' && Components.Onboarding && !Components.Onboarding.isDone()) {
-            setTimeout(() => Components.Onboarding.start(), 800);
-        }
-
-        // 初始化 Router 并注册所有路由
-        initRouter();
-
-        // 初始化告警通知服务
-        if (typeof AlertNotifier !== 'undefined') AlertNotifier.init();
-
-        // 路由守卫：运维页面时启动同步和告警检查
-        if (typeof Router !== 'undefined') {
-            Router.guard(function(to) {
-                if (to === 'ops_center') {
-                    if (typeof OpsSyncService !== 'undefined') OpsSyncService.start();
-                    if (typeof AlertChecker !== 'undefined') AlertChecker.start();
-                } else {
-                    if (typeof OpsSyncService !== 'undefined') OpsSyncService.stop();
-                    if (typeof AlertChecker !== 'undefined') AlertChecker.stop();
-                }
-            });
-        }
-
-        // 预加载版本元数据
-        API.meta();
-
-        // 启动热更新检查
-        API.checkForUpdate();
-        API.startUpdateCheck(30000);
-
-        // 检测后端连接状态
-        checkBackendStatus();
-
-        // 启动 SSE 实时事件监听（带轮询降级 V7-19）
-        connectSSE();
-
-        // 监听 SSEManager 派发的事件
-        window.addEventListener('hermes:event', function (e) {
-            var event = e.detail;
-            if (event && event.data) {
-                handleSSEEvent(event.data);
-            }
-        });
-
-        // 初始路由
-        handleRoute();
-    }
-
-    // --- Router 集成 ---
-
-    function initRouter() {
-        if (typeof Router === 'undefined') return;
-
-        // 注册所有路由
-        const routesMap = {};
-        Object.keys(pages).forEach(function(key) {
-            routesMap[key] = {
-                title: pageTitles[key] || key,
-                component: pages[key]
-            };
-        });
-        Router.registerAll(routesMap);
-
-        // 路由守卫：切换页面时更新导航状态
-        Router.guard(function(to, from) {
-            updateNavActive(to);
-            document.getElementById('pageTitle').textContent = pageTitles[to] || to;
-        });
-
-        // 初始化 hash 监听
-        Router.init();
-
-        // 监听 Router 事件进行页面切换
-        if (typeof Bus !== 'undefined' && typeof Events !== 'undefined') {
-            Bus.on(Events.PAGE_CHANGED, function(data) {
-                var path = data.path;
-                if (pages[path]) {
-                    // 销毁旧页面
-                    if (_currentPage && pages[_currentPage] && pages[_currentPage].destroy) {
-                        pages[_currentPage].destroy();
-                    }
-                    _currentPage = path;
-                    // 渲染新页面
-                    pages[path].render().catch(function(err) {
-                        if (typeof Logger !== 'undefined') Logger.error('[App]', '页面 ' + path + ' 渲染失败:', err);
-                        document.getElementById('contentBody').innerHTML = Components.createEmptyState(
-                            Components.icon('alertTriangle', 14),
-                            '页面加载失败',
-                            err.message || '未知错误',
-                            '<button class="btn btn-primary" onclick="App.refresh()">重试</button>'
-                        );
-                    });
-                    closeMobileSidebar();
-                }
-            });
-        }
-
-        if (typeof Logger !== 'undefined') Logger.info('[App]', 'Router initialized with ' + Object.keys(routesMap).length + ' routes');
-    }
-
+    /**
+     * 初始化主题
+     */
     function initTheme() {
-        const saved = localStorage.getItem('hermes-theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const isDark = saved === 'dark' || (!saved && prefersDark);
-        applyTheme(isDark);
-
-        document.getElementById('themeToggle').addEventListener('click', () => {
-            const current = document.documentElement.getAttribute('data-theme') === 'dark';
-            applyTheme(!current);
-        });
-    }
-
-    function applyTheme(isDark) {
-        document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-        const btn = document.getElementById('themeToggle');
-        if (btn) btn.innerHTML = Components.icon(isDark ? 'sun' : 'moon', 18);
-        localStorage.setItem('hermes-theme', isDark ? 'dark' : 'light');
-    }
-
-    async function checkBackendStatus() {
-        const dot = document.getElementById('statusDot');
-        const text = document.getElementById('statusText');
+        var saved = null;
         try {
-            await API.system.health();
-            if (dot) dot.style.background = 'var(--green)';
-            if (text) text.textContent = '已连接';
-        } catch (_err) {
-            if (dot) dot.style.background = 'var(--orange)';
-            if (text) text.textContent = '降级模式';
+            saved = localStorage.getItem('hermes-theme');
+        } catch (e) {
+            // localStorage 不可用
         }
-    }
-
-    // --- SSE 实时事件（V7-19: 使用 SSEManager 带轮询降级） ---
-
-    function connectSSE() {
-        SSEManager.connect('/api/events');
-    }
-
-    function handleSSEEvent(event) {
-        const type = event.type || '';
-        const data = event.data || {};
-
-        // 传递给当前页面的 onSSEEvent 方法（实时增量更新）
-        const page = pages[_currentPage];
-        if (page && typeof page.onSSEEvent === 'function') {
-            try {
-                page.onSSEEvent(type, data);
-            } catch (_e) {
-                /* ignore */
-            }
-        }
-    }
-
-    function handleRoute() {
-        const hash = window.location.hash.slice(1) || 'workspace';
-        const pageName = pages[hash] ? hash : 'workspace';
-        navigateTo(pageName);
-    }
-
-    async function navigateTo(pageName) {
-        if (!pages[pageName]) return;
-
-        if (_currentPage && pages[_currentPage].destroy) {
-            pages[_currentPage].destroy();
-        }
-
-        // Workspace 路由适配
-        if (pageName === 'workspace') {
-            // 进入工作台时恢复 DataService
-            if (typeof DataService !== 'undefined') DataService.init();
+        if (saved) {
+            applyTheme(saved);
         } else {
-            // 离开工作台时取消所有 pending 请求
-            if (typeof DataService !== 'undefined') DataService.cancelAll();
+            // 跟随系统偏好
+            if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                applyTheme('dark');
+            } else {
+                applyTheme('light');
+            }
         }
+    }
 
-        updateNavActive(pageName);
-        document.getElementById('pageTitle').textContent = pageTitles[pageName] || pageName;
-
-        const page = pages[pageName];
-        _currentPage = pageName;
-
+    /**
+     * 应用主题
+     * @param {string} theme - 'light' | 'dark'
+     */
+    function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
         try {
-            await page.render();
-        } catch (err) {
-            console.error(`[App] 页面 ${pageName} 渲染失败:`, err);
-            document.getElementById('contentBody').innerHTML = Components.createEmptyState(
-                Components.icon('alertTriangle', 14),
-                '页面加载失败',
-                err.message || '未知错误',
-                `<button class="btn btn-primary" onclick="App.refresh()">重试</button>`,
-            );
-        }
-
-        closeMobileSidebar();
-    }
-
-    function updateNavActive(pageName) {
-        document.querySelectorAll('.nav-item').forEach((item) => {
-            item.classList.toggle('active', item.dataset.page === pageName);
-        });
-    }
-
-    function refresh() {
-        if (_currentPage && pages[_currentPage]) {
-            pages[_currentPage].render();
+            localStorage.setItem('hermes-theme', theme);
+        } catch (e) {
+            // ignore
         }
     }
 
-    function replaceNavIcons() {
-        document.querySelectorAll('.nav-icon[data-icon]').forEach((el) => {
-            const name = el.getAttribute('data-icon');
-            if (name) {
-                el.innerHTML = Components.icon(name, 16);
-            }
-        });
-        // 主题切换按钮
-        const themeBtn = document.getElementById('themeToggle');
-        if (themeBtn) {
-            const iconName = themeBtn.getAttribute('data-icon') || 'moon';
-            themeBtn.innerHTML = Components.icon(iconName, 16);
-        }
+    /**
+     * 切换主题
+     */
+    function toggleTheme() {
+        var current = document.documentElement.getAttribute('data-theme') || 'light';
+        var next = current === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
     }
 
+    // ==================== 全局快捷键 ====================
+
+    /**
+     * 绑定全局事件
+     */
     function bindGlobalEvents() {
-        // 刷新按钮
-        document.getElementById('refreshBtn').addEventListener('click', () => {
-            refresh();
-            showToast('已刷新');
-        });
+        document.addEventListener('keydown', function (e) {
+            var isCmd = e.metaKey || e.ctrlKey;
 
-        // 移动端菜单
-        document.getElementById('mobileMenuBtn').addEventListener('click', openMobileSidebar);
-        document.getElementById('sidebarOverlay').addEventListener('click', closeMobileSidebar);
-
-        // 全局搜索
-        document.getElementById('globalSearch').addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') handleGlobalSearch(e.target.value);
-        });
-
-        // 快捷键
-        document.addEventListener('keydown', (e) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+            // Cmd+K / Ctrl+K -> SpotlightSearch
+            if (isCmd && e.key === 'k') {
                 e.preventDefault();
-                document.getElementById('globalSearch').focus();
-            }
-            if (e.key === 'Escape') {
-                Components.Modal.close();
-                closeMobileSidebar();
-            }
-        });
-
-        // 导航切换 (Mac 风格: .nav-item click -> .page active)
-        document.querySelectorAll('.nav-item').forEach((item) => {
-            item.addEventListener('click', (e) => {
-                e.preventDefault();
-                const page = item.dataset.page;
-                if (page) {
-                    window.location.hash = page;
+                if (typeof SpotlightSearch !== 'undefined' && SpotlightSearch.toggle) {
+                    SpotlightSearch.toggle();
                 }
-            });
-        });
-
-        // 监听 hash 变化
-        window.addEventListener('hashchange', handleRoute);
-
-        // 窗口大小变化
-        window.addEventListener(
-            'resize',
-            Components.debounce(() => {
-                if (window.innerWidth > 768) closeMobileSidebar();
-            }, 200),
-        );
-    }
-
-    function handleGlobalSearch(query) {
-        if (!query.trim()) return;
-        const term = query.toLowerCase().trim();
-        const searchMap = {
-            仪表盘: 'dashboard', 统计: 'dashboard', 概览: 'dashboard', 总览: 'dashboard',
-            知识库: 'knowledge', 知识: 'knowledge', 规则: 'knowledge',
-            会话: 'sessions', 会话管理: 'sessions', 历史: 'sessions', 聊天记录: 'sessions',
-            对话: 'sessions', 聊天: 'sessions',
-            功能商店: 'marketplace', 扩展管理: 'marketplace', 扩展: 'marketplace',
-            工具: 'marketplace', 函数: 'marketplace', 技能: 'marketplace', skill: 'marketplace',
-            mcp: 'marketplace', 服务: 'marketplace', 插件: 'marketplace',
-            AI助手: 'agents', 助手: 'agents', agent: 'agents', 子agent: 'agents', 子代理: 'agents',
-            性格: 'agents_behavior', 人格: 'agents_behavior', 行为: 'agents_behavior', 行为管理: 'agents_behavior',
-            记忆: 'memory', memory: 'memory', 画像: 'memory',
-            定时: 'cron', 任务: 'cron', cron: 'cron', 调度: 'cron', 计划任务: 'cron',
-            运维: 'ops_center', 监控: 'ops_center', ops: 'ops_center', 健康: 'ops_center',
-            告警: 'ops_center', 报警: 'ops_center', alert: 'ops_center',
-            日志: 'logs', log: 'logs', 操作: 'logs', 操作日志: 'logs',
-            备份: 'sync', 同步: 'sync', 恢复: 'sync', 更新: 'sync',
-            配置: 'config', 设置: 'config', config: 'config',
-            回收站: 'trash', 删除: 'trash',
-            截图: 'screenshot',
-            帮助: 'about',
-        };
-        for (const [keyword, page] of Object.entries(searchMap)) {
-            if (keyword.includes(term) || term.includes(keyword)) {
-                window.location.hash = page;
-                document.getElementById('globalSearch').value = '';
                 return;
             }
+
+            // Esc -> 关闭 CardOverlay + SpotlightSearch
+            if (e.key === 'Escape') {
+                if (typeof CardOverlay !== 'undefined' && CardOverlay.close) {
+                    CardOverlay.close();
+                }
+                if (typeof SpotlightSearch !== 'undefined' && SpotlightSearch.close) {
+                    SpotlightSearch.close();
+                }
+                return;
+            }
+
+            // E -> 切换编辑模式（不在输入框中时）
+            if (e.key === 'e' && !e.target.matches('input, textarea, [contenteditable]')) {
+                if (typeof WorkspacePage !== 'undefined' && WorkspacePage.toggleEditMode) {
+                    WorkspacePage.toggleEditMode();
+                }
+                return;
+            }
+        });
+
+        // 系统主题变化监听
+        if (window.matchMedia) {
+            try {
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+                    // 仅在用户未手动设置主题时跟随系统
+                    var saved = null;
+                    try { saved = localStorage.getItem('hermes-theme'); } catch (ex) {}
+                    if (!saved) {
+                        applyTheme(e.matches ? 'dark' : 'light');
+                    }
+                });
+            } catch (e) {
+                // matchMedia addEventListener 不支持时忽略
+            }
         }
-        showToast(`未找到与 "${query}" 匹配的页面`, 'info');
     }
 
-    function openMobileSidebar() {
-        document.getElementById('sidebar').classList.add('open');
-        document.getElementById('sidebarOverlay').classList.add('active');
+    // ==================== SSE 事件处理 ====================
+
+    /**
+     * 注册 SSE 事件监听
+     */
+    function setupSSEEventHandlers() {
+        if (typeof HermesClient === 'undefined') return;
+
+        // 通用 SSE 事件广播
+        HermesClient.on('sse:*', function (event, data) {
+            // 通知当前卡片数据更新
+            if (typeof WorkspacePage !== 'undefined' && WorkspacePage.onSSEEvent) {
+                WorkspacePage.onSSEEvent(event, data);
+            }
+
+            // 通知 StatusBar 更新
+            if (typeof StatusBar !== 'undefined' && StatusBar.onSSEEvent) {
+                StatusBar.onSSEEvent(event, data);
+            }
+        });
+
+        // 连接状态变化
+        HermesClient.on('connection:change', function (status) {
+            if (typeof StatusBar !== 'undefined' && StatusBar.updateConnectionStatus) {
+                StatusBar.updateConnectionStatus(status);
+            }
+        });
     }
 
-    function closeMobileSidebar() {
-        document.getElementById('sidebar').classList.remove('open');
-        document.getElementById('sidebarOverlay').classList.remove('active');
+    // ==================== 热更新检查 ====================
+
+    /**
+     * 设置热更新检查
+     */
+    function setupHotUpdate() {
+        if (typeof HermesClient === 'undefined') return;
+
+        // 首次检查
+        HermesClient.checkForUpdate();
+
+        // 定期检查（30秒）
+        HermesClient.startUpdateCheck(30000);
     }
 
-    // --- 全局错误边界 ---
+    // ==================== 全局错误边界 ====================
 
-    document.addEventListener('DOMContentLoaded', init);
+    /**
+     * 全局错误捕获
+     */
+    function setupGlobalErrorHandler() {
+        window.addEventListener('error', function (event) {
+            console.error('[App] Global error:', event.error);
 
-    return { init, refresh, navigateTo };
+            // 尝试通过 ErrorHandler 上报
+            if (typeof ErrorHandler !== 'undefined' && ErrorHandler.handleError) {
+                ErrorHandler.handleError(event.error || new Error(event.message), {
+                    source: 'global-error-boundary',
+                    filename: event.filename,
+                    lineno: event.lineno,
+                    colno: event.colno
+                });
+            }
+        });
+
+        window.addEventListener('unhandledrejection', function (event) {
+            console.error('[App] Unhandled rejection:', event.reason);
+
+            if (typeof ErrorHandler !== 'undefined' && ErrorHandler.handleError) {
+                ErrorHandler.handleError(
+                    event.reason instanceof Error ? event.reason : new Error(String(event.reason)),
+                    { source: 'unhandled-rejection' }
+                );
+            }
+        });
+    }
+
+    // ==================== 主初始化 ====================
+
+    /**
+     * 应用初始化入口
+     */
+    function init() {
+        console.log('[App] Initializing Hermes Workspace v17...');
+
+        // 1. 全局初始化
+        if (typeof Components !== 'undefined' && Components.Toast && Components.Toast.init) {
+            Components.Toast.init();
+        }
+        if (typeof Components !== 'undefined' && Components.Modal && Components.Modal.init) {
+            Components.Modal.init();
+        }
+        initTheme();
+
+        // 2. 初始化 Workspace 基础设施
+        if (typeof StateManager !== 'undefined' && StateManager.init) {
+            StateManager.init();
+        }
+
+        // 3. 新手引导
+        if (typeof Components !== 'undefined' && Components.Onboarding && !Components.Onboarding.isDone()) {
+            setTimeout(function () {
+                Components.Onboarding.start();
+            }, 800);
+        }
+
+        // 4. 连接 SSE（通过 HermesClient）
+        if (typeof HermesClient !== 'undefined') {
+            HermesClient.connect('/api/events');
+        }
+
+        // 5. 初始化告警通知
+        if (typeof AlertNotifier !== 'undefined' && AlertNotifier.init) {
+            AlertNotifier.init();
+        }
+
+        // 6. 渲染工作台主界面
+        var container = document.getElementById('workspaceContainer');
+        if (container && typeof WorkspacePage !== 'undefined') {
+            WorkspacePage.render(container);
+        }
+
+        // 7. 渲染 StatusBar
+        if (typeof StatusBar !== 'undefined') {
+            var statusBarEl = document.createElement('div');
+            statusBarEl.id = 'statusBar';
+            container.parentNode.insertBefore(statusBarEl, container);
+            StatusBar.render(statusBarEl);
+        }
+
+        // 8. 渲染 Dock
+        if (typeof Dock !== 'undefined') {
+            var dockEl = document.createElement('div');
+            dockEl.id = 'dock';
+            document.body.appendChild(dockEl);
+            Dock.render(dockEl);
+        }
+
+        // 9. 全局快捷键
+        bindGlobalEvents();
+
+        // 10. 热更新检查
+        setupHotUpdate();
+
+        // 11. SSE 事件处理
+        setupSSEEventHandlers();
+
+        // 12. 全局错误边界
+        setupGlobalErrorHandler();
+
+        console.log('[App] Hermes Workspace v17 initialized successfully.');
+    }
+
+    // ==================== DOM Ready ====================
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // ==================== 暴露全局 API ====================
+
+    window.App = {
+        init: init,
+        initTheme: initTheme,
+        applyTheme: applyTheme,
+        toggleTheme: toggleTheme
+    };
+
 })();

--- a/frontend/js/core/HermesClient.js
+++ b/frontend/js/core/HermesClient.js
@@ -1,0 +1,1112 @@
+/**
+ * HermesClient.js — Hermes Workspace V2 统一通信层
+ *
+ * 合并 4 个通信模块为统一客户端：
+ *   1. api.js        → API 端点定义
+ *   2. APIClient.js  → HTTP 重试 / 链路追踪 / 错误上报 / 超时
+ *   3. SSEManager    → SSE 连接 / 重连 / 轮询降级
+ *   4. DataService   → TTL + LRU 缓存 / 请求去重 / 并发控制 / SSE 失效映射
+ *
+ * 向后兼容：
+ *   window.HermesClient  — 新代码使用
+ *   window.API           — 旧代码兼容（指向同一实例）
+ *   window.APIClient     — 旧代码兼容（request/get/post/put/del 代理）
+ *   window.APP_VERSION   — 动态 getter（通过 Object.defineProperty）
+ */
+'use strict';
+
+var HermesClient = (function () {
+    'use strict';
+
+    // ================================================================
+    //  常量与配置
+    // ================================================================
+
+    /** BASE_URL 检测：localhost → http://localhost:3000 */
+    var BASE_URL = (function () {
+        if (typeof window === 'undefined') return '';
+        var h = window.location;
+        if (h.hostname === 'localhost' || h.hostname === '127.0.0.1') {
+            return 'http://' + h.hostname + ':3000';
+        }
+        return '';  // 同源，使用相对路径
+    })();
+
+    /** 默认超时 15s */
+    var DEFAULT_TIMEOUT = 15000;
+
+    /** 重试配置：502/503/504 指数退避 1s/2s/4s，最多 3 次 */
+    var RETRY_STATUS_CODES = [502, 503, 504];
+    var MAX_RETRIES = 3;
+    var RETRY_DELAYS = [1000, 2000, 4000];
+
+    /** 缓存配置 */
+    var CACHE_TTL = 60000;       // 60 秒
+    var CACHE_MAX_SIZE = 100;    // LRU 上限
+
+    /** 并发控制 */
+    var MAX_CONCURRENT = 6;
+
+    /** SSE 配置 */
+    var SSE_MAX_RECONNECTS = 5;
+    var SSE_POLL_INTERVAL = 3000;  // 降级后轮询间隔 3s
+    var SSE_DEFAULT_URL = '/api/events';
+
+    /** 错误上报端点 */
+    var ERROR_REPORT_URL = '/api/ops/frontend-errors';
+
+    // ================================================================
+    //  内部状态
+    // ================================================================
+
+    /** 简易事件总线（内嵌，不依赖外部 Bus.js） */
+    var _listeners = {};
+
+    /** SSE 状态 */
+    var _sseSource = null;
+    var _sseReconnectCount = 0;
+    var _ssePollTimer = null;
+    var _sseConnected = false;
+    var _sseUrl = SSE_DEFAULT_URL;
+
+    /** 缓存：Map<cacheKey, { data, timestamp }> */
+    var _cache = new Map();
+
+    /** 请求去重：Map<cacheKey, Promise> */
+    var _pending = new Map();
+
+    /** 并发控制：当前活跃请求数 */
+    var _activeRequests = 0;
+
+    /** 并发等待队列 */
+    var _requestQueue = [];
+
+    /** 热更新检查 */
+    var _updateCheckTimer = null;
+    var _currentVersion = null;
+
+    // ================================================================
+    //  工具函数
+    // ================================================================
+
+    /**
+     * 生成 Trace-Id（链路追踪）
+     * 优先使用 crypto.randomUUID，降级为时间戳+随机数
+     */
+    function generateTraceId() {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+        return Date.now().toString(36) + '-' + Math.random().toString(36).substr(2, 9);
+    }
+
+    /**
+     * 延迟指定毫秒
+     */
+    function sleep(ms) {
+        return new Promise(function (resolve) { setTimeout(resolve, ms); });
+    }
+
+    /**
+     * 安全 JSON.stringify（处理循环引用）
+     */
+    function safeStringify(obj) {
+        try {
+            return JSON.stringify(obj);
+        } catch (e) {
+            return '[Circular]';
+        }
+    }
+
+    /**
+     * 统一处理响应格式
+     * 兼容后端不一致的响应格式：
+     *   { success: true, data: {...} }  → data
+     *   { results: [...], total: 100 }  → results
+     *   直接数组/对象                   → 原样返回
+     */
+    function normalizeResponse(response) {
+        if (!response) return response;
+        if (typeof response !== 'object') return response;
+        // 标准格式
+        if ('success' in response && response.success) {
+            return response.data !== undefined ? response.data : response;
+        }
+        // 搜索分页格式
+        if ('results' in response) {
+            return response.results;
+        }
+        return response;
+    }
+
+    /**
+     * 错误上报（navigator.sendBeacon）
+     * 非阻塞，不影响用户体验
+     */
+    function reportError(error, context) {
+        try {
+            var payload = {
+                timestamp: new Date().toISOString(),
+                message: error.message || String(error),
+                stack: error.stack || '',
+                url: typeof window !== 'undefined' ? window.location.href : '',
+                context: context || {}
+            };
+            var blob = new Blob([safeStringify(payload)], { type: 'application/json' });
+            if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+                navigator.sendBeacon(BASE_URL + ERROR_REPORT_URL, blob);
+            }
+        } catch (e) {
+            // 上报失败静默处理，不影响主流程
+        }
+    }
+
+    /**
+     * 控制台日志前缀
+     */
+    function _log(tag, msg) {
+        if (typeof console !== 'undefined') {
+            console.log('[HermesClient:' + tag + '] ' + msg);
+        }
+    }
+
+    function _warn(tag, msg) {
+        if (typeof console !== 'undefined') {
+            console.warn('[HermesClient:' + tag + '] ' + msg);
+        }
+    }
+
+    function _error(tag, msg) {
+        if (typeof console !== 'undefined') {
+            console.error('[HermesClient:' + tag + '] ' + msg);
+        }
+    }
+
+    // ================================================================
+    //  事件总线（内嵌）
+    // ================================================================
+
+    /**
+     * 注册事件监听
+     * @param {string} event - 事件名
+     * @param {Function} handler - 处理函数
+     */
+    function on(event, handler) {
+        if (!_listeners[event]) {
+            _listeners[event] = [];
+        }
+        _listeners[event].push(handler);
+    }
+
+    /**
+     * 取消事件监听
+     * @param {string} event - 事件名
+     * @param {Function} handler - 处理函数
+     */
+    function off(event, handler) {
+        if (!_listeners[event]) return;
+        _listeners[event] = _listeners[event].filter(function (h) {
+            return h !== handler;
+        });
+        if (_listeners[event].length === 0) {
+            delete _listeners[event];
+        }
+    }
+
+    /**
+     * 触发事件
+     * @param {string} event - 事件名
+     * @param {*} data - 事件数据
+     */
+    function emit(event, data) {
+        if (!_listeners[event]) return;
+        // 复制数组防止迭代中修改
+        var handlers = _listeners[event].slice();
+        for (var i = 0; i < handlers.length; i++) {
+            try {
+                handlers[i](data);
+            } catch (e) {
+                _error('Bus', '事件处理异常: ' + event + ' - ' + e.message);
+            }
+        }
+    }
+
+    // ================================================================
+    //  HTTP 层
+    // ================================================================
+
+    /**
+     * 并发控制：等待可用槽位
+     */
+    function acquireSlot() {
+        return new Promise(function (resolve) {
+            if (_activeRequests < MAX_CONCURRENT) {
+                _activeRequests++;
+                resolve();
+                return;
+            }
+            _requestQueue.push(function () {
+                _activeRequests++;
+                resolve();
+            });
+        });
+    }
+
+    /**
+     * 释放并发槽位
+     */
+    function releaseSlot() {
+        _activeRequests--;
+        if (_requestQueue.length > 0 && _activeRequests < MAX_CONCURRENT) {
+            var next = _requestQueue.shift();
+            next();
+        }
+    }
+
+    /**
+     * 核心请求方法
+     *
+     * 特性：
+     *   - AbortController + 超时
+     *   - X-Trace-Id 自动注入
+     *   - 502/503/504 指数退避重试（最多 3 次）
+     *   - 错误自动上报（sendBeacon）
+     *   - 并发控制（最多 6 个）
+     *   - 响应格式统一处理
+     *
+     * @param {string} method - HTTP 方法
+     * @param {string} url - 请求路径（相对或绝对）
+     * @param {Object} [options] - 选项
+     * @param {Object} [options.body] - 请求体
+     * @param {number} [options.timeout] - 超时毫秒数
+     * @param {boolean} [options.raw] - 是否跳过响应格式化
+     * @param {boolean} [options.noRetry] - 禁用重试
+     * @param {AbortSignal} [options.signal] - 外部 AbortSignal
+     * @returns {Promise<*>} 响应数据
+     */
+    async function request(method, url, options) {
+        options = options || {};
+
+        // 并发控制
+        await acquireSlot();
+
+        var timeout = options.timeout || DEFAULT_TIMEOUT;
+        var retryCount = 0;
+        var lastError = null;
+
+        try {
+            while (retryCount <= MAX_RETRIES) {
+                var controller = new AbortController();
+                var timeoutId = setTimeout(function () { controller.abort(); }, timeout);
+
+                // 合并外部 signal
+                if (options.signal) {
+                    options.signal.addEventListener('abort', function () {
+                        controller.abort();
+                    });
+                }
+
+                var traceId = generateTraceId();
+                var fullUrl = url.indexOf('http') === 0 ? url : BASE_URL + url;
+
+                var fetchOptions = {
+                    method: method,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Trace-Id': traceId
+                    },
+                    signal: controller.signal
+                };
+
+                if (options.body && method !== 'GET') {
+                    fetchOptions.body = typeof options.body === 'string'
+                        ? options.body
+                        : safeStringify(options.body);
+                }
+
+                try {
+                    var response = await fetch(fullUrl, fetchOptions);
+                    clearTimeout(timeoutId);
+
+                    // 502/503/504 重试
+                    if (RETRY_STATUS_CODES.indexOf(response.status) !== -1 && !options.noRetry && retryCount < MAX_RETRIES) {
+                        var delay = RETRY_DELAYS[retryCount] || 4000;
+                        _warn('HTTP', method + ' ' + url + ' → ' + response.status + '，第 ' + (retryCount + 1) + ' 次重试（' + delay + 'ms 后）');
+                        retryCount++;
+                        await sleep(delay);
+                        continue;
+                    }
+
+                    // 非 2xx 响应
+                    if (!response.ok) {
+                        var errorBody = null;
+                        try {
+                            errorBody = await response.json();
+                        } catch (e) {
+                            errorBody = await response.text().catch(function () { return null; });
+                        }
+
+                        var apiError = new Error('HTTP ' + response.status + ': ' + (errorBody && errorBody.detail) || response.statusText);
+                        apiError.status = response.status;
+                        apiError.body = errorBody;
+                        apiError.traceId = traceId;
+
+                        // 4xx 不上报，5xx 上报
+                        if (response.status >= 500) {
+                            reportError(apiError, { method: method, url: url, traceId: traceId });
+                        }
+
+                        throw apiError;
+                    }
+
+                    // 解析响应
+                    var contentType = response.headers.get('content-type') || '';
+                    var data;
+                    if (contentType.indexOf('application/json') !== -1) {
+                        data = await response.json();
+                    } else {
+                        data = await response.text();
+                    }
+
+                    // 统一响应格式
+                    if (!options.raw) {
+                        data = normalizeResponse(data);
+                    }
+
+                    return data;
+
+                } catch (err) {
+                    clearTimeout(timeoutId);
+
+                    // AbortError：取消或超时，不重试
+                    if (err.name === 'AbortError') {
+                        if (options.signal && options.signal.aborted) {
+                            throw err;  // 外部取消
+                        }
+                        var timeoutError = new Error('请求超时 (' + timeout + 'ms): ' + method + ' ' + url);
+                        timeoutError.name = 'TimeoutError';
+                        timeoutError.traceId = traceId;
+                        reportError(timeoutError, { method: method, url: url, traceId: traceId });
+                        throw timeoutError;
+                    }
+
+                    // 网络错误重试
+                    if (!options.noRetry && retryCount < MAX_RETRIES) {
+                        var netDelay = RETRY_DELAYS[retryCount] || 4000;
+                        _warn('HTTP', method + ' ' + url + ' → 网络错误，第 ' + (retryCount + 1) + ' 次重试（' + netDelay + 'ms 后）');
+                        lastError = err;
+                        retryCount++;
+                        await sleep(netDelay);
+                        continue;
+                    }
+
+                    // 重试耗尽
+                    err.traceId = traceId;
+                    reportError(err, { method: method, url: url, traceId: traceId, retryCount: retryCount });
+                    throw err;
+                }
+            }
+
+            // 不应到达此处
+            throw lastError || new Error('请求失败: ' + method + ' ' + url);
+
+        } finally {
+            releaseSlot();
+        }
+    }
+
+    /**
+     * GET 请求
+     */
+    function get(url, options) {
+        return request('GET', url, options);
+    }
+
+    /**
+     * POST 请求
+     */
+    function post(url, body, options) {
+        options = options || {};
+        options.body = body;
+        return request('POST', url, options);
+    }
+
+    /**
+     * PUT 请求
+     */
+    function put(url, body, options) {
+        options = options || {};
+        options.body = body;
+        return request('PUT', url, options);
+    }
+
+    /**
+     * DELETE 请求
+     */
+    function del(url, options) {
+        return request('DELETE', url, options);
+    }
+
+    // ================================================================
+    //  SSE 层
+    // ================================================================
+
+    /**
+     * SSE 事件 → 缓存失效映射
+     * 当收到 SSE 事件时，自动清除对应前缀的缓存
+     */
+    var SSE_CACHE_INVALIDATION_MAP = {
+        'knowledge.updated':       ['knowledge'],
+        'rules.updated':           ['rules'],
+        'experiences.updated':     ['experiences'],
+        'memories.updated':        ['memories'],
+        'reviews.updated':         ['reviews'],
+        'mcp.tool_call':           ['mcp', 'tools'],
+        'mcp.tool_complete':       ['mcp', 'tools'],
+        'session.created':         ['sessions'],
+        'session.updated':         ['sessions'],
+        'session.deleted':         ['sessions'],
+        'session.message':         ['sessions'],
+        'cron.updated':            ['cron'],
+        'config.updated':          ['config'],
+        'agents.updated':          ['agents'],
+        'api.error':               []  // 仅通知，不清缓存
+    };
+
+    /**
+     * 已知的 SSE 事件类型列表
+     * 用于 EventSource 代理
+     */
+    var KNOWN_SSE_EVENTS = [
+        'message',
+        'session.created',
+        'session.updated',
+        'session.deleted',
+        'session.message',
+        'knowledge.updated',
+        'rules.updated',
+        'experiences.updated',
+        'memories.updated',
+        'reviews.updated',
+        'mcp.tool_call',
+        'mcp.tool_complete',
+        'cron.updated',
+        'config.updated',
+        'agents.updated',
+        'api.error'
+    ];
+
+    /**
+     * 建立 SSE 连接
+     * @param {string} [url] - SSE 端点 URL，默认 /api/events
+     */
+    function connect(url) {
+        if (url) _sseUrl = url;
+
+        // 先清理旧连接
+        disconnect();
+
+        _log('SSE', '正在连接 ' + BASE_URL + _sseUrl + ' ...');
+
+        try {
+            _sseSource = new EventSource(BASE_URL + _sseUrl);
+        } catch (e) {
+            _error('SSE', 'EventSource 创建失败: ' + e.message);
+            _startPolling();
+            return;
+        }
+
+        _sseSource.onopen = function () {
+            _sseReconnectCount = 0;
+            _sseConnected = true;
+            _log('SSE', '已连接');
+            emit('sse:connected', {});
+            // 停止轮询（如果正在轮询）
+            _stopPolling();
+        };
+
+        _sseSource.onerror = function () {
+            _sseConnected = false;
+            _sseReconnectCount++;
+            _warn('SSE', '连接断开（第 ' + _sseReconnectCount + ' 次）');
+
+            if (_sseReconnectCount >= SSE_MAX_RECONNECTS) {
+                _warn('SSE', '超过最大重连次数 (' + SSE_MAX_RECONNECTS + ')，降级为轮询');
+                emit('sse:degraded', { reconnectCount: _sseReconnectCount });
+                _sseSource.close();
+                _sseSource = null;
+                _startPolling();
+            } else {
+                emit('sse:reconnecting', { reconnectCount: _sseReconnectCount });
+            }
+        };
+
+        // 代理所有已知事件类型
+        for (var i = 0; i < KNOWN_SSE_EVENTS.length; i++) {
+            _bindSSEEvent(KNOWN_SSE_EVENTS[i]);
+        }
+
+        // 同时监听通用 message 事件
+        _sseSource.onmessage = function (event) {
+            var data = null;
+            try {
+                data = JSON.parse(event.data);
+            } catch (e) {
+                data = event.data;
+            }
+            emit('sse:message', { type: event.type, data: data, raw: event });
+            _handleSSECacheInvalidation('message', data);
+        };
+    }
+
+    /**
+     * 绑定单个 SSE 事件
+     */
+    function _bindSSEEvent(eventType) {
+        if (!_sseSource) return;
+        _sseSource.addEventListener(eventType, function (event) {
+            var data = null;
+            try {
+                data = JSON.parse(event.data);
+            } catch (e) {
+                data = event.data;
+            }
+            // 通过 Bus 分发，事件名加 sse: 前缀
+            emit('sse:' + eventType, { type: eventType, data: data, raw: event });
+            // 触发缓存失效
+            _handleSSECacheInvalidation(eventType, data);
+        });
+    }
+
+    /**
+     * 处理 SSE 事件触发的缓存失效
+     */
+    function _handleSSECacheInvalidation(eventType, data) {
+        var prefixes = SSE_CACHE_INVALIDATION_MAP[eventType];
+        if (!prefixes || prefixes.length === 0) return;
+
+        var invalidated = 0;
+        _cache.forEach(function (value, key) {
+            for (var i = 0; i < prefixes.length; i++) {
+                if (key.indexOf(prefixes[i]) === 0) {
+                    _cache.delete(key);
+                    invalidated++;
+                    break;
+                }
+            }
+        });
+
+        if (invalidated > 0) {
+            _log('Cache', 'SSE 事件 "' + eventType + '" 触发 ' + invalidated + ' 条缓存失效');
+        }
+    }
+
+    /**
+     * 断开 SSE 连接
+     */
+    function disconnect() {
+        if (_sseSource) {
+            _sseSource.close();
+            _sseSource = null;
+        }
+        _sseConnected = false;
+        _stopPolling();
+        _log('SSE', '已断开');
+        emit('sse:disconnected', {});
+    }
+
+    /**
+     * 启动轮询降级
+     */
+    function _startPolling() {
+        if (_ssePollTimer) return;
+        _log('SSE', '启动轮询降级（间隔 ' + SSE_POLL_INTERVAL + 'ms）');
+
+        _poll();
+        _ssePollTimer = setInterval(_poll, SSE_POLL_INTERVAL);
+    }
+
+    /**
+     * 执行一次轮询
+     */
+    async function _poll() {
+        try {
+            var data = await get(_sseUrl, { timeout: SSE_POLL_INTERVAL - 500, noRetry: true });
+            if (data && typeof data === 'object') {
+                // 轮询返回的数据可能是事件数组
+                var events = Array.isArray(data) ? data : [data];
+                for (var i = 0; i < events.length; i++) {
+                    var evt = events[i];
+                    var eventType = evt.type || evt.event || 'message';
+                    emit('sse:' + eventType, { type: eventType, data: evt, polled: true });
+                    _handleSSECacheInvalidation(eventType, evt);
+                }
+            }
+        } catch (e) {
+            // 轮询失败静默处理
+        }
+    }
+
+    /**
+     * 停止轮询
+     */
+    function _stopPolling() {
+        if (_ssePollTimer) {
+            clearInterval(_ssePollTimer);
+            _ssePollTimer = null;
+        }
+    }
+
+    /**
+     * 获取 SSE 连接状态
+     * @returns {Object} { connected, reconnectCount, polling }
+     */
+    function getSSEStatus() {
+        return {
+            connected: _sseConnected,
+            reconnectCount: _sseReconnectCount,
+            polling: !!_ssePollTimer
+        };
+    }
+
+    // ================================================================
+    //  Cache 层
+    // ================================================================
+
+    /**
+     * 带缓存的 GET 请求
+     *
+     * 特性：
+     *   - TTL 60s 缓存
+     *   - LRU 100 条上限
+     *   - 请求去重（相同 cacheKey 的并发请求只执行一次）
+     *   - 并发控制（最多 6 个）
+     *
+     * @param {string} cacheKey - 缓存键
+     * @param {Function} fetcherFn - 数据获取函数，返回 Promise
+     * @param {Object} [options] - 选项
+     * @param {number} [options.ttl] - 自定义 TTL（毫秒）
+     * @param {boolean} [options.forceRefresh] - 强制刷新，跳过缓存
+     * @returns {Promise<*>} 数据
+     */
+    async function cachedGet(cacheKey, fetcherFn, options) {
+        options = options || {};
+        var ttl = options.ttl || CACHE_TTL;
+
+        // 1. 检查缓存（除非强制刷新）
+        if (!options.forceRefresh && _cache.has(cacheKey)) {
+            var cached = _cache.get(cacheKey);
+            if (Date.now() - cached.timestamp < ttl) {
+                _log('Cache', '命中: ' + cacheKey);
+                // 更新 LRU（删除后重新插入）
+                _cache.delete(cacheKey);
+                _cache.set(cacheKey, cached);
+                return cached.data;
+            } else {
+                // 过期，删除
+                _cache.delete(cacheKey);
+            }
+        }
+
+        // 2. 请求去重：相同 cacheKey 的并发请求只执行一次
+        if (_pending.has(cacheKey)) {
+            _log('Cache', '去重: ' + cacheKey + '（等待已有请求）');
+            return _pending.get(cacheKey);
+        }
+
+        // 3. 执行请求
+        var fetchPromise = (async function () {
+            try {
+                var data = await fetcherFn();
+
+                // 写入缓存
+                _evictIfNeeded();
+                _cache.set(cacheKey, {
+                    data: data,
+                    timestamp: Date.now()
+                });
+
+                _log('Cache', '写入: ' + cacheKey);
+                return data;
+            } catch (err) {
+                throw err;
+            } finally {
+                _pending.delete(cacheKey);
+            }
+        })();
+
+        _pending.set(cacheKey, fetchPromise);
+        return fetchPromise;
+    }
+
+    /**
+     * LRU 淘汰：当缓存满时删除最旧的条目
+     */
+    function _evictIfNeeded() {
+        if (_cache.size < CACHE_MAX_SIZE) return;
+        // Map 保持插入顺序，第一个就是最旧的
+        var firstKey = _cache.keys().next().value;
+        if (firstKey !== undefined) {
+            _cache.delete(firstKey);
+            _log('Cache', 'LRU 淘汰: ' + firstKey);
+        }
+    }
+
+    /**
+     * 失效缓存
+     * 支持精确匹配和前缀匹配
+     *
+     * @param {string} pattern - 缓存键或前缀
+     * @returns {number} 失效的条目数
+     */
+    function invalidate(pattern) {
+        var count = 0;
+        if (!pattern) {
+            count = _cache.size;
+            _cache.clear();
+            _log('Cache', '清空全部缓存（' + count + ' 条）');
+            return count;
+        }
+
+        // 前缀匹配
+        _cache.forEach(function (value, key) {
+            if (key.indexOf(pattern) === 0) {
+                _cache.delete(key);
+                count++;
+            }
+        });
+
+        if (count > 0) {
+            _log('Cache', '失效 "' + pattern + '"（' + count + ' 条）');
+        }
+        return count;
+    }
+
+    /**
+     * 清空全部缓存
+     */
+    function clearCache() {
+        var count = _cache.size;
+        _cache.clear();
+        _pending.clear();
+        _log('Cache', '清空全部缓存（' + count + ' 条）');
+        return count;
+    }
+
+    /**
+     * 获取缓存统计
+     * @returns {Object} { size, maxSize, pending }
+     */
+    function getCacheStats() {
+        return {
+            size: _cache.size,
+            maxSize: CACHE_MAX_SIZE,
+            pending: _pending.size
+        };
+    }
+
+    /**
+     * 订阅数据变化
+     * 当指定 key 相关的缓存被失效时触发回调
+     *
+     * @param {string} key - 数据源 key
+     * @param {Function} callback - 回调函数
+     * @returns {Function} 取消订阅函数
+     */
+    function subscribe(key, callback) {
+        var eventName = 'cache:invalidate:' + key;
+        on(eventName, callback);
+        return function () {
+            off(eventName, callback);
+        };
+    }
+
+    // 增强 invalidate 方法，在失效时触发订阅回调
+    var _originalInvalidate = invalidate;
+    invalidate = function (pattern) {
+        var count = _originalInvalidate(pattern);
+        if (count > 0) {
+            emit('cache:invalidate:' + pattern, { pattern: pattern, count: count });
+            emit('cache:invalidated', { pattern: pattern, count: count });
+        }
+        return count;
+    };
+
+    // ================================================================
+    //  API 端点（向后兼容，保留 api.js 的所有分组）
+    // ================================================================
+
+    var sessions = {
+        list: function (params) { return get('/api/sessions', { body: params }); },
+        get: function (id) { return get('/api/sessions/' + id); },
+        create: function (data) { return post('/api/sessions', data); },
+        update: function (id, data) { return put('/api/sessions/' + id, data); },
+        delete: function (id) { return del('/api/sessions/' + id); },
+        sendMessage: function (id, message) { return post('/api/sessions/' + id + '/messages', { message: message }); },
+        getMessages: function (id, params) { return get('/api/sessions/' + id + '/messages', { body: params }); }
+    };
+
+    var tools = {
+        list: function () { return get('/api/tools'); },
+        get: function (name) { return get('/api/tools/' + name); },
+        call: function (name, args) { return post('/api/tools/' + name + '/call', args); }
+    };
+
+    var skills = {
+        list: function () { return get('/api/skills'); },
+        get: function (name) { return get('/api/skills/' + name); },
+        install: function (name) { return post('/api/skills/' + name + '/install'); },
+        uninstall: function (name) { return post('/api/skills/' + name + '/uninstall'); }
+    };
+
+    var memory = {
+        list: function (params) { return get('/api/memory', { body: params }); },
+        get: function (id) { return get('/api/memory/' + id); },
+        create: function (data) { return post('/api/memory', data); },
+        update: function (id, data) { return put('/api/memory/' + id, data); },
+        delete: function (id) { return del('/api/memory/' + id); },
+        search: function (query, params) { return get('/api/memory/search', { body: Object.assign({ q: query }, params || {}) }); }
+    };
+
+    var cron = {
+        list: function () { return get('/api/cron'); },
+        get: function (id) { return get('/api/cron/' + id); },
+        create: function (data) { return post('/api/cron', data); },
+        update: function (id, data) { return put('/api/cron/' + id, data); },
+        delete: function (id) { return del('/api/cron/' + id); },
+        trigger: function (id) { return post('/api/cron/' + id + '/trigger'); },
+        pause: function (id) { return post('/api/cron/' + id + '/pause'); },
+        resume: function (id) { return post('/api/cron/' + id + '/resume'); }
+    };
+
+    var agents = {
+        list: function () { return get('/api/agents'); },
+        get: function (name) { return get('/api/agents/' + name); },
+        create: function (data) { return post('/api/agents', data); },
+        update: function (name, data) { return put('/api/agents/' + name, data); },
+        delete: function (name) { return del('/api/agents/' + name); },
+        terminate: function (name) { return post('/api/agents/' + name + '/terminate'); }
+    };
+
+    var mcp = {
+        list: function () { return get('/api/mcp'); },
+        get: function (name) { return get('/api/mcp/' + name); },
+        callTool: function (serverName, toolName, args) {
+            return post('/api/mcp/' + serverName + '/tools/' + toolName + '/call', args);
+        },
+        listTools: function (serverName) { return get('/api/mcp/' + serverName + '/tools'); }
+    };
+
+    var mcpServers = {
+        list: function () { return get('/api/mcp/servers'); },
+        get: function (name) { return get('/api/mcp/servers/' + name); },
+        create: function (data) { return post('/api/mcp/servers', data); },
+        update: function (name, data) { return put('/api/mcp/servers/' + name, data); },
+        delete: function (name) { return del('/api/mcp/servers/' + name); },
+        start: function (name) { return post('/api/mcp/servers/' + name + '/start'); },
+        stop: function (name) { return post('/api/mcp/servers/' + name + '/stop'); },
+        restart: function (name) { return post('/api/mcp/servers/' + name + '/restart'); },
+        health: function (name) { return get('/api/mcp/servers/' + name + '/health'); }
+    };
+
+    var config = {
+        get: function () { return get('/api/config'); },
+        update: function (data) { return put('/api/config', data); },
+        getBackup: function () { return get('/api/config/backup'); },
+        restoreBackup: function (data) { return post('/api/config/backup/restore', data); }
+    };
+
+    var system = {
+        info: function () { return get('/api/system/info'); },
+        health: function () { return get('/api/system/health'); },
+        logs: function (params) { return get('/api/system/logs', { body: params }); },
+        stats: function () { return get('/api/system/stats'); }
+    };
+
+    var ops = {
+        getMetrics: function () { return get('/api/ops/metrics'); },
+        getAlerts: function (params) { return get('/api/ops/alerts', { body: params }); },
+        getDashboard: function () { return get('/api/ops/dashboard'); }
+    };
+
+    var dashboard = {
+        getStats: function () { return get('/api/dashboard/stats'); },
+        getTrend: function (params) { return get('/api/dashboard/trend', { body: params }); },
+        getOverview: function () { return get('/api/dashboard/overview'); }
+    };
+
+    var reviews = {
+        list: function (params) { return get('/api/reviews', { body: params }); },
+        get: function (id) { return get('/api/reviews/' + id); },
+        approve: function (id) { return post('/api/reviews/' + id + '/approve'); },
+        reject: function (id, reason) { return post('/api/reviews/' + id + '/reject', { reason: reason }); },
+        batchApprove: function (ids) { return post('/api/reviews/batch-approve', { ids: ids }); },
+        batchReject: function (ids, reason) { return post('/api/reviews/batch-reject', { ids: ids, reason: reason }); },
+        stats: function () { return get('/api/reviews/stats'); }
+    };
+
+    // ================================================================
+    //  热更新检查
+    // ================================================================
+
+    /**
+     * 检查是否有新版本
+     * @returns {Promise<{hasUpdate: boolean, currentVersion: string, latestVersion: string}>}
+     */
+    async function checkForUpdate() {
+        try {
+            var data = await get('/api/system/version', { timeout: 5000, noRetry: true });
+            var latestVersion = data && (data.version || data);
+            if (!latestVersion) return { hasUpdate: false, currentVersion: _currentVersion, latestVersion: null };
+
+            _currentVersion = _currentVersion || latestVersion;
+            var hasUpdate = latestVersion !== _currentVersion;
+
+            if (hasUpdate) {
+                emit('update:available', { currentVersion: _currentVersion, latestVersion: latestVersion });
+            }
+
+            return {
+                hasUpdate: hasUpdate,
+                currentVersion: _currentVersion,
+                latestVersion: latestVersion
+            };
+        } catch (e) {
+            return { hasUpdate: false, currentVersion: _currentVersion, latestVersion: null, error: e.message };
+        }
+    }
+
+    /**
+     * 启动定时更新检查
+     * @param {number} [intervalMs=60000] - 检查间隔（毫秒）
+     */
+    function startUpdateCheck(intervalMs) {
+        stopUpdateCheck();
+        intervalMs = intervalMs || 60000;
+
+        // 立即检查一次
+        checkForUpdate();
+
+        // 定时检查
+        _updateCheckTimer = setInterval(checkForUpdate, intervalMs);
+        _log('Update', '已启动定时检查（间隔 ' + intervalMs + 'ms）');
+    }
+
+    /**
+     * 停止定时更新检查
+     */
+    function stopUpdateCheck() {
+        if (_updateCheckTimer) {
+            clearInterval(_updateCheckTimer);
+            _updateCheckTimer = null;
+        }
+    }
+
+    /**
+     * 获取当前应用版本
+     * @returns {Promise<string|null>}
+     */
+    async function getAppVersion() {
+        if (_currentVersion) return _currentVersion;
+        try {
+            var data = await get('/api/system/version', { timeout: 5000, noRetry: true });
+            _currentVersion = data && (data.version || data);
+            return _currentVersion;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // ================================================================
+    //  公共 API
+    // ================================================================
+
+    var publicAPI = {
+        // === HTTP 层 ===
+        request: request,
+        get: get,
+        post: post,
+        put: put,
+        del: del,
+
+        // === SSE 层 ===
+        connect: connect,
+        disconnect: disconnect,
+        getSSEStatus: getSSEStatus,
+
+        // === Cache 层 ===
+        cachedGet: cachedGet,
+        invalidate: invalidate,
+        clearCache: clearCache,
+        getCacheStats: getCacheStats,
+        subscribe: subscribe,
+
+        // === 事件总线 ===
+        on: on,
+        off: off,
+        emit: emit,
+
+        // === API 端点分组 ===
+        sessions: sessions,
+        tools: tools,
+        skills: skills,
+        memory: memory,
+        cron: cron,
+        agents: agents,
+        mcp: mcp,
+        mcpServers: mcpServers,
+        config: config,
+        system: system,
+        ops: ops,
+        dashboard: dashboard,
+        reviews: reviews,
+
+        // === 工具 ===
+        checkForUpdate: checkForUpdate,
+        startUpdateCheck: startUpdateCheck,
+        stopUpdateCheck: stopUpdateCheck,
+        getAppVersion: getAppVersion,
+
+        // === 常量 ===
+        BASE_URL: BASE_URL,
+        VERSION: '2.0.0',
+
+        // === 内部状态（只读） ===
+        _currentVersion: null  // 由 getAppVersion/checkForUpdate 内部更新
+    };
+
+    // 暴露 _currentVersion 的引用到 publicAPI（用于 APP_VERSION getter）
+    Object.defineProperty(publicAPI, '_currentVersion', {
+        get: function () { return _currentVersion; },
+        enumerable: true,
+        configurable: true
+    });
+
+    return publicAPI;
+})();
+
+// ================================================================
+//  全局暴露
+// ================================================================
+
+window.HermesClient = HermesClient;
+
+// 向后兼容：旧代码通过 window.API 调用
+window.API = HermesClient;
+
+// 向后兼容：旧代码通过 window.APIClient 调用 request/get/post/put/del
+window.APIClient = {
+    request: function () { return HermesClient.request.apply(HermesClient, arguments); },
+    get: function () { return HermesClient.get.apply(HermesClient, arguments); },
+    post: function () { return HermesClient.post.apply(HermesClient, arguments); },
+    put: function () { return HermesClient.put.apply(HermesClient, arguments); },
+    del: function () { return HermesClient.del.apply(HermesClient, arguments); }
+};
+
+// APP_VERSION 动态 getter（兼容旧代码 window.APP_VERSION）
+Object.defineProperty(window, 'APP_VERSION', {
+    get: function () {
+        return HermesClient._currentVersion || null;
+    },
+    configurable: true
+});

--- a/frontend/js/workspace/components/Dock.js
+++ b/frontend/js/workspace/components/Dock.js
@@ -1,0 +1,341 @@
+/**
+ * Dock.js - 底部 Dock 栏
+ * macOS 风格，点击放大对应功能卡片
+ * 使用 IIFE 包裹，暴露全局变量
+ */
+var Dock = (() => {
+    'use strict';
+
+    // ========== 默认 Dock 项 ==========
+    var DEFAULT_ITEMS = [
+        { id: 'marketplace', icon: '🛒', label: '功能商店', bg: 'linear-gradient(135deg, #007aff, #5856d6)' },
+        { id: 'agents',      icon: '🤖', label: 'AI 助手',  bg: 'linear-gradient(135deg, #34c759, #30d158)' },
+        { id: 'ops_center',  icon: '📊', label: '运维中心', bg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+        { id: 'config',      icon: '⚙️', label: '系统配置', bg: 'linear-gradient(135deg, #8e8e93, #636366)' }
+    ];
+
+    // ========== 状态 ==========
+    var _container = null;
+    var _items = []; // 当前 Dock 项列表（可动态增删）
+    var _stylesInjected = false;
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (_stylesInjected) return;
+        _stylesInjected = true;
+
+        var css = `
+            /* Dock 容器 */
+            .dock-wrapper {
+                position: fixed;
+                bottom: 12px;
+                left: 50%;
+                transform: translateX(-50%);
+                z-index: 7000;
+            }
+
+            .dock {
+                display: flex;
+                align-items: flex-end;
+                gap: 6px;
+                padding: 6px 10px;
+                border-radius: 22px;
+                background: rgba(255, 255, 255, 0.65);
+                backdrop-filter: blur(20px);
+                -webkit-backdrop-filter: blur(20px);
+                box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12),
+                            0 2px 8px rgba(0, 0, 0, 0.06);
+                border: 1px solid rgba(255, 255, 255, 0.3);
+            }
+
+            /* Dock 项 */
+            .dock-item {
+                position: relative;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                cursor: pointer;
+                -webkit-tap-highlight-color: transparent;
+            }
+
+            .dock-item-icon {
+                width: 48px;
+                height: 48px;
+                border-radius: 12px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 24px;
+                transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+                            box-shadow 0.3s ease;
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+                will-change: transform;
+            }
+
+            .dock-item:hover .dock-item-icon {
+                transform: scale(1.25) translateY(-8px);
+                box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+            }
+
+            .dock-item:active .dock-item-icon {
+                transform: scale(1.15) translateY(-4px);
+                transition-duration: 0.1s;
+            }
+
+            /* Dock 项 tooltip */
+            .dock-item-tooltip {
+                position: absolute;
+                bottom: calc(100% + 8px);
+                left: 50%;
+                transform: translateX(-50%) translateY(4px);
+                padding: 4px 10px;
+                border-radius: 6px;
+                background: rgba(0, 0, 0, 0.75);
+                color: #fff;
+                font-size: 12px;
+                font-weight: 500;
+                white-space: nowrap;
+                pointer-events: none;
+                opacity: 0;
+                transition: opacity 0.2s, transform 0.2s;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            }
+
+            .dock-item:hover .dock-item-tooltip {
+                opacity: 1;
+                transform: translateX(-50%) translateY(0);
+            }
+
+            /* Dock 分隔线 */
+            .dock-separator {
+                width: 1px;
+                height: 36px;
+                background: rgba(0, 0, 0, 0.12);
+                margin: 0 4px;
+                align-self: center;
+                flex-shrink: 0;
+            }
+
+            /* Dock 项角标（可选） */
+            .dock-item-badge {
+                position: absolute;
+                top: -4px;
+                right: -4px;
+                min-width: 18px;
+                height: 18px;
+                padding: 0 4px;
+                border-radius: 9px;
+                background: #ff3b30;
+                color: #fff;
+                font-size: 11px;
+                font-weight: 600;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                box-shadow: 0 2px 6px rgba(255, 59, 48, 0.4);
+                z-index: 1;
+            }
+
+            /* 深色模式 */
+            @media (prefers-color-scheme: dark) {
+                .dock {
+                    background: rgba(40, 40, 40, 0.7);
+                    border-color: rgba(255, 255, 255, 0.08);
+                    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3),
+                                0 2px 8px rgba(0, 0, 0, 0.15);
+                }
+
+                .dock-item-icon {
+                    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+                }
+
+                .dock-item:hover .dock-item-icon {
+                    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+                }
+
+                .dock-separator {
+                    background: rgba(255, 255, 255, 0.12);
+                }
+            }
+        `;
+
+        var style = document.createElement('style');
+        style.id = 'dockStyles';
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    // ========== 构建 Dock 项 HTML ==========
+    function _buildItemHTML(item) {
+        var badgeHTML = item.badge ?
+            `<span class="dock-item-badge">${item.badge > 99 ? '99+' : item.badge}</span>` : '';
+
+        return `
+            <div class="dock-item" data-dock-id="${item.id}" title="${item.label || ''}">
+                <span class="dock-item-tooltip">${item.label || ''}</span>
+                ${badgeHTML}
+                <div class="dock-item-icon" style="background: ${item.bg || 'linear-gradient(135deg, #667eea, #764ba2)'}">
+                    ${item.icon || '📦'}
+                </div>
+            </div>
+        `;
+    }
+
+    // ========== 渲染 Dock ==========
+    function render(container) {
+        if (!container) {
+            console.warn('[Dock] render() 缺少 container 参数');
+            return;
+        }
+
+        _injectStyles();
+        _container = container;
+
+        // 初始化项列表（深拷贝默认项）
+        _items = DEFAULT_ITEMS.map(item => Object.assign({}, item));
+
+        _renderDock();
+    }
+
+    // ========== 渲染 Dock 内容 ==========
+    function _renderDock() {
+        if (!_container) return;
+
+        // 构建 HTML：项之间插入分隔线
+        var html = '<div class="dock">';
+        for (var i = 0; i < _items.length; i++) {
+            html += _buildItemHTML(_items[i]);
+            // 在第 2 个和第 3 个项之间加分隔线
+            if (i === 1 && _items.length > 2) {
+                html += '<div class="dock-separator"></div>';
+            }
+        }
+        html += '</div>';
+
+        _container.innerHTML = `<div class="dock-wrapper">${html}</div>`;
+
+        // 绑定事件
+        _bindEvents();
+    }
+
+    // ========== 绑定事件 ==========
+    function _bindEvents() {
+        var dockItems = _container.querySelectorAll('.dock-item');
+        for (var i = 0; i < dockItems.length; i++) {
+            (function(el) {
+                el.addEventListener('click', function() {
+                    var itemId = el.getAttribute('data-dock-id');
+                    if (!itemId) return;
+
+                    // 查找对应的 item 数据
+                    var itemData = null;
+                    for (var j = 0; j < _items.length; j++) {
+                        if (_items[j].id === itemId) {
+                            itemData = _items[j];
+                            break;
+                        }
+                    }
+
+                    // 点击动画反馈
+                    _animateClick(el);
+
+                    // 打开 CardOverlay
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open(itemId, itemData);
+                    } else {
+                        console.warn('[Dock] CardOverlay 未加载，无法打开:', itemId);
+                    }
+                });
+            })(dockItems[i]);
+        }
+    }
+
+    // ========== 点击动画反馈 ==========
+    function _animateClick(el) {
+        var icon = el.querySelector('.dock-item-icon');
+        if (!icon) return;
+
+        // 添加点击波纹效果
+        icon.style.transform = 'scale(0.9)';
+        setTimeout(() => {
+            icon.style.transform = '';
+        }, 150);
+    }
+
+    // ========== 动态添加 Dock 项 ==========
+    function addItem(item) {
+        if (!item || !item.id) {
+            console.warn('[Dock] addItem() 缺少 id 参数');
+            return;
+        }
+
+        // 检查是否已存在
+        for (var i = 0; i < _items.length; i++) {
+            if (_items[i].id === item.id) {
+                console.warn('[Dock] 项已存在:', item.id);
+                return;
+            }
+        }
+
+        // 添加到列表
+        _items.push(Object.assign({}, item));
+
+        // 重新渲染
+        _renderDock();
+    }
+
+    // ========== 移除 Dock 项 ==========
+    function removeItem(id) {
+        if (!id) return;
+
+        var found = false;
+        for (var i = 0; i < _items.length; i++) {
+            if (_items[i].id === id) {
+                _items.splice(i, 1);
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            console.warn('[Dock] 项不存在:', id);
+            return;
+        }
+
+        // 重新渲染
+        _renderDock();
+    }
+
+    // ========== 更新 Dock 项角标 ==========
+    function updateBadge(id, count) {
+        for (var i = 0; i < _items.length; i++) {
+            if (_items[i].id === id) {
+                _items[i].badge = count;
+                break;
+            }
+        }
+
+        // 重新渲染
+        _renderDock();
+    }
+
+    // ========== 销毁 ==========
+    function destroy() {
+        if (_container) {
+            _container.innerHTML = '';
+        }
+        _container = null;
+        _items = [];
+    }
+
+    // ========== 公开 API ==========
+    return {
+        render: render,
+        addItem: addItem,
+        removeItem: removeItem,
+        updateBadge: updateBadge,
+        destroy: destroy
+    };
+})();
+
+window.Dock = Dock;

--- a/frontend/js/workspace/components/SpotlightSearch.js
+++ b/frontend/js/workspace/components/SpotlightSearch.js
@@ -1,0 +1,815 @@
+/**
+ * SpotlightSearch.js - 全局搜索弹窗
+ * Cmd+K 触发，搜索知识/会话/记忆/规则
+ * 使用 IIFE 包裹，暴露全局变量
+ */
+var SpotlightSearch = (() => {
+    'use strict';
+
+    // ========== 状态 ==========
+    var _isOpen = false;
+    var _overlay = null;
+    var _input = null;
+    var _resultsContainer = null;
+    var _searchTimer = null;
+    var _onKeyDown = null;
+    var _stylesInjected = false;
+    var _currentQuery = '';
+    var _isLoading = false;
+    var _activeIndex = -1; // 当前高亮的结果索引
+
+    // 搜索分类配置
+    var CATEGORIES = {
+        knowledge:  { label: '知识库',   icon: '📚', cardId: 'knowledge' },
+        sessions:   { label: '会话记录', icon: '💬', cardId: 'sessions' },
+        memory:     { label: '记忆',     icon: '🧠', cardId: 'memory' },
+        rules:      { label: '规则',     icon: '📋', cardId: 'rules' },
+        agents:     { label: 'AI 助手',  icon: '🤖', cardId: 'agents' },
+        config:     { label: '配置项',   icon: '⚙️', cardId: 'config' }
+    };
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (_stylesInjected) return;
+        _stylesInjected = true;
+
+        var css = `
+            /* 搜索遮罩层 */
+            .spotlight-overlay {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                z-index: 9500;
+                display: flex;
+                align-items: flex-start;
+                justify-content: center;
+                padding-top: 15vh;
+                background: rgba(0, 0, 0, 0.3);
+                backdrop-filter: blur(4px);
+                -webkit-backdrop-filter: blur(4px);
+                opacity: 0;
+                visibility: hidden;
+                transition: opacity 200ms ease, visibility 200ms ease;
+            }
+
+            .spotlight-overlay.active {
+                opacity: 1;
+                visibility: visible;
+            }
+
+            /* 搜索框容器 */
+            .spotlight-box {
+                width: 90%;
+                max-width: 600px;
+                border-radius: 16px;
+                background: rgba(255, 255, 255, 0.9);
+                backdrop-filter: blur(20px);
+                -webkit-backdrop-filter: blur(20px);
+                box-shadow: 0 24px 80px rgba(0, 0, 0, 0.25),
+                            0 8px 32px rgba(0, 0, 0, 0.1);
+                overflow: hidden;
+                transform: scale(0.95) translateY(-10px);
+                opacity: 0;
+                transition: transform 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                            opacity 200ms ease;
+                display: flex;
+                flex-direction: column;
+                max-height: 60vh;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            }
+
+            .spotlight-overlay.active .spotlight-box {
+                transform: scale(1) translateY(0);
+                opacity: 1;
+            }
+
+            /* 搜索输入区域 */
+            .spotlight-input-wrap {
+                display: flex;
+                align-items: center;
+                padding: 16px 20px;
+                border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+                gap: 12px;
+                flex-shrink: 0;
+            }
+
+            .spotlight-input-icon {
+                font-size: 20px;
+                flex-shrink: 0;
+                opacity: 0.5;
+            }
+
+            .spotlight-input {
+                flex: 1;
+                border: none;
+                outline: none;
+                background: transparent;
+                font-size: 18px;
+                color: #1a1a1a;
+                font-weight: 400;
+                line-height: 1.4;
+            }
+
+            .spotlight-input::placeholder {
+                color: #bbb;
+            }
+
+            .spotlight-input-hint {
+                font-size: 11px;
+                color: #999;
+                background: rgba(0, 0, 0, 0.05);
+                padding: 2px 6px;
+                border-radius: 4px;
+                flex-shrink: 0;
+                font-weight: 500;
+            }
+
+            /* 加载指示器 */
+            .spotlight-loading {
+                display: none;
+                align-items: center;
+                justify-content: center;
+                padding: 24px;
+                color: #999;
+                font-size: 14px;
+                gap: 8px;
+            }
+
+            .spotlight-loading.visible {
+                display: flex;
+            }
+
+            .spotlight-spinner {
+                width: 16px;
+                height: 16px;
+                border: 2px solid rgba(0, 0, 0, 0.1);
+                border-top-color: #007aff;
+                border-radius: 50%;
+                animation: spotlight-spin 0.6s linear infinite;
+            }
+
+            @keyframes spotlight-spin {
+                to { transform: rotate(360deg); }
+            }
+
+            /* 搜索结果区域 */
+            .spotlight-results {
+                flex: 1;
+                overflow-y: auto;
+                overflow-x: hidden;
+                padding: 8px 0;
+                -webkit-overflow-scrolling: touch;
+            }
+
+            .spotlight-results::-webkit-scrollbar {
+                width: 4px;
+            }
+
+            .spotlight-results::-webkit-scrollbar-thumb {
+                background: rgba(0, 0, 0, 0.12);
+                border-radius: 2px;
+            }
+
+            /* 分类标题 */
+            .spotlight-category {
+                padding: 8px 20px 4px;
+                font-size: 11px;
+                font-weight: 600;
+                color: #999;
+                text-transform: uppercase;
+                letter-spacing: 0.5px;
+            }
+
+            /* 结果项 */
+            .spotlight-result {
+                display: flex;
+                align-items: center;
+                padding: 10px 20px;
+                gap: 12px;
+                cursor: pointer;
+                transition: background 0.15s;
+            }
+
+            .spotlight-result:hover,
+            .spotlight-result.active {
+                background: rgba(0, 122, 255, 0.08);
+            }
+
+            .spotlight-result-icon {
+                width: 36px;
+                height: 36px;
+                border-radius: 8px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 18px;
+                flex-shrink: 0;
+                background: rgba(0, 0, 0, 0.04);
+            }
+
+            .spotlight-result-content {
+                flex: 1;
+                min-width: 0;
+            }
+
+            .spotlight-result-title {
+                font-size: 14px;
+                font-weight: 500;
+                color: #1a1a1a;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .spotlight-result-desc {
+                font-size: 12px;
+                color: #999;
+                margin-top: 2px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .spotlight-result-arrow {
+                color: #ccc;
+                font-size: 12px;
+                flex-shrink: 0;
+                opacity: 0;
+                transition: opacity 0.15s;
+            }
+
+            .spotlight-result:hover .spotlight-result-arrow,
+            .spotlight-result.active .spotlight-result-arrow {
+                opacity: 1;
+            }
+
+            /* 空状态 */
+            .spotlight-empty {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                padding: 32px 20px;
+                color: #bbb;
+                font-size: 14px;
+                gap: 8px;
+            }
+
+            .spotlight-empty-icon {
+                font-size: 32px;
+                opacity: 0.5;
+            }
+
+            /* 底部快捷键提示 */
+            .spotlight-footer {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 8px 20px;
+                border-top: 1px solid rgba(0, 0, 0, 0.04);
+                font-size: 11px;
+                color: #bbb;
+                flex-shrink: 0;
+            }
+
+            .spotlight-footer kbd {
+                display: inline-block;
+                padding: 1px 5px;
+                border-radius: 3px;
+                background: rgba(0, 0, 0, 0.06);
+                font-family: inherit;
+                font-size: 10px;
+                margin: 0 2px;
+            }
+
+            /* 深色模式 */
+            @media (prefers-color-scheme: dark) {
+                .spotlight-box {
+                    background: rgba(30, 30, 30, 0.92);
+                    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5),
+                                0 8px 32px rgba(0, 0, 0, 0.3);
+                }
+
+                .spotlight-input-wrap {
+                    border-bottom-color: rgba(255, 255, 255, 0.06);
+                }
+
+                .spotlight-input {
+                    color: #f0f0f0;
+                }
+
+                .spotlight-input::placeholder {
+                    color: #666;
+                }
+
+                .spotlight-input-hint {
+                    color: #777;
+                    background: rgba(255, 255, 255, 0.08);
+                }
+
+                .spotlight-result:hover,
+                .spotlight-result.active {
+                    background: rgba(0, 122, 255, 0.15);
+                }
+
+                .spotlight-result-title {
+                    color: #f0f0f0;
+                }
+
+                .spotlight-result-desc {
+                    color: #888;
+                }
+
+                .spotlight-result-icon {
+                    background: rgba(255, 255, 255, 0.06);
+                }
+
+                .spotlight-category {
+                    color: #777;
+                }
+
+                .spotlight-empty {
+                    color: #666;
+                }
+
+                .spotlight-footer {
+                    color: #666;
+                    border-top-color: rgba(255, 255, 255, 0.04);
+                }
+
+                .spotlight-footer kbd {
+                    background: rgba(255, 255, 255, 0.08);
+                }
+
+                .spotlight-spinner {
+                    border-color: rgba(255, 255, 255, 0.1);
+                    border-top-color: #0a84ff;
+                }
+            }
+        `;
+
+        var style = document.createElement('style');
+        style.id = 'spotlightSearchStyles';
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    // ========== 创建 DOM ==========
+    function _createDOM() {
+        if (_overlay) return;
+
+        _overlay = document.createElement('div');
+        _overlay.className = 'spotlight-overlay';
+        _overlay.innerHTML = `
+            <div class="spotlight-box">
+                <div class="spotlight-input-wrap">
+                    <span class="spotlight-input-icon">🔍</span>
+                    <input class="spotlight-input" type="text"
+                           placeholder="搜索知识、会话、记忆、规则..."
+                           autocomplete="off" spellcheck="false" />
+                    <span class="spotlight-input-hint">ESC 关闭</span>
+                </div>
+                <div class="spotlight-loading">
+                    <span class="spotlight-spinner"></span>
+                    <span>搜索中...</span>
+                </div>
+                <div class="spotlight-results"></div>
+                <div class="spotlight-footer">
+                    <span><kbd>↑</kbd><kbd>↓</kbd> 导航  <kbd>Enter</kbd> 打开</span>
+                    <span><kbd>ESC</kbd> 关闭</span>
+                </div>
+            </div>
+        `;
+
+        document.body.appendChild(_overlay);
+
+        // 缓存 DOM 引用
+        _input = _overlay.querySelector('.spotlight-input');
+        _resultsContainer = _overlay.querySelector('.spotlight-results');
+    }
+
+    // ========== 打开搜索弹窗 ==========
+    function open() {
+        if (_isOpen) return;
+
+        _injectStyles();
+        _createDOM();
+
+        _isOpen = true;
+        _currentQuery = '';
+        _activeIndex = -1;
+
+        // 清空输入和结果
+        if (_input) {
+            _input.value = '';
+        }
+        if (_resultsContainer) {
+            _resultsContainer.innerHTML = _getEmptyState();
+        }
+
+        // 绑定事件
+        _bindEvents();
+
+        // 显示遮罩 + 聚焦输入框
+        requestAnimationFrame(() => {
+            _overlay.classList.add('active');
+            if (_input) {
+                _input.focus();
+            }
+        });
+
+        // 锁定 body 滚动
+        document.body.style.overflow = 'hidden';
+    }
+
+    // ========== 关闭搜索弹窗 ==========
+    function close() {
+        if (!_isOpen || !_overlay) return;
+
+        // 清除搜索定时器
+        if (_searchTimer) {
+            clearTimeout(_searchTimer);
+            _searchTimer = null;
+        }
+
+        // 触发关闭动画
+        _overlay.classList.remove('active');
+
+        // 等待动画完成后清理
+        setTimeout(() => {
+            _cleanup();
+        }, 200);
+    }
+
+    // ========== 切换搜索弹窗 ==========
+    function toggle() {
+        if (_isOpen) {
+            close();
+        } else {
+            open();
+        }
+    }
+
+    // ========== 执行搜索 ==========
+    function _search(query) {
+        if (!query || !query.trim()) {
+            if (_resultsContainer) {
+                _resultsContainer.innerHTML = _getEmptyState();
+            }
+            return;
+        }
+
+        _currentQuery = query.trim();
+        _isLoading = true;
+        _activeIndex = -1;
+
+        // 显示加载状态
+        _setLoading(true);
+
+        // 尝试调用 API 搜索
+        if (typeof HermesClient !== 'undefined' && HermesClient.search) {
+            HermesClient.search(_currentQuery)
+                .then(results => {
+                    _isLoading = false;
+                    _setLoading(false);
+                    _renderResults(results || []);
+                })
+                .catch(err => {
+                    console.warn('[SpotlightSearch] 搜索出错:', err);
+                    _isLoading = false;
+                    _setLoading(false);
+                    _renderResults(_getFallbackResults(_currentQuery));
+                });
+        } else {
+            // 无 API 时使用模拟数据
+            setTimeout(() => {
+                _isLoading = false;
+                _setLoading(false);
+                _renderResults(_getFallbackResults(_currentQuery));
+            }, 300);
+        }
+    }
+
+    // ========== 设置加载状态 ==========
+    function _setLoading(loading) {
+        if (!_overlay) return;
+        var loadingEl = _overlay.querySelector('.spotlight-loading');
+        if (loadingEl) {
+            if (loading) {
+                loadingEl.classList.add('visible');
+            } else {
+                loadingEl.classList.remove('visible');
+            }
+        }
+    }
+
+    // ========== 渲染搜索结果 ==========
+    function _renderResults(results) {
+        if (!_resultsContainer) return;
+
+        if (!results || results.length === 0) {
+            _resultsContainer.innerHTML = `
+                <div class="spotlight-empty">
+                    <span class="spotlight-empty-icon">🔍</span>
+                    <span>未找到 "${_escapeHTML(_currentQuery)}" 的相关结果</span>
+                </div>
+            `;
+            return;
+        }
+
+        // 按分类分组
+        var grouped = {};
+        for (var i = 0; i < results.length; i++) {
+            var item = results[i];
+            var cat = item.category || 'other';
+            if (!grouped[cat]) {
+                grouped[cat] = [];
+            }
+            grouped[cat].push(item);
+        }
+
+        // 构建 HTML
+        var html = '';
+        var resultIndex = 0;
+
+        var catKeys = Object.keys(grouped);
+        for (var c = 0; c < catKeys.length; c++) {
+            var catKey = catKeys[c];
+            var catInfo = CATEGORIES[catKey] || { label: catKey, icon: '📁' };
+            var items = grouped[catKey];
+
+            html += `<div class="spotlight-category">${catInfo.icon} ${catInfo.label}</div>`;
+
+            for (var j = 0; j < items.length; j++) {
+                var item = items[j];
+                var desc = item.description || item.summary || item.content || '';
+                if (desc.length > 80) {
+                    desc = desc.substring(0, 80) + '...';
+                }
+
+                html += `
+                    <div class="spotlight-result" data-index="${resultIndex}"
+                         data-card-id="${item.cardId || catInfo.cardId || ''}"
+                         data-item-id="${item.id || ''}">
+                        <div class="spotlight-result-icon">${catInfo.icon}</div>
+                        <div class="spotlight-result-content">
+                            <div class="spotlight-result-title">${_escapeHTML(item.title || item.name || '未命名')}</div>
+                            <div class="spotlight-result-desc">${_escapeHTML(desc)}</div>
+                        </div>
+                        <span class="spotlight-result-arrow">→</span>
+                    </div>
+                `;
+                resultIndex++;
+            }
+        }
+
+        _resultsContainer.innerHTML = html;
+
+        // 绑定结果点击事件
+        _bindResultEvents();
+    }
+
+    // ========== 绑定结果点击事件 ==========
+    function _bindResultEvents() {
+        if (!_resultsContainer) return;
+
+        var results = _resultsContainer.querySelectorAll('.spotlight-result');
+        for (var i = 0; i < results.length; i++) {
+            (function(el) {
+                el.addEventListener('click', function() {
+                    _openResult(el);
+                });
+                el.addEventListener('mouseenter', function() {
+                    _setActiveIndex(parseInt(el.getAttribute('data-index'), 10));
+                });
+            })(results[i]);
+        }
+    }
+
+    // ========== 打开搜索结果 ==========
+    function _openResult(el) {
+        var cardId = el.getAttribute('data-card-id');
+        var itemId = el.getAttribute('data-item-id');
+
+        if (!cardId) return;
+
+        // 关闭搜索弹窗
+        close();
+
+        // 打开对应的 CardOverlay
+        setTimeout(() => {
+            if (typeof CardOverlay !== 'undefined') {
+                CardOverlay.open(cardId, { id: itemId, fromSearch: true, query: _currentQuery });
+            }
+        }, 250);
+    }
+
+    // ========== 设置高亮索引 ==========
+    function _setActiveIndex(index) {
+        _activeIndex = index;
+
+        if (!_resultsContainer) return;
+
+        var results = _resultsContainer.querySelectorAll('.spotlight-result');
+        for (var i = 0; i < results.length; i++) {
+            if (parseInt(results[i].getAttribute('data-index'), 10) === index) {
+                results[i].classList.add('active');
+                // 滚动到可见区域
+                results[i].scrollIntoView({ block: 'nearest' });
+            } else {
+                results[i].classList.remove('active');
+            }
+        }
+    }
+
+    // ========== 获取结果总数 ==========
+    function _getResultCount() {
+        if (!_resultsContainer) return 0;
+        return _resultsContainer.querySelectorAll('.spotlight-result').length;
+    }
+
+    // ========== 空状态 HTML ==========
+    function _getEmptyState() {
+        return `
+            <div class="spotlight-empty">
+                <span class="spotlight-empty-icon">💡</span>
+                <span>输入关键词开始搜索</span>
+            </div>
+        `;
+    }
+
+    // ========== 模拟搜索结果（无 API 时使用） ==========
+    function _getFallbackResults(query) {
+        var q = query.toLowerCase();
+        var results = [];
+
+        // 模拟知识库结果
+        results.push({
+            category: 'knowledge',
+            id: 'kb-001',
+            title: `关于 "${query}" 的知识条目`,
+            description: '这是一条模拟的知识库搜索结果，实际使用时请接入后端搜索 API。',
+            cardId: 'knowledge'
+        });
+
+        // 模拟会话结果
+        results.push({
+            category: 'sessions',
+            id: 'sess-001',
+            title: `包含 "${query}" 的历史会话`,
+            description: '这是一条模拟的会话搜索结果，实际使用时请接入后端搜索 API。',
+            cardId: 'sessions'
+        });
+
+        // 模拟记忆结果
+        results.push({
+            category: 'memory',
+            id: 'mem-001',
+            title: `与 "${query}" 相关的记忆`,
+            description: '这是一条模拟的记忆搜索结果，实际使用时请接入后端搜索 API。',
+            cardId: 'memory'
+        });
+
+        // 模拟规则结果
+        results.push({
+            category: 'rules',
+            id: 'rule-001',
+            title: `匹配 "${query}" 的规则`,
+            description: '这是一条模拟的规则搜索结果，实际使用时请接入后端搜索 API。',
+            cardId: 'rules'
+        });
+
+        return results;
+    }
+
+    // ========== HTML 转义 ==========
+    function _escapeHTML(str) {
+        if (!str) return '';
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    // ========== 绑定事件 ==========
+    function _bindEvents() {
+        // 输入框输入事件（防抖搜索）
+        if (_input) {
+            _input.addEventListener('input', function() {
+                var value = _input.value;
+                if (_searchTimer) {
+                    clearTimeout(_searchTimer);
+                }
+                _searchTimer = setTimeout(() => {
+                    _search(value);
+                }, 250);
+            });
+        }
+
+        // 全局键盘事件
+        _onKeyDown = function(e) {
+            // Esc 关闭
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                close();
+                return;
+            }
+
+            // 上下键导航
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                var count = _getResultCount();
+                if (count > 0) {
+                    _setActiveIndex(_activeIndex < count - 1 ? _activeIndex + 1 : 0);
+                }
+                return;
+            }
+
+            if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                var count2 = _getResultCount();
+                if (count2 > 0) {
+                    _setActiveIndex(_activeIndex > 0 ? _activeIndex - 1 : count2 - 1);
+                }
+                return;
+            }
+
+            // Enter 打开选中结果
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                if (_activeIndex >= 0 && _resultsContainer) {
+                    var activeEl = _resultsContainer.querySelector(`.spotlight-result[data-index="${_activeIndex}"]`);
+                    if (activeEl) {
+                        _openResult(activeEl);
+                    }
+                }
+                return;
+            }
+        };
+        document.addEventListener('keydown', _onKeyDown);
+
+        // 点击遮罩关闭
+        if (_overlay) {
+            _overlay.addEventListener('click', function(e) {
+                // 只在点击遮罩本身（非内容区）时关闭
+                if (e.target === _overlay) {
+                    close();
+                }
+            });
+        }
+    }
+
+    // ========== 清理资源 ==========
+    function _cleanup() {
+        // 移除键盘事件
+        if (_onKeyDown) {
+            document.removeEventListener('keydown', _onKeyDown);
+            _onKeyDown = null;
+        }
+
+        // 清除搜索定时器
+        if (_searchTimer) {
+            clearTimeout(_searchTimer);
+            _searchTimer = null;
+        }
+
+        // 重置状态
+        _isOpen = false;
+        _currentQuery = '';
+        _isLoading = false;
+        _activeIndex = -1;
+
+        // 移除 DOM
+        if (_overlay && _overlay.parentNode) {
+            _overlay.parentNode.removeChild(_overlay);
+        }
+        _overlay = null;
+        _input = null;
+        _resultsContainer = null;
+
+        // 恢复 body 滚动
+        document.body.style.overflow = '';
+    }
+
+    // ========== 公开 API ==========
+    return {
+        open: open,
+        close: close,
+        toggle: toggle
+    };
+})();
+
+// 全局 Cmd+K 快捷键（独立注册，确保始终可用）
+(function() {
+    document.addEventListener('keydown', function(e) {
+        // Cmd+K (Mac) 或 Ctrl+K (Windows/Linux)
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+            e.preventDefault();
+            if (typeof SpotlightSearch !== 'undefined') {
+                SpotlightSearch.toggle();
+            }
+        }
+    });
+})();
+
+window.SpotlightSearch = SpotlightSearch;

--- a/frontend/js/workspace/components/StatusBar.js
+++ b/frontend/js/workspace/components/StatusBar.js
@@ -1,0 +1,446 @@
+/**
+ * StatusBar.js - 顶部状态栏
+ * 显示时间、搜索、通知、设置、SSE 连接状态
+ * 使用 IIFE 包裹，暴露全局变量
+ */
+var StatusBar = (() => {
+    'use strict';
+
+    // ========== 状态 ==========
+    var _container = null;
+    var _clockTimer = null;
+    var _stylesInjected = false;
+
+    // DOM 引用
+    var _searchBtn = null;
+    var _notifBtn = null;
+    var _notifBadge = null;
+    var _sseDot = null;
+    var _themeBtn = null;
+    var _editBtn = null;
+    var _clockEl = null;
+    var _versionEl = null;
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (_stylesInjected) return;
+        _stylesInjected = true;
+
+        var css = `
+            /* 状态栏容器 */
+            .status-bar {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 36px;
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 0 16px;
+                background: rgba(255, 255, 255, 0.75);
+                backdrop-filter: blur(20px);
+                -webkit-backdrop-filter: blur(20px);
+                border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+                z-index: 8000;
+                user-select: none;
+                -webkit-user-select: none;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            }
+
+            /* 左侧区域 */
+            .status-bar-left {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .status-bar-logo {
+                font-size: 16px;
+                line-height: 1;
+            }
+
+            .status-bar-title {
+                font-size: 13px;
+                font-weight: 600;
+                color: #1a1a1a;
+                letter-spacing: -0.2px;
+            }
+
+            .status-bar-version {
+                font-size: 10px;
+                color: #999;
+                background: rgba(0, 0, 0, 0.05);
+                padding: 1px 6px;
+                border-radius: 4px;
+                font-weight: 500;
+            }
+
+            /* 右侧区域 */
+            .status-bar-right {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+            }
+
+            .status-bar-item {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 28px;
+                height: 28px;
+                border-radius: 6px;
+                cursor: pointer;
+                transition: background 0.2s;
+                position: relative;
+                font-size: 14px;
+                line-height: 1;
+            }
+
+            .status-bar-item:hover {
+                background: rgba(0, 0, 0, 0.06);
+            }
+
+            .status-bar-item:active {
+                background: rgba(0, 0, 0, 0.1);
+            }
+
+            /* 通知角标 */
+            .status-bar-badge {
+                position: absolute;
+                top: 2px;
+                right: 2px;
+                min-width: 14px;
+                height: 14px;
+                padding: 0 3px;
+                border-radius: 7px;
+                background: #ff3b30;
+                color: #fff;
+                font-size: 9px;
+                font-weight: 600;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                line-height: 1;
+                box-shadow: 0 1px 3px rgba(255, 59, 48, 0.4);
+            }
+
+            /* SSE 连接状态点 */
+            .status-bar-dot {
+                display: inline-block;
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                transition: background 0.3s, box-shadow 0.3s;
+            }
+
+            .status-bar-dot.connected {
+                background: #34c759;
+                box-shadow: 0 0 6px rgba(52, 199, 89, 0.5);
+            }
+
+            .status-bar-dot.reconnecting {
+                background: #ffcc00;
+                box-shadow: 0 0 6px rgba(255, 204, 0, 0.5);
+                animation: sse-pulse 1.5s ease-in-out infinite;
+            }
+
+            .status-bar-dot.disconnected {
+                background: #8e8e93;
+            }
+
+            @keyframes sse-pulse {
+                0%, 100% { opacity: 1; }
+                50% { opacity: 0.4; }
+            }
+
+            /* 时钟 */
+            .status-bar-clock {
+                font-size: 12px;
+                color: #666;
+                font-weight: 500;
+                font-variant-numeric: tabular-nums;
+                margin-left: 4px;
+                padding-left: 8px;
+                border-left: 1px solid rgba(0, 0, 0, 0.08);
+                line-height: 1;
+            }
+
+            /* 深色模式 */
+            @media (prefers-color-scheme: dark) {
+                .status-bar {
+                    background: rgba(30, 30, 30, 0.8);
+                    border-bottom-color: rgba(255, 255, 255, 0.06);
+                }
+
+                .status-bar-title {
+                    color: #f0f0f0;
+                }
+
+                .status-bar-version {
+                    color: #888;
+                    background: rgba(255, 255, 255, 0.08);
+                }
+
+                .status-bar-item:hover {
+                    background: rgba(255, 255, 255, 0.08);
+                }
+
+                .status-bar-item:active {
+                    background: rgba(255, 255, 255, 0.12);
+                }
+
+                .status-bar-clock {
+                    color: #aaa;
+                    border-left-color: rgba(255, 255, 255, 0.08);
+                }
+            }
+        `;
+
+        var style = document.createElement('style');
+        style.id = 'statusBarStyles';
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    // ========== 渲染状态栏 ==========
+    function render(container) {
+        if (!container) {
+            console.warn('[StatusBar] render() 缺少 container 参数');
+            return;
+        }
+
+        _injectStyles();
+        _container = container;
+
+        _container.innerHTML = `
+            <div class="status-bar">
+                <div class="status-bar-left">
+                    <span class="status-bar-logo">🏠</span>
+                    <span class="status-bar-title">Hermes</span>
+                    <span class="status-bar-version" id="sbVersion"></span>
+                </div>
+                <div class="status-bar-right">
+                    <span class="status-bar-item" id="sbSearch" title="搜索 (⌘K)">🔍</span>
+                    <span class="status-bar-item" id="sbNotif" title="通知">
+                        🔔
+                        <span class="status-bar-badge" id="sbNotifBadge" style="display:none">0</span>
+                    </span>
+                    <span class="status-bar-item" id="sbSSE" title="连接状态">
+                        <span class="status-bar-dot disconnected" id="sbSSEDot"></span>
+                    </span>
+                    <span class="status-bar-item" id="sbTheme" title="切换主题">🌙</span>
+                    <span class="status-bar-item" id="sbEdit" title="编辑模式">✏️</span>
+                    <span class="status-bar-clock" id="sbClock"></span>
+                </div>
+            </div>
+        `;
+
+        // 缓存 DOM 引用
+        _searchBtn = document.getElementById('sbSearch');
+        _notifBtn = document.getElementById('sbNotif');
+        _notifBadge = document.getElementById('sbNotifBadge');
+        _sseDot = document.getElementById('sbSSEDot');
+        _themeBtn = document.getElementById('sbTheme');
+        _editBtn = document.getElementById('sbEdit');
+        _clockEl = document.getElementById('sbClock');
+        _versionEl = document.getElementById('sbVersion');
+
+        // 启动时钟
+        _startClock();
+
+        // 绑定事件
+        _bindEvents();
+
+        // 更新版本号
+        _updateVersion();
+    }
+
+    // ========== 启动时钟 ==========
+    function _startClock() {
+        // 立即更新一次
+        _updateClock();
+
+        // 每分钟更新
+        _clockTimer = setInterval(_updateClock, 30000);
+    }
+
+    // ========== 更新时钟显示 ==========
+    function _updateClock() {
+        if (!_clockEl) return;
+
+        var now = new Date();
+        var hours = String(now.getHours()).padStart(2, '0');
+        var minutes = String(now.getMinutes()).padStart(2, '0');
+        _clockEl.textContent = `${hours}:${minutes}`;
+    }
+
+    // ========== 绑定事件 ==========
+    function _bindEvents() {
+        // 搜索按钮 → 打开 SpotlightSearch
+        if (_searchBtn) {
+            _searchBtn.addEventListener('click', () => {
+                if (typeof SpotlightSearch !== 'undefined') {
+                    SpotlightSearch.toggle();
+                }
+            });
+        }
+
+        // 通知按钮 → 打开通知中心
+        if (_notifBtn) {
+            _notifBtn.addEventListener('click', () => {
+                if (typeof CardOverlay !== 'undefined') {
+                    CardOverlay.open('notifications');
+                }
+            });
+        }
+
+        // SSE 状态点击 → 显示连接信息
+        if (_sseDot) {
+            _sseDot.parentElement.addEventListener('click', () => {
+                var status = _sseDot.classList.contains('connected') ? '已连接' :
+                             _sseDot.classList.contains('reconnecting') ? '重连中' : '离线';
+                // 可以用 toast 或其他方式显示
+                console.log('[StatusBar] SSE 连接状态:', status);
+            });
+        }
+
+        // 主题切换按钮
+        if (_themeBtn) {
+            _themeBtn.addEventListener('click', () => {
+                _toggleTheme();
+            });
+        }
+
+        // 编辑模式按钮
+        if (_editBtn) {
+            _editBtn.addEventListener('click', () => {
+                _toggleEditMode();
+            });
+        }
+    }
+
+    // ========== 切换主题 ==========
+    function _toggleTheme() {
+        // 检测当前主题
+        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+
+        // 切换
+        if (isDark) {
+            document.documentElement.setAttribute('data-theme', 'light');
+            if (_themeBtn) _themeBtn.textContent = '🌙';
+        } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            if (_themeBtn) _themeBtn.textContent = '☀️';
+        }
+
+        // 保存到 localStorage
+        try {
+            localStorage.setItem('hermes-theme', isDark ? 'light' : 'dark');
+        } catch (e) {
+            // 忽略存储错误
+        }
+    }
+
+    // ========== 切换编辑模式 ==========
+    function _toggleEditMode() {
+        var isEditing = document.body.classList.toggle('edit-mode');
+        if (_editBtn) {
+            _editBtn.style.opacity = isEditing ? '1' : '';
+            _editBtn.style.background = isEditing ? 'rgba(0, 122, 255, 0.15)' : '';
+        }
+        console.log('[StatusBar] 编辑模式:', isEditing ? '开启' : '关闭');
+    }
+
+    // ========== 更新版本号 ==========
+    function _updateVersion() {
+        if (!_versionEl) return;
+
+        // 尝试从 HermesClient 获取版本
+        if (typeof HermesClient !== 'undefined' && HermesClient.getAppVersion) {
+            try {
+                var version = HermesClient.getAppVersion();
+                if (version) {
+                    _versionEl.textContent = 'v' + version;
+                    return;
+                }
+            } catch (e) {
+                // 忽略错误
+            }
+        }
+
+        // 尝试从全局变量获取
+        if (typeof HERMES_VERSION !== 'undefined') {
+            _versionEl.textContent = 'v' + HERMES_VERSION;
+            return;
+        }
+
+        // 默认不显示版本号
+        _versionEl.style.display = 'none';
+    }
+
+    // ========== 更新 SSE 连接状态 ==========
+    function updateSSEStatus(connected) {
+        if (!_sseDot) return;
+
+        // 移除所有状态类
+        _sseDot.classList.remove('connected', 'reconnecting', 'disconnected');
+
+        if (connected === true) {
+            _sseDot.classList.add('connected');
+        } else if (connected === 'reconnecting') {
+            _sseDot.classList.add('reconnecting');
+        } else {
+            _sseDot.classList.add('disconnected');
+        }
+    }
+
+    // ========== 更新通知角标 ==========
+    function updateNotifBadge(count) {
+        if (!_notifBadge) return;
+
+        count = parseInt(count, 10) || 0;
+
+        if (count > 0) {
+            _notifBadge.style.display = 'flex';
+            _notifBadge.textContent = count > 99 ? '99+' : String(count);
+        } else {
+            _notifBadge.style.display = 'none';
+        }
+    }
+
+    // ========== 销毁 ==========
+    function destroy() {
+        // 停止时钟
+        if (_clockTimer) {
+            clearInterval(_clockTimer);
+            _clockTimer = null;
+        }
+
+        // 清空容器
+        if (_container) {
+            _container.innerHTML = '';
+        }
+
+        // 重置引用
+        _container = null;
+        _searchBtn = null;
+        _notifBtn = null;
+        _notifBadge = null;
+        _sseDot = null;
+        _themeBtn = null;
+        _editBtn = null;
+        _clockEl = null;
+        _versionEl = null;
+    }
+
+    // ========== 公开 API ==========
+    return {
+        render: render,
+        updateSSEStatus: updateSSEStatus,
+        updateNotifBadge: updateNotifBadge,
+        destroy: destroy
+    };
+})();
+
+window.StatusBar = StatusBar;

--- a/frontend/js/workspace/core/CardOverlay.js
+++ b/frontend/js/workspace/core/CardOverlay.js
@@ -402,7 +402,21 @@ var CardOverlay = (() => {
             'agent-card':        { title: 'AI助手',  icon: '🤖', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
             'agent-entry':       { title: 'AI助手',  icon: '🤖', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
             'ops-card':          { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
-            'ops-entry':         { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' }
+            'ops-entry':         { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            'memory-card':      { title: '记忆',     icon: '🧠', iconBg: 'linear-gradient(135deg, #ff2d55, #ff375f)' },
+            'memory-entry':     { title: '记忆',     icon: '🧠', iconBg: 'linear-gradient(135deg, #ff2d55, #ff375f)' },
+            'cron-card':        { title: '定时任务', icon: '⏰', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            'cron-entry':       { title: '定时任务', icon: '⏰', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            'rules-card':       { title: '规则引擎', icon: '📋', iconBg: 'linear-gradient(135deg, #007aff, #5ac8fa)' },
+            'rules-entry':      { title: '规则引擎', icon: '📋', iconBg: 'linear-gradient(135deg, #007aff, #5ac8fa)' },
+            'experience-card':  { title: '经验',     icon: '💡', iconBg: 'linear-gradient(135deg, #ffcc00, #ff9500)' },
+            'experience-entry': { title: '经验',     icon: '💡', iconBg: 'linear-gradient(135deg, #ffcc00, #ff9500)' },
+            'settings-card':    { title: '系统设置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' },
+            'settings-entry':   { title: '系统设置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' },
+            'logs-card':        { title: '系统日志', icon: '📝', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
+            'logs-entry':       { title: '系统日志', icon: '📝', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
+            'trash-card':       { title: '回收站',   icon: '🗑️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' },
+            'trash-entry':      { title: '回收站',   icon: '🗑️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' }
         };
 
         return metaMap[cardId] || { title: cardId, icon: '📦', iconBg: 'linear-gradient(135deg, #667eea, #764ba2)' };

--- a/frontend/js/workspace/core/CardOverlay.js
+++ b/frontend/js/workspace/core/CardOverlay.js
@@ -396,7 +396,13 @@ var CardOverlay = (() => {
             'knowledge-card':  { title: '知识库', icon: '📚', iconBg: 'linear-gradient(135deg, #af52de, #5856d6)' },
             'session-card':    { title: '会话',   icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' },
             'knowledge-entry': { title: '知识库', icon: '📚', iconBg: 'linear-gradient(135deg, #af52de, #5856d6)' },
-            'session-entry':   { title: '会话',   icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' }
+            'session-entry':   { title: '会话',   icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' },
+            'marketplace-card':  { title: '功能商店', icon: '🛒', iconBg: 'linear-gradient(135deg, #007aff, #5856d6)' },
+            'marketplace-entry': { title: '功能商店', icon: '🛒', iconBg: 'linear-gradient(135deg, #007aff, #5856d6)' },
+            'agent-card':        { title: 'AI助手',  icon: '🤖', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
+            'agent-entry':       { title: 'AI助手',  icon: '🤖', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
+            'ops-card':          { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            'ops-entry':         { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' }
         };
 
         return metaMap[cardId] || { title: cardId, icon: '📦', iconBg: 'linear-gradient(135deg, #667eea, #764ba2)' };

--- a/frontend/js/workspace/core/CardOverlay.js
+++ b/frontend/js/workspace/core/CardOverlay.js
@@ -392,7 +392,11 @@ var CardOverlay = (() => {
             rules:       { title: '规则引擎', icon: '📋', iconBg: 'linear-gradient(135deg, #007aff, #5ac8fa)' },
             sessions:    { title: '会话记录', icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' },
             notifications:{ title: '通知中心', icon: '🔔', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
-            settings:    { title: '系统设置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' }
+            settings:    { title: '系统设置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' },
+            'knowledge-card':  { title: '知识库', icon: '📚', iconBg: 'linear-gradient(135deg, #af52de, #5856d6)' },
+            'session-card':    { title: '会话',   icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' },
+            'knowledge-entry': { title: '知识库', icon: '📚', iconBg: 'linear-gradient(135deg, #af52de, #5856d6)' },
+            'session-entry':   { title: '会话',   icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' }
         };
 
         return metaMap[cardId] || { title: cardId, icon: '📦', iconBg: 'linear-gradient(135deg, #667eea, #764ba2)' };

--- a/frontend/js/workspace/core/CardOverlay.js
+++ b/frontend/js/workspace/core/CardOverlay.js
@@ -1,0 +1,540 @@
+/**
+ * CardOverlay.js - 卡片放大系统
+ * 点击卡片时放大为 xlarge overlay，替代原来的 PanelManager
+ * 使用 IIFE 包裹，暴露全局变量
+ */
+var CardOverlay = (() => {
+    'use strict';
+
+    // ========== 状态 ==========
+    var _isOpen = false;
+    var _currentCardId = null;
+    var _currentData = null;
+    var _navStack = [];       // 卡片内导航栈（列表→详情→...）
+    var _cleanupFns = [];     // 清理函数列表
+    var _animFrameId = null;  // 动画帧 ID
+
+    // DOM 引用（延迟获取）
+    var _overlay = null;
+    var _container = null;
+    var _body = null;
+    var _header = null;
+    var _backBtn = null;
+    var _closeBtn = null;
+    var _backdrop = null;
+
+    // 样式是否已注入
+    var _stylesInjected = false;
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (_stylesInjected) return;
+        _stylesInjected = true;
+
+        var css = `
+            /* 卡片放大遮罩层 */
+            .card-overlay {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                z-index: 9000;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                opacity: 0;
+                visibility: hidden;
+                transition: opacity 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                            visibility 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            }
+
+            /* 激活状态 */
+            .card-overlay.active {
+                opacity: 1;
+                visibility: visible;
+            }
+
+            /* 背景遮罩 */
+            .card-overlay-backdrop {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background: rgba(0, 0, 0, 0.4);
+                backdrop-filter: blur(8px);
+                -webkit-backdrop-filter: blur(8px);
+            }
+
+            /* 内容容器 */
+            .card-overlay-content {
+                position: relative;
+                width: 90%;
+                max-width: 900px;
+                max-height: 85vh;
+                display: flex;
+                flex-direction: column;
+                border-radius: 24px;
+                background: rgba(255, 255, 255, 0.85);
+                backdrop-filter: blur(20px);
+                -webkit-backdrop-filter: blur(20px);
+                box-shadow: 0 24px 80px rgba(0, 0, 0, 0.25),
+                            0 8px 32px rgba(0, 0, 0, 0.1);
+                transform: scale(0.9);
+                opacity: 0;
+                transition: transform 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                            opacity 300ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+                overflow: hidden;
+            }
+
+            .card-overlay.active .card-overlay-content {
+                transform: scale(1);
+                opacity: 1;
+            }
+
+            /* 头部 */
+            .card-overlay-header {
+                display: flex;
+                align-items: center;
+                padding: 16px 20px;
+                border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+                flex-shrink: 0;
+                gap: 12px;
+            }
+
+            .card-overlay-back {
+                display: none;
+                align-items: center;
+                justify-content: center;
+                width: 32px;
+                height: 32px;
+                border: none;
+                border-radius: 8px;
+                background: rgba(0, 0, 0, 0.05);
+                color: #333;
+                font-size: 16px;
+                cursor: pointer;
+                transition: background 0.2s;
+                flex-shrink: 0;
+            }
+
+            .card-overlay-back:hover {
+                background: rgba(0, 0, 0, 0.1);
+            }
+
+            .card-overlay-back.visible {
+                display: flex;
+            }
+
+            .card-overlay-title {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                flex: 1;
+                min-width: 0;
+                font-size: 16px;
+                font-weight: 600;
+                color: #1a1a1a;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .card-overlay-icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 32px;
+                height: 32px;
+                border-radius: 8px;
+                font-size: 16px;
+                flex-shrink: 0;
+            }
+
+            .card-overlay-close {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 32px;
+                height: 32px;
+                border: none;
+                border-radius: 8px;
+                background: rgba(0, 0, 0, 0.05);
+                color: #666;
+                font-size: 20px;
+                cursor: pointer;
+                transition: background 0.2s, color 0.2s;
+                flex-shrink: 0;
+                line-height: 1;
+            }
+
+            .card-overlay-close:hover {
+                background: rgba(255, 59, 48, 0.1);
+                color: #ff3b30;
+            }
+
+            /* 内容主体 */
+            .card-overlay-body {
+                flex: 1;
+                overflow-y: auto;
+                overflow-x: hidden;
+                padding: 20px;
+                -webkit-overflow-scrolling: touch;
+            }
+
+            /* 滚动条美化 */
+            .card-overlay-body::-webkit-scrollbar {
+                width: 6px;
+            }
+
+            .card-overlay-body::-webkit-scrollbar-track {
+                background: transparent;
+            }
+
+            .card-overlay-body::-webkit-scrollbar-thumb {
+                background: rgba(0, 0, 0, 0.15);
+                border-radius: 3px;
+            }
+
+            .card-overlay-body::-webkit-scrollbar-thumb:hover {
+                background: rgba(0, 0, 0, 0.25);
+            }
+
+            /* 深色模式 */
+            @media (prefers-color-scheme: dark) {
+                .card-overlay-content {
+                    background: rgba(30, 30, 30, 0.9);
+                    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5),
+                                0 8px 32px rgba(0, 0, 0, 0.3);
+                }
+
+                .card-overlay-header {
+                    border-bottom-color: rgba(255, 255, 255, 0.08);
+                }
+
+                .card-overlay-title {
+                    color: #f0f0f0;
+                }
+
+                .card-overlay-back,
+                .card-overlay-close {
+                    background: rgba(255, 255, 255, 0.08);
+                    color: #ccc;
+                }
+
+                .card-overlay-back:hover {
+                    background: rgba(255, 255, 255, 0.15);
+                }
+
+                .card-overlay-close:hover {
+                    background: rgba(255, 59, 48, 0.2);
+                    color: #ff6b6b;
+                }
+            }
+        `;
+
+        var style = document.createElement('style');
+        style.id = 'cardOverlayStyles';
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    // ========== 创建 DOM 结构 ==========
+    function _createDOM() {
+        // 如果已存在则复用
+        _overlay = document.getElementById('cardOverlay');
+        if (_overlay) return;
+
+        _overlay = document.createElement('div');
+        _overlay.id = 'cardOverlay';
+        _overlay.className = 'card-overlay';
+        _overlay.innerHTML = `
+            <div class="card-overlay-backdrop"></div>
+            <div class="card-overlay-content">
+                <div class="card-overlay-header">
+                    <button class="card-overlay-back" title="返回">&#8592; 返回</button>
+                    <div class="card-overlay-title">
+                        <span class="card-overlay-icon"></span>
+                        <span class="card-overlay-title-text"></span>
+                    </div>
+                    <button class="card-overlay-close" title="关闭">&times;</button>
+                </div>
+                <div class="card-overlay-body"></div>
+            </div>
+        `;
+
+        document.body.appendChild(_overlay);
+
+        // 缓存 DOM 引用
+        _backdrop = _overlay.querySelector('.card-overlay-backdrop');
+        _container = _overlay.querySelector('.card-overlay-content');
+        _header = _overlay.querySelector('.card-overlay-header');
+        _backBtn = _overlay.querySelector('.card-overlay-back');
+        _closeBtn = _overlay.querySelector('.card-overlay-close');
+        _body = _overlay.querySelector('.card-overlay-body');
+    }
+
+    // ========== 渲染头部 ==========
+    function _renderHeader(title, icon, iconBg, showBack) {
+        var iconEl = _overlay.querySelector('.card-overlay-icon');
+        var titleEl = _overlay.querySelector('.card-overlay-title-text');
+
+        // 设置图标
+        if (iconEl) {
+            iconEl.textContent = icon || '';
+            iconEl.style.background = iconBg || 'linear-gradient(135deg, #667eea, #764ba2)';
+        }
+
+        // 设置标题
+        if (titleEl) {
+            titleEl.textContent = title || '';
+        }
+
+        // 返回按钮显示/隐藏
+        if (_backBtn) {
+            if (showBack) {
+                _backBtn.classList.add('visible');
+            } else {
+                _backBtn.classList.remove('visible');
+            }
+        }
+    }
+
+    // ========== 渲染卡片内容 ==========
+    function _renderContent(cardId, size, data) {
+        // 清空内容区
+        _body.innerHTML = '';
+
+        // 尝试从 WidgetRegistry 获取渲染函数
+        var renderer = null;
+        if (typeof WidgetRegistry !== 'undefined' && WidgetRegistry.getRenderer) {
+            renderer = WidgetRegistry.getRenderer(cardId);
+        }
+
+        if (renderer && typeof renderer === 'function') {
+            // 使用注册的渲染函数
+            renderer(_body, { size: size || 'xlarge', data: data || {} });
+        } else {
+            // 无渲染函数时显示占位内容
+            _body.innerHTML = `
+                <div style="text-align:center; padding:40px; color:#999;">
+                    <div style="font-size:48px; margin-bottom:16px;">📦</div>
+                    <div style="font-size:16px;">卡片组件 "${cardId}" 暂无渲染器</div>
+                    <div style="font-size:13px; margin-top:8px; color:#bbb;">
+                        请在 WidgetRegistry 中注册对应的渲染函数
+                    </div>
+                </div>
+            `;
+        }
+    }
+
+    // ========== 打开卡片放大视图 ==========
+    function open(cardId, data) {
+        if (!cardId) {
+            console.warn('[CardOverlay] open() 缺少 cardId 参数');
+            return;
+        }
+
+        // 如果已经打开，先关闭再打开
+        if (_isOpen) {
+            _cleanup();
+        }
+
+        // 注入样式 & 创建 DOM
+        _injectStyles();
+        _createDOM();
+
+        // 更新状态
+        _isOpen = true;
+        _currentCardId = cardId;
+        _currentData = data || null;
+        _navStack = [];
+        _cleanupFns = [];
+
+        // 获取卡片元信息
+        var meta = _getCardMeta(cardId);
+
+        // 渲染头部
+        _renderHeader(meta.title, meta.icon, meta.iconBg, false);
+
+        // 渲染内容
+        _renderContent(cardId, 'xlarge', data);
+
+        // 绑定事件
+        _bindEvents();
+
+        // 触发打开动画
+        requestAnimationFrame(() => {
+            _overlay.classList.add('active');
+        });
+
+        // 锁定 body 滚动
+        document.body.style.overflow = 'hidden';
+    }
+
+    // ========== 获取卡片元信息 ==========
+    function _getCardMeta(cardId) {
+        // 尝试从 WidgetRegistry 获取
+        if (typeof WidgetRegistry !== 'undefined' && WidgetRegistry.getMeta) {
+            var meta = WidgetRegistry.getMeta(cardId);
+            if (meta) return meta;
+        }
+
+        // 默认元信息映射
+        var metaMap = {
+            marketplace: { title: '功能商店', icon: '🛒', iconBg: 'linear-gradient(135deg, #007aff, #5856d6)' },
+            agents:      { title: 'AI 助手', icon: '🤖', iconBg: 'linear-gradient(135deg, #34c759, #30d158)' },
+            ops_center:  { title: '运维中心', icon: '📊', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            config:      { title: '系统配置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' },
+            knowledge:   { title: '知识库',   icon: '📚', iconBg: 'linear-gradient(135deg, #af52de, #5856d6)' },
+            memory:      { title: '记忆管理', icon: '🧠', iconBg: 'linear-gradient(135deg, #ff2d55, #ff375f)' },
+            rules:       { title: '规则引擎', icon: '📋', iconBg: 'linear-gradient(135deg, #007aff, #5ac8fa)' },
+            sessions:    { title: '会话记录', icon: '💬', iconBg: 'linear-gradient(135deg, #34c759, #00c7be)' },
+            notifications:{ title: '通知中心', icon: '🔔', iconBg: 'linear-gradient(135deg, #ff9500, #ff6b00)' },
+            settings:    { title: '系统设置', icon: '⚙️', iconBg: 'linear-gradient(135deg, #8e8e93, #636366)' }
+        };
+
+        return metaMap[cardId] || { title: cardId, icon: '📦', iconBg: 'linear-gradient(135deg, #667eea, #764ba2)' };
+    }
+
+    // ========== 关闭放大视图 ==========
+    function close() {
+        if (!_isOpen || !_overlay) return;
+
+        // 触发关闭动画
+        _overlay.classList.remove('active');
+
+        // 等待动画完成后清理
+        setTimeout(() => {
+            _cleanup();
+        }, 300);
+    }
+
+    // ========== 卡片内导航：推入新视图 ==========
+    function pushView(renderFn) {
+        if (!_isOpen || typeof renderFn !== 'function') return;
+
+        // 保存当前 body 内容到栈中
+        _navStack.push(_body.innerHTML);
+
+        // 清空内容区
+        _body.innerHTML = '';
+
+        // 调用渲染函数
+        renderFn(_body);
+
+        // 显示返回按钮
+        if (_backBtn) {
+            _backBtn.classList.add('visible');
+        }
+    }
+
+    // ========== 卡片内导航：返回上一视图 ==========
+    function popView() {
+        if (!_isOpen || _navStack.length === 0) return;
+
+        // 恢复上一视图
+        var prevContent = _navStack.pop();
+        _body.innerHTML = prevContent;
+
+        // 如果栈为空，隐藏返回按钮
+        if (_navStack.length === 0 && _backBtn) {
+            _backBtn.classList.remove('visible');
+        }
+    }
+
+    // ========== 绑定事件 ==========
+    function _bindEvents() {
+        // 关闭按钮
+        if (_closeBtn) {
+            _closeBtn.addEventListener('click', close);
+        }
+
+        // 返回按钮
+        if (_backBtn) {
+            _backBtn.addEventListener('click', popView);
+        }
+
+        // 背景点击关闭
+        if (_backdrop) {
+            _backdrop.addEventListener('click', close);
+        }
+
+        // Esc 键关闭
+        _onKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                // 如果有导航栈，先 pop；否则关闭
+                if (_navStack.length > 0) {
+                    popView();
+                } else {
+                    close();
+                }
+            }
+        };
+        document.addEventListener('keydown', _onKeyDown);
+    }
+
+    // 键盘事件引用（用于清理）
+    var _onKeyDown = null;
+
+    // ========== 清理资源 ==========
+    function _cleanup() {
+        // 执行注册的清理函数
+        for (var i = 0; i < _cleanupFns.length; i++) {
+            try {
+                _cleanupFns[i]();
+            } catch (e) {
+                console.warn('[CardOverlay] 清理函数执行出错:', e);
+            }
+        }
+        _cleanupFns = [];
+
+        // 移除键盘事件
+        if (_onKeyDown) {
+            document.removeEventListener('keydown', _onKeyDown);
+            _onKeyDown = null;
+        }
+
+        // 重置状态
+        _isOpen = false;
+        _currentCardId = null;
+        _currentData = null;
+        _navStack = [];
+
+        // 移除 DOM
+        if (_overlay && _overlay.parentNode) {
+            _overlay.parentNode.removeChild(_overlay);
+        }
+        _overlay = null;
+        _container = null;
+        _body = null;
+        _header = null;
+        _backBtn = null;
+        _closeBtn = null;
+        _backdrop = null;
+
+        // 恢复 body 滚动
+        document.body.style.overflow = '';
+    }
+
+    // ========== 注册清理函数 ==========
+    function registerCleanup(fn) {
+        if (typeof fn === 'function') {
+            _cleanupFns.push(fn);
+        }
+    }
+
+    // ========== 公开 API ==========
+    return {
+        open: open,
+        close: close,
+        pushView: pushView,
+        popView: popView,
+        registerCleanup: registerCleanup,
+        isOpen: () => _isOpen,
+        getCurrentCardId: () => _currentCardId
+    };
+})();
+
+window.CardOverlay = CardOverlay;

--- a/frontend/js/workspace/core/ContextMenuManager.js
+++ b/frontend/js/workspace/core/ContextMenuManager.js
@@ -1,0 +1,1217 @@
+/**
+ * ContextMenuManager - 右键菜单管理器
+ * Hermes Workspace V2
+ * 负责卡片和桌面的右键上下文菜单
+ */
+var ContextMenuManager = (() => {
+
+    /* ============================
+     * 常量与状态
+     * ============================ */
+    var MENU_Z_INDEX = 10000;          // 菜单层级
+    var ANIM_DURATION = 150;           // 动画时长（毫秒）
+    var SUBMENU_DELAY = 180;           // 子菜单展开延迟（毫秒）
+    var MIN_WIDTH = 180;               // 菜单最小宽度
+    var ITEM_HEIGHT = 34;              // 菜单项预估高度（用于键盘导航计算）
+
+    var _container = null;             // 挂载容器
+    var _menuEl = null;                // 当前菜单 DOM
+    var _submenuEl = null;             // 当前子菜单 DOM
+    var _visible = false;              // 菜单是否可见
+    var _context = null;               // 当前菜单上下文数据
+    var _activeIndex = -1;             // 键盘导航当前选中索引
+    var _items = [];                   // 当前菜单项数据
+    var _submenuTimer = null;          // 子菜单延迟定时器
+    var _boundHandlers = {};           // 绑定的事件处理器（用于销毁时解绑）
+    var _copiedCardId = null;          // 被复制的卡片 ID（粘贴功能用）
+
+    /* ============================
+     * 样式注入
+     * ============================ */
+    function _injectStyles() {
+        if (document.getElementById('ctx-menu-styles')) {
+            return; // 已存在，不重复注入
+        }
+
+        var style = document.createElement('style');
+        style.id = 'ctx-menu-styles';
+        style.textContent = [
+            /* 菜单容器 */
+            '.ctx-menu {',
+            '  position: fixed;',
+            '  z-index: ' + MENU_Z_INDEX + ';',
+            '  min-width: ' + MIN_WIDTH + 'px;',
+            '  background: #1e1e2e;',
+            '  border: 1px solid rgba(255, 255, 255, 0.08);',
+            '  border-radius: 8px;',
+            '  padding: 4px 0;',
+            '  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.3);',
+            '  opacity: 0;',
+            '  transform: scale(0.95);',
+            '  transform-origin: top left;',
+            '  transition: opacity ' + ANIM_DURATION + 'ms ease, transform ' + ANIM_DURATION + 'ms ease;',
+            '  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;',
+            '  font-size: 13px;',
+            '  color: #cdd6f4;',
+            '  user-select: none;',
+            '}',
+
+            /* 菜单显示动画 */
+            '.ctx-menu--visible {',
+            '  opacity: 1;',
+            '  transform: scale(1);',
+            '}',
+
+            /* 菜单项 */
+            '.ctx-menu__item {',
+            '  display: flex;',
+            '  align-items: center;',
+            '  padding: 8px 12px;',
+            '  cursor: pointer;',
+            '  white-space: nowrap;',
+            '  position: relative;',
+            '  transition: background 80ms ease;',
+            '}',
+
+            '.ctx-menu__item:hover,',
+            '.ctx-menu__item--active {',
+            '  background: rgba(255, 255, 255, 0.08);',
+            '}',
+
+            /* 菜单项图标 */
+            '.ctx-menu__icon {',
+            '  width: 20px;',
+            '  text-align: center;',
+            '  margin-right: 8px;',
+            '  font-size: 14px;',
+            '  flex-shrink: 0;',
+            '}',
+
+            /* 菜单项标签 */
+            '.ctx-menu__label {',
+            '  flex: 1;',
+            '  overflow: hidden;',
+            '  text-overflow: ellipsis;',
+            '}',
+
+            /* 快捷键文本 */
+            '.ctx-menu__shortcut {',
+            '  margin-left: 24px;',
+            '  color: #6c7086;',
+            '  font-size: 12px;',
+            '  flex-shrink: 0;',
+            '}',
+
+            /* 子菜单箭头 */
+            '.ctx-menu__arrow {',
+            '  margin-left: 16px;',
+            '  color: #6c7086;',
+            '  font-size: 10px;',
+            '  flex-shrink: 0;',
+            '}',
+
+            /* 危险操作（红色） */
+            '.ctx-menu__item--danger {',
+            '  color: #f38ba8;',
+            '}',
+
+            '.ctx-menu__item--danger:hover,',
+            '.ctx-menu__item--danger.ctx-menu__item--active {',
+            '  background: rgba(243, 139, 168, 0.12);',
+            '}',
+
+            /* 禁用状态 */
+            '.ctx-menu__item--disabled {',
+            '  color: #585b70;',
+            '  cursor: default;',
+            '  pointer-events: none;',
+            '}',
+
+            /* 分割线 */
+            '.ctx-menu__divider {',
+            '  height: 1px;',
+            '  margin: 4px 8px;',
+            '  background: rgba(255, 255, 255, 0.06);',
+            '}',
+
+            /* 子菜单 */
+            '.ctx-menu__submenu {',
+            '  position: fixed;',
+            '  z-index: ' + (MENU_Z_INDEX + 1) + ';',
+            '  min-width: ' + MIN_WIDTH + 'px;',
+            '  background: #1e1e2e;',
+            '  border: 1px solid rgba(255, 255, 255, 0.08);',
+            '  border-radius: 8px;',
+            '  padding: 4px 0;',
+            '  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.3);',
+            '  opacity: 0;',
+            '  transform: scale(0.95);',
+            '  transform-origin: top left;',
+            '  transition: opacity ' + ANIM_DURATION + 'ms ease, transform ' + ANIM_DURATION + 'ms ease;',
+            '  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;',
+            '  font-size: 13px;',
+            '  color: #cdd6f4;',
+            '  user-select: none;',
+            '}',
+
+            '.ctx-menu__submenu--visible {',
+            '  opacity: 1;',
+            '  transform: scale(1);',
+            '}',
+
+            /* 子菜单组标题 */
+            '.ctx-menu__group-title {',
+            '  padding: 6px 12px 2px;',
+            '  font-size: 11px;',
+            '  color: #6c7086;',
+            '  text-transform: uppercase;',
+            '  letter-spacing: 0.5px;',
+            '  pointer-events: none;',
+            '}'
+        ].join('\n');
+
+        document.head.appendChild(style);
+    }
+
+    /* ============================
+     * 视口边界检测与位置修正
+     * ============================ */
+
+    /**
+     * 修正菜单位置，确保不超出视口
+     * @param {HTMLElement} el - 菜单 DOM 元素
+     * @param {number} x - 目标 X 坐标
+     * @param {number} y - 目标 Y 坐标
+     * @returns {{ x: number, y: number, flipX: boolean, flipY: boolean }}
+     */
+    function _adjustPosition(el, x, y) {
+        var rect = el.getBoundingClientRect();
+        var vw = window.innerWidth;
+        var vh = window.innerHeight;
+        var gap = 4; // 与视口边缘的最小间距
+        var flipX = false;
+        var flipY = false;
+
+        // 右侧溢出 → 向左翻转
+        if (x + rect.width + gap > vw) {
+            x = Math.max(gap, x - rect.width);
+            flipX = true;
+        }
+
+        // 底部溢出 → 向上翻转
+        if (y + rect.height + gap > vh) {
+            y = Math.max(gap, y - rect.height);
+            flipY = true;
+        }
+
+        // 确保不超出左/上边界
+        x = Math.max(gap, x);
+        y = Math.max(gap, y);
+
+        return { x: x, y: y, flipX: flipX, flipY: flipY };
+    }
+
+    /* ============================
+     * DOM 构建
+     * ============================ */
+
+    /**
+     * 创建菜单容器 DOM
+     * @param {string} className - CSS 类名
+     * @returns {HTMLElement}
+     */
+    function _createMenuContainer(className) {
+        var menu = document.createElement('div');
+        menu.className = className;
+        return menu;
+    }
+
+    /**
+     * 创建单个菜单项 DOM
+     * @param {Object} item - 菜单项配置
+     * @param {number} index - 在列表中的索引
+     * @returns {HTMLElement|null} 分割线返回 null
+     */
+    function _createMenuItem(item, index) {
+        // 分割线
+        if (item.divider) {
+            var divider = document.createElement('div');
+            divider.className = 'ctx-menu__divider';
+            divider.setAttribute('data-index', String(index));
+            return divider;
+        }
+
+        var el = document.createElement('div');
+        var classes = ['ctx-menu__item'];
+
+        if (item.danger) {
+            classes.push('ctx-menu__item--danger');
+        }
+        if (item.disabled) {
+            classes.push('ctx-menu__item--disabled');
+        }
+
+        el.className = classes.join(' ');
+        el.setAttribute('data-index', String(index));
+        el.setAttribute('role', 'menuitem');
+
+        // 图标
+        if (item.icon) {
+            var iconSpan = document.createElement('span');
+            iconSpan.className = 'ctx-menu__icon';
+            iconSpan.textContent = item.icon;
+            el.appendChild(iconSpan);
+        }
+
+        // 标签
+        var labelSpan = document.createElement('span');
+        labelSpan.className = 'ctx-menu__label';
+        labelSpan.textContent = item.label || '';
+        el.appendChild(labelSpan);
+
+        // 快捷键
+        if (item.shortcut) {
+            var shortcutSpan = document.createElement('span');
+            shortcutSpan.className = 'ctx-menu__shortcut';
+            shortcutSpan.textContent = item.shortcut;
+            el.appendChild(shortcutSpan);
+        }
+
+        // 子菜单箭头
+        if (item.submenu) {
+            var arrowSpan = document.createElement('span');
+            arrowSpan.className = 'ctx-menu__arrow';
+            arrowSpan.textContent = '\u25B6'; // ▶
+            el.appendChild(arrowSpan);
+        }
+
+        return el;
+    }
+
+    /**
+     * 渲染菜单项列表到容器
+     * @param {HTMLElement} container - 菜单容器
+     * @param {Array} items - 菜单项数据
+     */
+    function _renderItems(container, items) {
+        // 清空容器
+        container.innerHTML = '';
+
+        for (var i = 0; i < items.length; i++) {
+            var itemEl = _createMenuItem(items[i], i);
+            if (itemEl) {
+                container.appendChild(itemEl);
+            }
+        }
+    }
+
+    /* ============================
+     * 菜单项构建 - 卡片右键菜单
+     * ============================ */
+
+    /**
+     * 构建卡片右键菜单项
+     * @param {Object} ctx - 上下文 { cardId, cardEl, desktopId, state }
+     * @returns {Array}
+     */
+    function _buildCardMenuItems(ctx) {
+        var items = [];
+        var state = ctx.state || {};
+        var isPinned = !!state.pinned;
+        var isCollapsed = !!state.collapsed;
+
+        // 1. 展开
+        items.push({
+            icon: '\uD83D\uDD0D',  // 🔍
+            label: '\u5C55\u5F00',  // 展开
+            shortcut: 'Click',
+            action: function () {
+                if (typeof CardOverlay !== 'undefined' && CardOverlay.open) {
+                    CardOverlay.open(ctx.cardId);
+                }
+            }
+        });
+
+        // 2. 刷新
+        items.push({
+            icon: '\uD83D\uDD04',  // 🔄
+            label: '\u5237\u65B0',  // 刷新
+            shortcut: 'R',
+            action: function () {
+                Bus.emit('ws:card:refresh', {
+                    cardId: ctx.cardId,
+                    desktopId: ctx.desktopId
+                });
+            }
+        });
+
+        // 3. 分割线
+        items.push({ divider: true });
+
+        // 4. 置顶
+        items.push({
+            icon: '\uD83D\uDCCC',  // 📌
+            label: isPinned ? '\u53D6\u6D88\u7F6E\u9876' : '\u7F6E\u9876',  // 取消置顶 / 置顶
+            action: function () {
+                if (typeof ZIndexManager !== 'undefined' && ZIndexManager.bringToTop) {
+                    ZIndexManager.bringToTop(ctx.cardEl);
+                }
+                // 保存置顶状态
+                if (typeof StateManager !== 'undefined' && StateManager.updateCard) {
+                    StateManager.updateCard(ctx.cardId, { pinned: !isPinned });
+                }
+            }
+        });
+
+        // 5. 固定位置
+        items.push({
+            icon: '\uD83D\uDCCF',  // 📏
+            label: isPinned ? '\u53D6\u6D88\u56FA\u5B9A' : '\u56FA\u5B9A\u4F4D\u7F6E',  // 取消固定 / 固定位置
+            action: function () {
+                if (typeof StateManager !== 'undefined' && StateManager.updateCard) {
+                    StateManager.updateCard(ctx.cardId, { pinned: !isPinned });
+                }
+            }
+        });
+
+        // 6. 分割线
+        items.push({ divider: true });
+
+        // 7. 折叠
+        items.push({
+            icon: '\uD83D\uDCE6',  // 📦
+            label: isCollapsed ? '\u5C55\u5F00\u5361\u7247' : '\u6298\u53E0',  // 展开卡片 / 折叠
+            action: function () {
+                Bus.emit('ws:card:collapse', {
+                    cardId: ctx.cardId,
+                    desktopId: ctx.desktopId
+                });
+            }
+        });
+
+        // 8. 移动到...（子菜单，仅当有多个桌面时显示）
+        var desktops = _getDesktopList();
+        if (desktops.length > 1) {
+            var submenuItems = [];
+            for (var d = 0; d < desktops.length; d++) {
+                (function (desktop) {
+                    submenuItems.push({
+                        icon: desktop.icon || '\uD83D\uDDBE',  // 🖾
+                        label: desktop.name || ('\u684C\u9762 ' + (d + 1)),  // 桌面 N
+                        disabled: desktop.id === ctx.desktopId,
+                        action: function () {
+                            Bus.emit('ws:card:move', {
+                                cardId: ctx.cardId,
+                                fromDesktopId: ctx.desktopId,
+                                toDesktopId: desktop.id
+                            });
+                        }
+                    });
+                })(desktops[d]);
+            }
+
+            items.push({
+                icon: '\uD83D\uDCC2',  // 📂
+                label: '\u79FB\u52A8\u5230...',  // 移动到...
+                submenu: submenuItems
+            });
+        }
+
+        // 9. 分割线
+        items.push({ divider: true });
+
+        // 10. 删除
+        items.push({
+            icon: '\uD83D\uDDD1\uFE0F',  // 🗑️
+            label: '\u5220\u9664',  // 删除
+            shortcut: 'Del',
+            danger: true,
+            action: function () {
+                if (typeof CardManager !== 'undefined' && CardManager.deleteCard) {
+                    CardManager.deleteCard(ctx.desktopId, ctx.cardId);
+                }
+            }
+        });
+
+        return items;
+    }
+
+    /* ============================
+     * 菜单项构建 - 桌面背景右键菜单
+     * ============================ */
+
+    /**
+     * 构建桌面背景右键菜单项
+     * @param {Object} ctx - 上下文 { desktopId, event }
+     * @returns {Array}
+     */
+    function _buildDesktopMenuItems(ctx) {
+        var items = [];
+
+        // 1. 添加卡片
+        items.push({
+            icon: '\u2795',  // ➕
+            label: '\u6DFB\u52A0\u5361\u7247',  // 添加卡片
+            action: function () {
+                Bus.emit('ws:card:store:open', { desktopId: ctx.desktopId });
+            }
+        });
+
+        // 2. 粘贴卡片（仅当有已复制的卡片时可用）
+        items.push({
+            icon: '\uD83D\uDCCB',  // 📋
+            label: '\u7C98\u8D34\u5361\u7247',  // 粘贴卡片
+            disabled: !_copiedCardId,
+            action: function () {
+                if (_copiedCardId) {
+                    Bus.emit('ws:card:paste', {
+                        cardId: _copiedCardId,
+                        desktopId: ctx.desktopId
+                    });
+                }
+            }
+        });
+
+        // 3. 分割线
+        items.push({ divider: true });
+
+        // 4. 切换布局（子菜单）
+        items.push({
+            icon: '\uD83D\uDCD0',  // 📐
+            label: '\u5207\u6362\u5E03\u5C40',  // 切换布局
+            submenu: [
+                {
+                    icon: '\u2588',  // █
+                    label: '\u7F51\u683C',  // 网格
+                    action: function () {
+                        Bus.emit('ws:layout:change', { desktopId: ctx.desktopId, layout: 'grid' });
+                    }
+                },
+                {
+                    icon: '\u2630',  // ☰
+                    label: '\u5217\u8868',  // 列表
+                    action: function () {
+                        Bus.emit('ws:layout:change', { desktopId: ctx.desktopId, layout: 'list' });
+                    }
+                },
+                {
+                    icon: '\u2261',  // ≡
+                    label: '\u7011\u5E03\u6D41',  // 瀑布流
+                    action: function () {
+                        Bus.emit('ws:layout:change', { desktopId: ctx.desktopId, layout: 'masonry' });
+                    }
+                },
+                {
+                    icon: '\u25A1',  // □
+                    label: '\u753B\u5E03',  // 画布
+                    action: function () {
+                        Bus.emit('ws:layout:change', { desktopId: ctx.desktopId, layout: 'canvas' });
+                    }
+                }
+            ]
+        });
+
+        // 5. 重排所有卡片
+        items.push({
+            icon: '\uD83D\uDD00',  // 🔀
+            label: '\u91CD\u6392\u6240\u6709\u5361\u7247',  // 重排所有卡片
+            action: function () {
+                if (typeof LayoutEngine !== 'undefined' && LayoutEngine.clearPinned) {
+                    LayoutEngine.clearPinned();
+                }
+                Bus.emit('ws:layout:reflow', { desktopId: ctx.desktopId });
+            }
+        });
+
+        // 6. 分割线
+        items.push({ divider: true });
+
+        // 7. 桌面设置
+        items.push({
+            icon: '\u2699\uFE0F',  // ⚙️
+            label: '\u684C\u9762\u8BBE\u7F6E',  // 桌面设置
+            action: function () {
+                Bus.emit('ws:desktop:settings', { desktopId: ctx.desktopId });
+            }
+        });
+
+        return items;
+    }
+
+    /* ============================
+     * 辅助函数
+     * ============================ */
+
+    /**
+     * 获取桌面列表
+     * @returns {Array}
+     */
+    function _getDesktopList() {
+        if (typeof StateManager !== 'undefined' && StateManager.getDesktops) {
+            return StateManager.getDesktops() || [];
+        }
+        return [];
+    }
+
+    /**
+     * 获取卡片状态
+     * @param {string} cardId
+     * @returns {Object|null}
+     */
+    function _getCardState(cardId) {
+        if (typeof StateManager !== 'undefined' && StateManager.getCard) {
+            return StateManager.getCard(cardId);
+        }
+        return null;
+    }
+
+    /**
+     * 判断点击目标是否为卡片元素
+     * @param {HTMLElement} target
+     * @returns {Object|null} { cardId, cardEl, desktopId }
+     */
+    function _findCardFromTarget(target) {
+        var el = target;
+        var maxDepth = 10; // 最多向上查找 10 层
+
+        while (el && maxDepth > 0) {
+            if (el.getAttribute && el.getAttribute('data-card-id')) {
+                return {
+                    cardId: el.getAttribute('data-card-id'),
+                    cardEl: el,
+                    desktopId: el.getAttribute('data-desktop-id') || ''
+                };
+            }
+            el = el.parentElement;
+            maxDepth--;
+        }
+
+        return null;
+    }
+
+    /**
+     * 判断点击目标是否为桌面背景区域
+     * @param {HTMLElement} target
+     * @returns {boolean}
+     */
+    function _isDesktopBackground(target) {
+        // 桌面背景通常有 data-desktop-id 但不是卡片
+        var el = target;
+        var maxDepth = 10;
+
+        while (el && maxDepth > 0) {
+            if (el.getAttribute && el.getAttribute('data-desktop-id') && !el.getAttribute('data-card-id')) {
+                return true;
+            }
+            el = el.parentElement;
+            maxDepth--;
+        }
+
+        return false;
+    }
+
+    /**
+     * 获取可操作的菜单项（排除分割线和禁用项）
+     * @returns {Array}
+     */
+    function _getActionableItems() {
+        var result = [];
+        for (var i = 0; i < _items.length; i++) {
+            var item = _items[i];
+            if (!item.divider && !item.disabled) {
+                result.push({ index: i, item: item });
+            }
+        }
+        return result;
+    }
+
+    /* ============================
+     * 菜单显示与隐藏
+     * ============================ */
+
+    /**
+     * 显示菜单
+     * @param {number} x - 鼠标 X 坐标
+     * @param {number} y - 鼠标 Y 坐标
+     * @param {Array} items - 菜单项数据
+     * @param {Object} context - 上下文数据
+     */
+    function show(x, y, items, context) {
+        // 先隐藏已有菜单
+        hide();
+
+        _items = items || [];
+        _context = context || {};
+        _activeIndex = -1;
+
+        // 创建菜单 DOM
+        _menuEl = _createMenuContainer('ctx-menu');
+        _renderItems(_menuEl, _items);
+        document.body.appendChild(_menuEl);
+
+        // 先设为可见以测量尺寸，但透明
+        _menuEl.style.left = '-9999px';
+        _menuEl.style.top = '-9999px';
+        _menuEl.style.display = 'block';
+
+        // 计算修正后的位置
+        var pos = _adjustPosition(_menuEl, x, y);
+        _menuEl.style.left = pos.x + 'px';
+        _menuEl.style.top = pos.y + 'px';
+
+        // 设置 transform-origin 根据翻转方向调整
+        if (pos.flipX && pos.flipY) {
+            _menuEl.style.transformOrigin = 'bottom right';
+        } else if (pos.flipX) {
+            _menuEl.style.transformOrigin = 'top right';
+        } else if (pos.flipY) {
+            _menuEl.style.transformOrigin = 'bottom left';
+        }
+
+        // 触发动画
+        requestAnimationFrame(function () {
+            if (_menuEl) {
+                _menuEl.classList.add('ctx-menu--visible');
+            }
+        });
+
+        _visible = true;
+
+        // 绑定菜单项事件
+        _bindItemEvents(_menuEl, _items);
+    }
+
+    /**
+     * 隐藏菜单
+     */
+    function hide() {
+        // 隐藏子菜单
+        _hideSubmenu();
+
+        if (_menuEl) {
+            _menuEl.classList.remove('ctx-menu--visible');
+
+            // 等待动画结束后移除 DOM
+            var menuRef = _menuEl;
+            setTimeout(function () {
+                if (menuRef && menuRef.parentNode) {
+                    menuRef.parentNode.removeChild(menuRef);
+                }
+            }, ANIM_DURATION + 20);
+
+            _menuEl = null;
+        }
+
+        _visible = false;
+        _items = [];
+        _context = null;
+        _activeIndex = -1;
+    }
+
+    /**
+     * 菜单是否可见
+     * @returns {boolean}
+     */
+    function isVisible() {
+        return _visible;
+    }
+
+    /* ============================
+     * 子菜单管理
+     * ============================ */
+
+    /**
+     * 显示子菜单
+     * @param {HTMLElement} parentItemEl - 父菜单项 DOM
+     * @param {Array} submenuItems - 子菜单项数据
+     */
+    function _showSubmenu(parentItemEl, submenuItems) {
+        _hideSubmenu();
+
+        var parentRect = parentItemEl.getBoundingClientRect();
+
+        _submenuEl = _createMenuContainer('ctx-menu__submenu');
+        _renderItems(_submenuEl, submenuItems);
+        document.body.appendChild(_submenuEl);
+
+        // 先定位到屏幕外以测量
+        _submenuEl.style.left = '-9999px';
+        _submenuEl.style.top = '-9999px';
+        _submenuEl.style.display = 'block';
+
+        // 默认在父项右侧展开
+        var subX = parentRect.right;
+        var subY = parentRect.top;
+
+        // 如果右侧空间不足，尝试左侧
+        if (subX + _submenuEl.offsetWidth + 4 > window.innerWidth) {
+            subX = parentRect.left - _submenuEl.offsetWidth;
+        }
+
+        // 如果左侧也不够，则紧贴右边缘
+        if (subX < 4) {
+            subX = window.innerWidth - _submenuEl.offsetWidth - 4;
+        }
+
+        // 底部溢出修正
+        if (subY + _submenuEl.offsetHeight + 4 > window.innerHeight) {
+            subY = window.innerHeight - _submenuEl.offsetHeight - 4;
+        }
+
+        _submenuEl.style.left = subX + 'px';
+        _submenuEl.style.top = subY + 'px';
+
+        // 触发动画
+        requestAnimationFrame(function () {
+            if (_submenuEl) {
+                _submenuEl.classList.add('ctx-menu__submenu--visible');
+            }
+        });
+
+        // 绑定子菜单项事件
+        _bindItemEvents(_submenuEl, submenuItems);
+    }
+
+    /**
+     * 隐藏子菜单
+     */
+    function _hideSubmenu() {
+        if (_submenuTimer) {
+            clearTimeout(_submenuTimer);
+            _submenuTimer = null;
+        }
+
+        if (_submenuEl) {
+            _submenuEl.classList.remove('ctx-menu__submenu--visible');
+
+            var subRef = _submenuEl;
+            setTimeout(function () {
+                if (subRef && subRef.parentNode) {
+                    subRef.parentNode.removeChild(subRef);
+                }
+            }, ANIM_DURATION + 20);
+
+            _submenuEl = null;
+        }
+    }
+
+    /* ============================
+     * 事件绑定
+     * ============================ */
+
+    /**
+     * 绑定菜单项的点击和悬停事件
+     * @param {HTMLElement} container - 菜单容器
+     * @param {Array} items - 菜单项数据
+     */
+    function _bindItemEvents(container, items) {
+        var itemEls = container.querySelectorAll('.ctx-menu__item');
+
+        for (var i = 0; i < itemEls.length; i++) {
+            (function (el, idx) {
+                var item = items[idx];
+                if (!item || item.divider || item.disabled) {
+                    return;
+                }
+
+                // 点击执行动作
+                el.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    e.preventDefault();
+
+                    if (item.action) {
+                        item.action();
+                    }
+
+                    hide();
+                });
+
+                // 悬停高亮 + 子菜单展开
+                el.addEventListener('mouseenter', function () {
+                    _clearActiveItems(container);
+                    el.classList.add('ctx-menu__item--active');
+
+                    // 如果有子菜单，延迟展开
+                    if (item.submenu) {
+                        if (_submenuTimer) {
+                            clearTimeout(_submenuTimer);
+                        }
+                        _submenuTimer = setTimeout(function () {
+                            _showSubmenu(el, item.submenu);
+                        }, SUBMENU_DELAY);
+                    } else {
+                        // 没有子菜单则关闭已有子菜单
+                        _hideSubmenu();
+                    }
+                });
+
+                el.addEventListener('mouseleave', function () {
+                    el.classList.remove('ctx-menu__item--active');
+
+                    // 鼠标离开时取消子菜单展开
+                    if (item.submenu && _submenuTimer) {
+                        clearTimeout(_submenuTimer);
+                        _submenuTimer = null;
+                    }
+                });
+            })(itemEls[i], parseInt(itemEls[i].getAttribute('data-index'), 10));
+        }
+    }
+
+    /**
+     * 清除菜单容器中所有项的激活状态
+     * @param {HTMLElement} container
+     */
+    function _clearActiveItems(container) {
+        var activeEls = container.querySelectorAll('.ctx-menu__item--active');
+        for (var i = 0; i < activeEls.length; i++) {
+            activeEls[i].classList.remove('ctx-menu__item--active');
+        }
+    }
+
+    /**
+     * 绑定全局事件（点击外部关闭、Esc 关闭、滚动关闭）
+     */
+    function _bindGlobalEvents() {
+        // 点击外部关闭菜单
+        _boundHandlers.documentClick = function (e) {
+            if (!_visible) {
+                return;
+            }
+
+            // 检查点击是否在菜单内部
+            if (_menuEl && _menuEl.contains(e.target)) {
+                return;
+            }
+            if (_submenuEl && _submenuEl.contains(e.target)) {
+                return;
+            }
+
+            hide();
+        };
+        document.addEventListener('mousedown', _boundHandlers.documentClick, true);
+
+        // Esc 键关闭
+        _boundHandlers.keydown = function (e) {
+            if (!_visible) {
+                return;
+            }
+
+            switch (e.key) {
+                case 'Escape':
+                    e.preventDefault();
+                    if (_submenuEl) {
+                        _hideSubmenu();
+                    } else {
+                        hide();
+                    }
+                    break;
+
+                case 'ArrowDown':
+                    e.preventDefault();
+                    _navigateMenu(1);
+                    break;
+
+                case 'ArrowUp':
+                    e.preventDefault();
+                    _navigateMenu(-1);
+                    break;
+
+                case 'ArrowRight':
+                    e.preventDefault();
+                    _openActiveSubmenu();
+                    break;
+
+                case 'ArrowLeft':
+                    e.preventDefault();
+                    if (_submenuEl) {
+                        _hideSubmenu();
+                    }
+                    break;
+
+                case 'Enter':
+                    e.preventDefault();
+                    _activateCurrentItem();
+                    break;
+            }
+        };
+        document.addEventListener('keydown', _boundHandlers.keydown, true);
+
+        // 滚动关闭
+        _boundHandlers.scroll = function () {
+            if (_visible) {
+                hide();
+            }
+        };
+        window.addEventListener('scroll', _boundHandlers.scroll, true);
+        window.addEventListener('wheel', _boundHandlers.scroll, true);
+
+        // 新的 contextmenu 事件关闭旧菜单
+        _boundHandlers.contextmenu = function () {
+            if (_visible) {
+                hide();
+            }
+        };
+        document.addEventListener('contextmenu', _boundHandlers.contextmenu, true);
+    }
+
+    /**
+     * 解绑全局事件
+     */
+    function _unbindGlobalEvents() {
+        if (_boundHandlers.documentClick) {
+            document.removeEventListener('mousedown', _boundHandlers.documentClick, true);
+        }
+        if (_boundHandlers.keydown) {
+            document.removeEventListener('keydown', _boundHandlers.keydown, true);
+        }
+        if (_boundHandlers.scroll) {
+            window.removeEventListener('scroll', _boundHandlers.scroll, true);
+            window.removeEventListener('wheel', _boundHandlers.scroll, true);
+        }
+        if (_boundHandlers.contextmenu) {
+            document.removeEventListener('contextmenu', _boundHandlers.contextmenu, true);
+        }
+        _boundHandlers = {};
+    }
+
+    /* ============================
+     * 键盘导航
+     * ============================ */
+
+    /**
+     * 上下箭头导航菜单
+     * @param {number} direction - 1 向下, -1 向上
+     */
+    function _navigateMenu(direction) {
+        var actionable = _getActionableItems();
+        if (actionable.length === 0) {
+            return;
+        }
+
+        // 清除所有高亮
+        if (_menuEl) {
+            _clearActiveItems(_menuEl);
+        }
+
+        // 计算新索引
+        var currentPos = -1;
+        for (var i = 0; i < actionable.length; i++) {
+            if (actionable[i].index === _activeIndex) {
+                currentPos = i;
+                break;
+            }
+        }
+
+        var newPos = currentPos + direction;
+        if (newPos < 0) {
+            newPos = actionable.length - 1; // 循环到底部
+        } else if (newPos >= actionable.length) {
+            newPos = 0; // 循环到顶部
+        }
+
+        _activeIndex = actionable[newPos].index;
+
+        // 高亮当前项
+        if (_menuEl) {
+            var targetEl = _menuEl.querySelector('[data-index="' + _activeIndex + '"]');
+            if (targetEl) {
+                targetEl.classList.add('ctx-menu__item--active');
+
+                // 确保可见（如果菜单项超出视口则滚动）
+                targetEl.scrollIntoView({ block: 'nearest' });
+            }
+        }
+    }
+
+    /**
+     * 打开当前激活项的子菜单
+     */
+    function _openActiveSubmenu() {
+        if (!_menuEl || _activeIndex < 0) {
+            return;
+        }
+
+        var item = _items[_activeIndex];
+        if (!item || !item.submenu) {
+            return;
+        }
+
+        var targetEl = _menuEl.querySelector('[data-index="' + _activeIndex + '"]');
+        if (targetEl) {
+            _showSubmenu(targetEl, item.submenu);
+        }
+    }
+
+    /**
+     * 激活当前选中项（执行动作）
+     */
+    function _activateCurrentItem() {
+        if (!_menuEl || _activeIndex < 0) {
+            return;
+        }
+
+        var item = _items[_activeIndex];
+        if (!item || item.divider || item.disabled) {
+            return;
+        }
+
+        if (item.action) {
+            item.action();
+        }
+
+        hide();
+    }
+
+    /* ============================
+     * 容器事件处理
+     * ============================ */
+
+    /**
+     * 处理容器内的 contextmenu 事件
+     * @param {MouseEvent} e
+     */
+    function _handleContextMenu(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var target = e.target;
+        var mouseX = e.clientX;
+        var mouseY = e.clientY;
+
+        // 尝试识别为卡片
+        var cardInfo = _findCardFromTarget(target);
+        if (cardInfo) {
+            var cardState = _getCardState(cardInfo.cardId);
+            var cardItems = _buildCardMenuItems({
+                cardId: cardInfo.cardId,
+                cardEl: cardInfo.cardEl,
+                desktopId: cardInfo.desktopId,
+                state: cardState
+            });
+            show(mouseX, mouseY, cardItems, {
+                type: 'card',
+                cardId: cardInfo.cardId,
+                cardEl: cardInfo.cardEl,
+                desktopId: cardInfo.desktopId
+            });
+            return;
+        }
+
+        // 尝试识别为桌面背景
+        var desktopEl = target;
+        var maxDepth = 10;
+        var desktopId = '';
+
+        while (desktopEl && maxDepth > 0) {
+            if (desktopEl.getAttribute && desktopEl.getAttribute('data-desktop-id')) {
+                desktopId = desktopEl.getAttribute('data-desktop-id');
+                break;
+            }
+            desktopEl = desktopEl.parentElement;
+            maxDepth--;
+        }
+
+        if (desktopId) {
+            var desktopItems = _buildDesktopMenuItems({
+                desktopId: desktopId,
+                event: e
+            });
+            show(mouseX, mouseY, desktopItems, {
+                type: 'desktop',
+                desktopId: desktopId
+            });
+            return;
+        }
+    }
+
+    /* ============================
+     * 公共 API - 初始化与销毁
+     * ============================ */
+
+    /**
+     * 初始化上下文菜单管理器
+     * @param {HTMLElement} container - 工作区容器 DOM
+     */
+    function init(container) {
+        if (!container) {
+            console.warn('[ContextMenuManager] \u521D\u59CB\u5316\u5931\u8D25\uFF1A\u7F3A\u5C11\u5BB9\u5668\u5143\u7D20');
+            return;
+        }
+
+        _container = container;
+
+        // 注入样式
+        _injectStyles();
+
+        // 绑定容器右键事件
+        _boundHandlers.containerContextmenu = function (e) {
+            _handleContextMenu(e);
+        };
+        _container.addEventListener('contextmenu', _boundHandlers.containerContextmenu);
+
+        // 绑定全局事件（点击外部关闭、键盘导航等）
+        _bindGlobalEvents();
+
+        // 监听卡片复制事件
+        if (typeof Bus !== 'undefined') {
+            Bus.on('ws:card:copied', function (data) {
+                _copiedCardId = data.cardId || null;
+            });
+
+            Bus.on('ws:card:pasted', function () {
+                _copiedCardId = null;
+            });
+        }
+
+        console.log('[ContextMenuManager] \u521D\u59CB\u5316\u5B8C\u6210');
+    }
+
+    /**
+     * 销毁上下文菜单管理器，清理所有事件和 DOM
+     */
+    function destroy() {
+        // 隐藏菜单
+        hide();
+
+        // 解绑容器事件
+        if (_container && _boundHandlers.containerContextmenu) {
+            _container.removeEventListener('contextmenu', _boundHandlers.containerContextmenu);
+        }
+
+        // 解绑全局事件
+        _unbindGlobalEvents();
+
+        // 移除注入的样式
+        var styleEl = document.getElementById('ctx-menu-styles');
+        if (styleEl && styleEl.parentNode) {
+            styleEl.parentNode.removeChild(styleEl);
+        }
+
+        // 重置状态
+        _container = null;
+        _copiedCardId = null;
+        _items = [];
+        _context = null;
+
+        // 取消 Bus 监听
+        if (typeof Bus !== 'undefined') {
+            Bus.off('ws:card:copied');
+            Bus.off('ws:card:pasted');
+        }
+
+        console.log('[ContextMenuManager] \u5DF2\u9500\u6BC1');
+    }
+
+    /* ============================
+     * 导出公共接口
+     * ============================ */
+    return {
+        init: init,
+        destroy: destroy,
+        show: show,
+        hide: hide,
+        isVisible: isVisible
+    };
+
+})();

--- a/frontend/js/workspace/core/ResponsiveManager.js
+++ b/frontend/js/workspace/core/ResponsiveManager.js
@@ -1,0 +1,879 @@
+/**
+ * ResponsiveManager.js - 响应式布局管理器
+ * Hermes Workspace V2
+ * 负责移动端/平板适配，断点检测，布局自动切换
+ *
+ * 位置: frontend/js/workspace/core/ResponsiveManager.js
+ * 依赖: Bus, StateManager, LayoutEngine (全局变量)
+ */
+
+var ResponsiveManager = (() => {
+
+    'use strict';
+
+    /* ============================================================
+     * 常量定义
+     * ============================================================ */
+
+    /** 断点阈值配置 */
+    var BREAKPOINTS = {
+        mobile: 480,     // <= 480px: 单列布局，简化界面
+        tablet: 768,     // <= 768px: 两列布局，中等界面
+        desktop: 1024,   // <= 1024px: 三列布局
+        wide: Infinity   // > 1024px: 四列布局，完整界面
+    };
+
+    /** 防抖延迟时间（毫秒） */
+    var DEBOUNCE_DELAY = 200;
+
+    /** 注入样式表 ID */
+    var STYLE_ELEMENT_ID = 'responsive-styles';
+
+    /** 根元素 CSS 类名前缀 */
+    var CLASS_MOBILE = 'ws-mobile';
+    var CLASS_TABLET = 'ws-tablet';
+
+    /** 事件名称常量 */
+    var EVENT_CHANGE = 'ws:responsive:change';
+    var EVENT_MOBILE = 'ws:responsive:mobile';
+    var EVENT_DESKTOP = 'ws:responsive:desktop';
+    var EVENT_ORIENTATION = 'ws:responsive:orientation';
+
+    /** 布局模式映射 */
+    var LAYOUT_MAP = {
+        mobile: 'list',
+        tablet: 'grid-2col',
+        desktop: 'grid',
+        wide: 'grid'
+    };
+
+    /* ============================================================
+     * 内部状态
+     * ============================================================ */
+
+    /** 当前断点 */
+    var currentBreakpoint = null;
+
+    /** 当前容器宽度 */
+    var currentWidth = 0;
+
+    /** 当前方向: 'portrait' | 'landscape' */
+    var currentOrientation = 'portrait';
+
+    /** 防抖定时器 ID */
+    var resizeTimer = null;
+
+    /** 方向变化防抖定时器 */
+    var orientationTimer = null;
+
+    /** 样式元素引用 */
+    var styleElement = null;
+
+    /** 是否已初始化 */
+    var initialized = false;
+
+    /** 是否已销毁 */
+    var destroyed = false;
+
+    /** 绑定的事件处理函数引用（用于移除监听） */
+    var boundHandleResize = null;
+    var boundHandleOrientation = null;
+    var boundHandleVisibility = null;
+
+    /* ============================================================
+     * 工具函数
+     * ============================================================ */
+
+    /**
+     * 根据窗口宽度计算当前断点
+     * @param {number} width - 容器宽度（像素）
+     * @returns {string} 断点名称: 'mobile' | 'tablet' | 'desktop' | 'wide'
+     */
+    function calculateBreakpoint(width) {
+        if (width <= BREAKPOINTS.mobile) {
+            return 'mobile';
+        }
+        if (width <= BREAKPOINTS.tablet) {
+            return 'tablet';
+        }
+        if (width <= BREAKPOINTS.desktop) {
+            return 'desktop';
+        }
+        return 'wide';
+    }
+
+    /**
+     * 获取当前视口宽度
+     * @returns {number} 视口宽度（像素）
+     */
+    function getViewportWidth() {
+        if (typeof window === 'undefined') {
+            return BREAKPOINTS.desktop;
+        }
+        return window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0;
+    }
+
+    /**
+     * 获取当前屏幕方向
+     * @returns {string} 'portrait' 或 'landscape'
+     */
+    function detectOrientation() {
+        if (typeof screen === 'undefined') {
+            return 'portrait';
+        }
+        // 优先使用 screen.orientation API
+        if (screen.orientation && screen.orientation.type) {
+            if (screen.orientation.type.indexOf('portrait') !== -1) {
+                return 'portrait';
+            }
+            if (screen.orientation.type.indexOf('landscape') !== -1) {
+                return 'landscape';
+            }
+        }
+        // 回退到宽高比较
+        if (typeof window !== 'undefined') {
+            return (window.innerHeight > window.innerWidth) ? 'portrait' : 'landscape';
+        }
+        return 'portrait';
+    }
+
+    /**
+     * 检测是否为触摸设备
+     * @returns {boolean}
+     */
+    function isTouchDevice() {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        return ('ontouchstart' in window) ||
+               (navigator.maxTouchPoints > 0) ||
+               (navigator.msMaxTouchPoints > 0);
+    }
+
+    /**
+     * 防抖函数
+     * @param {Function} fn - 要防抖的函数
+     * @param {number} delay - 延迟毫秒数
+     * @returns {Function} 防抖后的函数
+     */
+    function debounce(fn, delay) {
+        var timerId = null;
+        return function () {
+            var context = this;
+            var args = arguments;
+            if (timerId) {
+                clearTimeout(timerId);
+            }
+            timerId = setTimeout(function () {
+                fn.apply(context, args);
+                timerId = null;
+            }, delay);
+        };
+    }
+
+    /* ============================================================
+     * CSS 类名管理
+     * ============================================================ */
+
+    /**
+     * 更新根元素上的响应式 CSS 类名
+     * @param {string} breakpoint - 当前断点
+     */
+    function updateRootClasses(breakpoint) {
+        var root = document.documentElement;
+        if (!root) {
+            return;
+        }
+
+        // 移除所有响应式类名
+        root.classList.remove(CLASS_MOBILE, CLASS_TABLET);
+
+        // 根据断点添加对应类名
+        if (breakpoint === 'mobile') {
+            root.classList.add(CLASS_MOBILE);
+        } else if (breakpoint === 'tablet') {
+            root.classList.add(CLASS_TABLET);
+        }
+    }
+
+    /**
+     * 移除根元素上的所有响应式 CSS 类名
+     */
+    function removeRootClasses() {
+        var root = document.documentElement;
+        if (!root) {
+            return;
+        }
+        root.classList.remove(CLASS_MOBILE, CLASS_TABLET);
+    }
+
+    /* ============================================================
+     * 样式注入
+     * ============================================================ */
+
+    /**
+     * 生成响应式 CSS 样式内容
+     * @returns {string} CSS 字符串
+     */
+    function generateStyles() {
+        var css = '';
+
+        css += '/* ========================================\n';
+        css += ' * Hermes Workspace V2 - 响应式样式\n';
+        css += ' * 由 ResponsiveManager 自动注入\n';
+        css += ' * ======================================== */\n\n';
+
+        /* --- 移动端样式：单列布局，简化界面 --- */
+        css += '/* 移动端：单列布局，简化界面 */\n';
+        css += '@media (max-width: 480px) {\n';
+        css += '    .rsp-dock-icons .ws-dock__item-label { display: none; }\n';
+        css += '    .rsp-dock-icons .ws-dock { padding: 4px 8px; gap: 4px; }\n';
+        css += '    .rsp-dock-icons .ws-dock__item { width: 44px; height: 44px; font-size: 20px; }\n';
+        css += '    .rsp-hide-mobile { display: none !important; }\n';
+        css += '    .rsp-full-mobile { width: 100% !important; max-width: 100% !important; }\n';
+        css += '    .ws-card-store { max-width: 100%; }\n';
+        css += '    .rsp-mobile-stack { flex-direction: column !important; }\n';
+        css += '    .rsp-mobile-compact { padding: 8px !important; margin: 4px !important; }\n';
+        css += '    .rsp-mobile-no-shadow { box-shadow: none !important; }\n';
+        css += '    .rsp-mobile-text-sm { font-size: 13px !important; }\n';
+        css += '    .rsp-mobile-overflow { overflow-x: auto; -webkit-overflow-scrolling: touch; }\n';
+        css += '}\n\n';
+
+        /* --- 平板样式：两列布局 --- */
+        css += '/* 平板：两列布局 */\n';
+        css += '@media (max-width: 768px) {\n';
+        css += '    .rsp-dock-icons .ws-dock { padding: 6px 12px; gap: 8px; }\n';
+        css += '    .rsp-dock-icons .ws-dock__item { width: 48px; height: 48px; }\n';
+        css += '    .rsp-hide-tablet { display: none !important; }\n';
+        css += '    .rsp-tablet-compact { padding: 12px !important; }\n';
+        css += '    .rsp-tablet-2col { column-count: 2; column-gap: 12px; }\n';
+        css += '}\n\n';
+
+        /* --- 触摸设备：始终显示操作按钮 --- */
+        css += '/* 触摸设备：始终显示操作按钮 */\n';
+        css += '@media (hover: none) and (pointer: coarse) {\n';
+        css += '    .ws-card__actions { opacity: 1 !important; }\n';
+        css += '    .ws-card__resize { width: 20px !important; height: 20px !important; }\n';
+        css += '    .rsp-touch-target { min-width: 44px !important; min-height: 44px !important; }\n';
+        css += '}\n\n';
+
+        /* --- 桌面端以下通用样式 --- */
+        css += '/* 桌面端以下通用样式 */\n';
+        css += '@media (max-width: 1024px) {\n';
+        css += '    .rsp-hide-below-desktop { display: none !important; }\n';
+        css += '    .rsp-desktop-only { display: none !important; }\n';
+        css += '}\n\n';
+
+        /* --- 移动端 Dock 图标模式过渡动画 --- */
+        css += '/* Dock 过渡动画 */\n';
+        css += '.rsp-dock-icons .ws-dock,\n';
+        css += '.rsp-dock-icons .ws-dock__item {\n';
+        css += '    transition: all 0.2s ease-in-out;\n';
+        css += '}\n\n';
+
+        /* --- 根元素类名驱动的样式 --- */
+        css += '/* 根元素类名驱动样式 */\n';
+        css += '.' + CLASS_MOBILE + ' .ws-statusbar__time { display: none; }\n';
+        css += '.' + CLASS_MOBILE + ' .ws-sidebar { width: 100% !important; max-width: 100% !important; }\n';
+        css += '.' + CLASS_MOBILE + ' .ws-workspace { padding: 4px !important; }\n';
+        css += '.' + CLASS_MOBILE + ' .ws-card { border-radius: 8px !important; }\n';
+        css += '.' + CLASS_TABLET + ' .ws-sidebar { width: 240px !important; }\n';
+        css += '.' + CLASS_TABLET + ' .ws-workspace { padding: 8px !important; }\n';
+
+        return css;
+    }
+
+    /**
+     * 注入响应式样式到文档
+     */
+    function injectStyles() {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        // 如果样式元素已存在，先移除
+        var existing = document.getElementById(STYLE_ELEMENT_ID);
+        if (existing) {
+            existing.parentNode.removeChild(existing);
+        }
+
+        // 创建新的样式元素
+        styleElement = document.createElement('style');
+        styleElement.id = STYLE_ELEMENT_ID;
+        styleElement.setAttribute('type', 'text/css');
+        styleElement.textContent = generateStyles();
+
+        // 插入到 head 末尾
+        var head = document.head || document.getElementsByTagName('head')[0];
+        if (head) {
+            head.appendChild(styleElement);
+        }
+    }
+
+    /**
+     * 移除注入的样式
+     */
+    function removeStyles() {
+        if (typeof document === 'undefined') {
+            return;
+        }
+        var el = document.getElementById(STYLE_ELEMENT_ID);
+        if (el) {
+            el.parentNode.removeChild(el);
+        }
+        styleElement = null;
+    }
+
+    /* ============================================================
+     * 移动端 UI 简化
+     * ============================================================ */
+
+    /**
+     * 应用移动端简化模式
+     * 隐藏状态栏时间，简化 Dock 为仅图标模式
+     */
+    function applyMobileSimplifications() {
+        // 给 Dock 添加图标模式类
+        var dock = document.querySelector('.ws-dock');
+        if (dock) {
+            dock.classList.add('rsp-dock-icons');
+        }
+
+        // 隐藏状态栏时间
+        var statusBarTime = document.querySelector('.ws-statusbar__time');
+        if (statusBarTime) {
+            statusBarTime.classList.add('rsp-hide-mobile');
+        }
+    }
+
+    /**
+     * 移除移动端简化模式
+     */
+    function removeMobileSimplifications() {
+        // 移除 Dock 图标模式类
+        var dock = document.querySelector('.ws-dock');
+        if (dock) {
+            dock.classList.remove('rsp-dock-icons');
+        }
+
+        // 恢复状态栏时间显示
+        var statusBarTime = document.querySelector('.ws-statusbar__time');
+        if (statusBarTime) {
+            statusBarTime.classList.remove('rsp-hide-mobile');
+        }
+    }
+
+    /* ============================================================
+     * 布局切换
+     * ============================================================ */
+
+    /**
+     * 通知 LayoutEngine 切换布局
+     * @param {string} breakpoint - 当前断点
+     */
+    function notifyLayoutEngine(breakpoint) {
+        if (typeof LayoutEngine === 'undefined' || !LayoutEngine) {
+            return;
+        }
+
+        var layout = LAYOUT_MAP[breakpoint];
+        if (!layout) {
+            return;
+        }
+
+        // 检查 LayoutEngine 是否有 setLayout 方法
+        if (typeof LayoutEngine.setLayout === 'function') {
+            try {
+                LayoutEngine.setLayout(layout);
+            } catch (e) {
+                // 静默处理布局切换错误
+                if (typeof console !== 'undefined' && console.warn) {
+                    console.warn('[ResponsiveManager] 布局切换失败:', e.message);
+                }
+            }
+        }
+    }
+
+    /**
+     * 同步状态到 StateManager
+     * @param {string} breakpoint - 当前断点
+     * @param {number} width - 当前宽度
+     */
+    function syncState(breakpoint, width) {
+        if (typeof StateManager === 'undefined' || !StateManager) {
+            return;
+        }
+
+        if (typeof StateManager.set === 'function') {
+            try {
+                StateManager.set('responsive.breakpoint', breakpoint);
+                StateManager.set('responsive.width', width);
+                StateManager.set('responsive.orientation', currentOrientation);
+                StateManager.set('responsive.isMobile', breakpoint === 'mobile');
+                StateManager.set('responsive.isTablet', breakpoint === 'tablet');
+                StateManager.set('responsive.isTouch', isTouchDevice());
+            } catch (e) {
+                if (typeof console !== 'undefined' && console.warn) {
+                    console.warn('[ResponsiveManager] 状态同步失败:', e.message);
+                }
+            }
+        }
+    }
+
+    /* ============================================================
+     * 事件发射
+     * ============================================================ */
+
+    /**
+     * 发射断点变更事件
+     * @param {string} from - 之前的断点
+     * @param {string} to - 新的断点
+     * @param {number} width - 当前宽度
+     */
+    function emitChange(from, to, width) {
+        if (typeof Bus === 'undefined' || !Bus) {
+            return;
+        }
+
+        var payload = {
+            from: from,
+            to: to,
+            breakpoint: to,
+            width: width,
+            orientation: currentOrientation,
+            timestamp: Date.now()
+        };
+
+        if (typeof Bus.emit === 'function') {
+            Bus.emit(EVENT_CHANGE, payload);
+        }
+
+        // 进入移动端时发射专用事件
+        if (to === 'mobile' && from !== 'mobile') {
+            if (typeof Bus.emit === 'function') {
+                Bus.emit(EVENT_MOBILE, payload);
+            }
+        }
+
+        // 进入桌面端时发射专用事件
+        if ((to === 'desktop' || to === 'wide') && from !== 'desktop' && from !== 'wide') {
+            if (typeof Bus.emit === 'function') {
+                Bus.emit(EVENT_DESKTOP, payload);
+            }
+        }
+    }
+
+    /**
+     * 发射方向变更事件
+     * @param {string} newOrientation - 新方向
+     */
+    function emitOrientationChange(newOrientation) {
+        if (typeof Bus === 'undefined' || !Bus) {
+            return;
+        }
+
+        var payload = {
+            from: currentOrientation,
+            to: newOrientation,
+            breakpoint: currentBreakpoint,
+            width: currentWidth,
+            timestamp: Date.now()
+        };
+
+        if (typeof Bus.emit === 'function') {
+            Bus.emit(EVENT_ORIENTATION, payload);
+        }
+    }
+
+    /* ============================================================
+     * 核心处理逻辑
+     * ============================================================ */
+
+    /**
+     * 处理视口尺寸变化
+     * 检测断点变更并执行相应操作
+     */
+    function handleResize() {
+        if (destroyed) {
+            return;
+        }
+
+        var width = getViewportWidth();
+        var newBreakpoint = calculateBreakpoint(width);
+        var previousBreakpoint = currentBreakpoint;
+
+        // 更新当前状态
+        currentWidth = width;
+
+        // 如果断点没有变化，只更新宽度
+        if (newBreakpoint === previousBreakpoint) {
+            return;
+        }
+
+        // 断点发生变化，执行切换逻辑
+        currentBreakpoint = newBreakpoint;
+
+        // 更新根元素 CSS 类名
+        updateRootClasses(newBreakpoint);
+
+        // 发射变更事件
+        emitChange(previousBreakpoint, newBreakpoint, width);
+
+        // 移动端简化处理
+        if (newBreakpoint === 'mobile') {
+            applyMobileSimplifications();
+        } else {
+            removeMobileSimplifications();
+        }
+
+        // 通知 LayoutEngine 切换布局
+        notifyLayoutEngine(newBreakpoint);
+
+        // 同步状态
+        syncState(newBreakpoint, width);
+
+        // 开发环境日志
+        if (typeof console !== 'undefined' && console.log) {
+            console.log(
+                '[ResponsiveManager] 断点变更: ' + previousBreakpoint + ' -> ' + newBreakpoint +
+                ' (' + width + 'px)'
+            );
+        }
+    }
+
+    /**
+     * 处理屏幕方向变化
+     */
+    function handleOrientationChange() {
+        if (destroyed) {
+            return;
+        }
+
+        var newOrientation = detectOrientation();
+
+        if (newOrientation === currentOrientation) {
+            return;
+        }
+
+        var previousOrientation = currentOrientation;
+        currentOrientation = newOrientation;
+
+        // 发射方向变更事件
+        emitOrientationChange(newOrientation);
+
+        // 方向变化后重新检测断点（宽度可能因虚拟键盘等原因变化）
+        setTimeout(function () {
+            handleResize();
+        }, 100);
+
+        // 开发环境日志
+        if (typeof console !== 'undefined' && console.log) {
+            console.log(
+                '[ResponsiveManager] 方向变更: ' + previousOrientation + ' -> ' + newOrientation
+            );
+        }
+    }
+
+    /**
+     * 处理页面可见性变化
+     * 页面从隐藏恢复时重新检测断点
+     */
+    function handleVisibilityChange() {
+        if (destroyed) {
+            return;
+        }
+
+        if (typeof document === 'undefined' || document.hidden) {
+            return;
+        }
+
+        // 页面恢复可见时，延迟检测（等待布局稳定）
+        setTimeout(function () {
+            handleResize();
+        }, 100);
+    }
+
+    /* ============================================================
+     * 事件绑定与解绑
+     * ============================================================ */
+
+    /**
+     * 绑定所有事件监听
+     */
+    function bindEvents() {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        // 创建绑定的处理函数引用
+        boundHandleResize = debounce(handleResize, DEBOUNCE_DELAY);
+        boundHandleOrientation = debounce(handleOrientationChange, 150);
+        boundHandleVisibility = handleVisibilityChange;
+
+        // 监听窗口大小变化
+        window.addEventListener('resize', boundHandleResize, false);
+
+        // 监听屏幕方向变化（多种方式兼容）
+        window.addEventListener('orientationchange', boundHandleOrientation, false);
+
+        // 使用 screen.orientation API（如果可用）
+        if (screen && screen.orientation) {
+            try {
+                screen.orientation.addEventListener('change', boundHandleOrientation, false);
+            } catch (e) {
+                // screen.orientation.addEventListener 可能不被所有浏览器支持
+            }
+        }
+
+        // 监听页面可见性变化
+        if (typeof document !== 'undefined' && document.addEventListener) {
+            document.addEventListener('visibilitychange', boundHandleVisibility, false);
+        }
+    }
+
+    /**
+     * 解绑所有事件监听
+     */
+    function unbindEvents() {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
+        // 移除窗口大小变化监听
+        if (boundHandleResize) {
+            window.removeEventListener('resize', boundHandleResize, false);
+            boundHandleResize = null;
+        }
+
+        // 移除方向变化监听
+        if (boundHandleOrientation) {
+            window.removeEventListener('orientationchange', boundHandleOrientation, false);
+            if (screen && screen.orientation) {
+                try {
+                    screen.orientation.removeEventListener('change', boundHandleOrientation, false);
+                } catch (e) {
+                    // 忽略移除失败
+                }
+            }
+            boundHandleOrientation = null;
+        }
+
+        // 移除可见性变化监听
+        if (boundHandleVisibility) {
+            if (typeof document !== 'undefined' && document.removeEventListener) {
+                document.removeEventListener('visibilitychange', boundHandleVisibility, false);
+            }
+            boundHandleVisibility = null;
+        }
+
+        // 清除所有定时器
+        if (resizeTimer) {
+            clearTimeout(resizeTimer);
+            resizeTimer = null;
+        }
+        if (orientationTimer) {
+            clearTimeout(orientationTimer);
+            orientationTimer = null;
+        }
+    }
+
+    /* ============================================================
+     * 公共 API
+     * ============================================================ */
+
+    /**
+     * 初始化响应式管理器
+     * 开始监听窗口大小变化，注入样式，执行初始检测
+     */
+    function init() {
+        if (initialized) {
+            if (typeof console !== 'undefined' && console.warn) {
+                console.warn('[ResponsiveManager] 已经初始化，请勿重复调用');
+            }
+            return;
+        }
+
+        if (destroyed) {
+            if (typeof console !== 'undefined' && console.warn) {
+                console.warn('[ResponsiveManager] 已被销毁，无法重新初始化');
+            }
+            return;
+        }
+
+        // 检测初始方向
+        currentOrientation = detectOrientation();
+
+        // 注入响应式样式
+        injectStyles();
+
+        // 绑定事件监听
+        bindEvents();
+
+        // 执行初始断点检测
+        currentWidth = getViewportWidth();
+        currentBreakpoint = calculateBreakpoint(currentWidth);
+
+        // 更新根元素类名
+        updateRootClasses(currentBreakpoint);
+
+        // 如果初始就是移动端，应用简化
+        if (currentBreakpoint === 'mobile') {
+            applyMobileSimplifications();
+        }
+
+        // 通知 LayoutEngine
+        notifyLayoutEngine(currentBreakpoint);
+
+        // 同步初始状态
+        syncState(currentBreakpoint, currentWidth);
+
+        initialized = true;
+
+        // 开发环境日志
+        if (typeof console !== 'undefined' && console.log) {
+            console.log(
+                '[ResponsiveManager] 初始化完成 - 断点: ' + currentBreakpoint +
+                ', 宽度: ' + currentWidth + 'px, 方向: ' + currentOrientation +
+                ', 触摸设备: ' + isTouchDevice()
+            );
+        }
+    }
+
+    /**
+     * 销毁响应式管理器
+     * 移除所有事件监听，清理样式和状态
+     */
+    function destroy() {
+        if (destroyed) {
+            return;
+        }
+
+        // 解绑事件
+        unbindEvents();
+
+        // 移除根元素类名
+        removeRootClasses();
+
+        // 移除移动端简化
+        removeMobileSimplifications();
+
+        // 移除注入的样式
+        removeStyles();
+
+        // 重置内部状态
+        currentBreakpoint = null;
+        currentWidth = 0;
+        currentOrientation = 'portrait';
+        initialized = false;
+        destroyed = true;
+
+        // 开发环境日志
+        if (typeof console !== 'undefined' && console.log) {
+            console.log('[ResponsiveManager] 已销毁');
+        }
+    }
+
+    /**
+     * 获取当前断点名称
+     * @returns {string} 'mobile' | 'tablet' | 'desktop' | 'wide'
+     */
+    function getBreakpoint() {
+        return currentBreakpoint;
+    }
+
+    /**
+     * 判断当前是否为移动端
+     * @returns {boolean}
+     */
+    function isMobile() {
+        return currentBreakpoint === 'mobile';
+    }
+
+    /**
+     * 判断当前是否为平板
+     * @returns {boolean}
+     */
+    function isTablet() {
+        return currentBreakpoint === 'tablet';
+    }
+
+    /**
+     * 获取当前容器宽度
+     * @returns {number} 宽度（像素）
+     */
+    function getContainerWidth() {
+        return currentWidth;
+    }
+
+    /**
+     * 获取推荐的布局模式
+     * mobile -> 'list'
+     * tablet -> 'grid-2col'
+     * desktop -> 'grid'
+     * wide -> 'grid'
+     * @returns {string} 布局模式名称
+     */
+    function getRecommendedLayout() {
+        if (!currentBreakpoint) {
+            return 'grid';
+        }
+        return LAYOUT_MAP[currentBreakpoint] || 'grid';
+    }
+
+    /**
+     * 强制重新检测断点
+     * 在 DOM 结构变化后可手动调用
+     */
+    function forceCheck() {
+        handleResize();
+    }
+
+    /**
+     * 获取所有断点配置
+     * @returns {Object} 断点配置对象
+     */
+    function getBreakpoints() {
+        // 返回副本，防止外部修改
+        return {
+            mobile: BREAKPOINTS.mobile,
+            tablet: BREAKPOINTS.tablet,
+            desktop: BREAKPOINTS.desktop,
+            wide: BREAKPOINTS.wide
+        };
+    }
+
+    /**
+     * 获取当前方向
+     * @returns {string} 'portrait' | 'landscape'
+     */
+    function getOrientation() {
+        return currentOrientation;
+    }
+
+    /**
+     * 判断是否为触摸设备
+     * @returns {boolean}
+     */
+    function checkTouch() {
+        return isTouchDevice();
+    }
+
+    /* ============================================================
+     * 导出公共接口
+     * ============================================================ */
+
+    return {
+        init: init,
+        destroy: destroy,
+        getBreakpoint: getBreakpoint,
+        isMobile: isMobile,
+        isTablet: isTablet,
+        getContainerWidth: getContainerWidth,
+        getRecommendedLayout: getRecommendedLayout,
+        forceCheck: forceCheck,
+        getBreakpoints: getBreakpoints,
+        getOrientation: getOrientation,
+        checkTouch: checkTouch
+    };
+
+})();

--- a/frontend/js/workspace/core/SkeletonLoader.js
+++ b/frontend/js/workspace/core/SkeletonLoader.js
@@ -1,0 +1,510 @@
+/**
+ * SkeletonLoader.js — 骨架屏加载组件
+ * 
+ * 为卡片提供骨架屏加载动画，替代简单的"加载中..."文本。
+ * 支持 IIFE 模块模式，使用 var 声明，自动注入样式。
+ * 
+ * @module SkeletonLoader
+ * @version 1.0.0
+ * @location frontend/js/workspace/core/SkeletonLoader.js
+ */
+var SkeletonLoader = (() => {
+
+    // ============================================================
+    // 样式注入
+    // ============================================================
+
+    /** 样式表 ID，防止重复注入 */
+    var STYLE_ID = 'skeleton-styles';
+
+    /** 是否已注入样式 */
+    var stylesInjected = false;
+
+    /**
+     * 生成骨架屏 CSS 样式
+     * @returns {string} 完整的 CSS 字符串
+     */
+    function buildStyles() {
+        return [
+            /* 基础骨架元素样式 */
+            '.skel {',
+            '    background: linear-gradient(90deg, var(--bg-secondary, #e8e8e8) 25%, var(--bg-tertiary, #f0f0f0) 50%, var(--bg-secondary, #e8e8e8) 75%);',
+            '    background-size: 200% 100%;',
+            '    animation: skel-shimmer 1.5s ease-in-out infinite;',
+            '    border-radius: var(--radius-xs, 4px);',
+            '    box-sizing: border-box;',
+            '}',
+
+            /* 闪烁动画 — 从左到右渐变扫过 */
+            '@keyframes skel-shimmer {',
+            '    0% { background-position: 200% 0; }',
+            '    100% { background-position: -200% 0; }',
+            '}',
+
+            /* 圆形占位 — 头像、图标 */
+            '.skel-circle {',
+            '    border-radius: 50%;',
+            '    flex-shrink: 0;',
+            '}',
+
+            /* 矩形占位 — 按钮、卡片背景 */
+            '.skel-rect {',
+            '    border-radius: var(--radius-xs, 4px);',
+            '}',
+
+            /* 文本行占位 */
+            '.skel-line {',
+            '    height: 12px;',
+            '    width: 100%;',
+            '    border-radius: var(--radius-xs, 4px);',
+            '}',
+
+            /* 短文本行 */
+            '.skel-line--short {',
+            '    width: 60px;',
+            '}',
+
+            /* 中等文本行 */
+            '.skel-line--medium {',
+            '    width: 120px;',
+            '}',
+
+            /* 长文本行 */
+            '.skel-line--long {',
+            '    width: 200px;',
+            '}',
+
+            /* 内容块占位 */
+            '.skel-block {',
+            '    height: 48px;',
+            '    width: 100%;',
+            '}',
+
+            /* 统计数字占位 */
+            '.skel-stat-number {',
+            '    height: 32px;',
+            '    width: 80px;',
+            '    margin-bottom: 8px;',
+            '}',
+
+            /* 统计标签占位 */
+            '.skel-stat-label {',
+            '    height: 10px;',
+            '    width: 60px;',
+            '}',
+
+            /* 骨架卡片容器 */
+            '.skel-card {',
+            '    padding: 16px;',
+            '    border-radius: var(--radius-sm, 8px);',
+            '    border: 1px solid var(--border-color, #e0e0e0);',
+            '    background: var(--bg-primary, #ffffff);',
+            '}',
+
+            /* 骨架行容器 */
+            '.skel-row {',
+            '    display: flex;',
+            '    align-items: center;',
+            '    gap: 12px;',
+            '    padding: 10px 0;',
+            '}',
+
+            /* 骨架统计网格 */
+            '.skel-stats-grid {',
+            '    display: grid;',
+            '    grid-template-columns: 1fr 1fr;',
+            '    gap: 12px;',
+            '}',
+
+            /* 骨架统计项 */
+            '.skel-stat-item {',
+            '    padding: 16px;',
+            '    border-radius: var(--radius-sm, 8px);',
+            '    border: 1px solid var(--border-color, #e0e0e0);',
+            '    background: var(--bg-primary, #ffffff);',
+            '}',
+
+            /* 骨架头部区域 */
+            '.skel-header {',
+            '    display: flex;',
+            '    align-items: center;',
+            '    gap: 12px;',
+            '    margin-bottom: 16px;',
+            '}',
+
+            /* 骨架头部文本区域 */
+            '.skel-header-text {',
+            '    flex: 1;',
+            '    display: flex;',
+            '    flex-direction: column;',
+            '    gap: 8px;',
+            '}',
+
+            /* 骨架主体区域 */
+            '.skel-body {',
+            '    display: flex;',
+            '    flex-direction: column;',
+            '    gap: 10px;',
+            '}',
+
+            /* 骨架按钮区域 */
+            '.skel-footer {',
+            '    margin-top: 16px;',
+            '    display: flex;',
+            '    justify-content: flex-end;',
+            '}'
+        ].join('\n');
+    }
+
+    /**
+     * 注入骨架屏样式到页面（仅注入一次）
+     */
+    function injectStyles() {
+        if (stylesInjected) return;
+        if (document.getElementById(STYLE_ID)) {
+            stylesInjected = true;
+            return;
+        }
+
+        var style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = buildStyles();
+        document.head.appendChild(style);
+        stylesInjected = true;
+    }
+
+    // ============================================================
+    // 工具函数
+    // ============================================================
+
+    /**
+     * 生成随机动画延迟（0-500ms），产生自然错落效果
+     * @returns {string} CSS animation-delay 值
+     */
+    function randomDelay() {
+        var ms = Math.floor(Math.random() * 500);
+        return ms + 'ms';
+    }
+
+    /**
+     * 创建骨架元素
+     * @param {string} className - CSS 类名
+     * @param {Object} [style] - 额外内联样式
+     * @returns {HTMLElement} 骨架 DOM 元素
+     */
+    function createSkel(className, style) {
+        var el = document.createElement('div');
+        el.className = 'skel ' + className;
+        el.style.animationDelay = randomDelay();
+        if (style) {
+            var keys = Object.keys(style);
+            for (var i = 0; i < keys.length; i++) {
+                el.style[keys[i]] = style[keys[i]];
+            }
+        }
+        return el;
+    }
+
+    /**
+     * 生成随机宽度百分比（用于文本行宽度变化）
+     * @param {number} min - 最小百分比
+     * @param {number} max - 最大百分比
+     * @returns {string} CSS width 值
+     */
+    function randomWidth(min, max) {
+        var pct = min + Math.floor(Math.random() * (max - min));
+        return pct + '%';
+    }
+
+    /**
+     * 获取合并后的选项（默认值 + 用户传入）
+     * @param {Object} defaults - 默认选项
+     * @param {Object} options - 用户选项
+     * @returns {Object} 合并后的选项
+     */
+    function mergeOptions(defaults, options) {
+        var merged = {};
+        var keys = Object.keys(defaults);
+        for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            merged[key] = (options && options[key] !== undefined) ? options[key] : defaults[key];
+        }
+        return merged;
+    }
+
+    /**
+     * 标记容器为骨架状态
+     * @param {HTMLElement} container - 目标容器
+     */
+    function markContainer(container) {
+        container.setAttribute('data-skeleton', 'true');
+    }
+
+    // ============================================================
+    // 渲染方法
+    // ============================================================
+
+    /**
+     * 渲染骨架卡片
+     * 模拟卡片布局：头部（头像+标题）+ 正文（多行文本）+ 底部按钮
+     * 
+     * @param {HTMLElement} container - 目标容器
+     * @param {Object} [options] - 配置选项
+     * @param {number} [options.lines=3] - 正文文本行数
+     * @param {boolean} [options.hasAvatar=false] - 是否显示头像占位
+     * @param {boolean} [options.hasButton=false] - 是否显示按钮占位
+     */
+    function renderCard(container, options) {
+        if (!container) return;
+        injectStyles();
+
+        var opts = mergeOptions({
+            lines: 3,
+            hasAvatar: false,
+            hasButton: false
+        }, options);
+
+        // 创建卡片容器
+        var card = document.createElement('div');
+        card.className = 'skel-card';
+
+        // 头部区域
+        var header = document.createElement('div');
+        header.className = 'skel-header';
+
+        // 头像占位（可选）
+        if (opts.hasAvatar) {
+            var avatar = createSkel('skel-circle', {
+                width: '40px',
+                height: '40px'
+            });
+            header.appendChild(avatar);
+        }
+
+        // 标题和副标题
+        var headerText = document.createElement('div');
+        headerText.className = 'skel-header-text';
+
+        var titleLine = createSkel('skel-line', { width: '70%' });
+        var subtitleLine = createSkel('skel-line', { width: '45%' });
+        subtitleLine.style.height = '10px';
+        headerText.appendChild(titleLine);
+        headerText.appendChild(subtitleLine);
+
+        header.appendChild(headerText);
+        card.appendChild(header);
+
+        // 正文区域 — N 行文本，宽度递减
+        var body = document.createElement('div');
+        body.className = 'skel-body';
+
+        // 预定义宽度比例，模拟真实文本分布
+        var widthPatterns = [0.8, 0.6, 0.4, 0.75, 0.55, 0.85, 0.5, 0.7];
+
+        for (var i = 0; i < opts.lines; i++) {
+            var widthPct = widthPatterns[i % widthPatterns.length];
+            var line = createSkel('skel-line', { width: (widthPct * 100) + '%' });
+            body.appendChild(line);
+        }
+
+        card.appendChild(body);
+
+        // 底部按钮占位（可选）
+        if (opts.hasButton) {
+            var footer = document.createElement('div');
+            footer.className = 'skel-footer';
+            var btn = createSkel('skel-rect', {
+                width: '80px',
+                height: '32px'
+            });
+            footer.appendChild(btn);
+            card.appendChild(footer);
+        }
+
+        container.appendChild(card);
+        markContainer(container);
+    }
+
+    /**
+     * 渲染骨架列表
+     * 模拟列表布局：N 行，每行包含图标 + 两行文本 + 元信息
+     * 
+     * @param {HTMLElement} container - 目标容器
+     * @param {Object} [options] - 配置选项
+     * @param {number} [options.count=5] - 列表行数
+     * @param {boolean} [options.hasIcon=true] - 是否显示图标占位
+     */
+    function renderList(container, options) {
+        if (!container) return;
+        injectStyles();
+
+        var opts = mergeOptions({
+            count: 5,
+            hasIcon: true
+        }, options);
+
+        // 文本宽度变化模式，产生自然交替效果
+        var textWidths = [
+            { line1: '65%', line2: '40%', meta: '60px' },
+            { line1: '75%', line2: '50%', meta: '80px' },
+            { line1: '55%', line2: '35%', meta: '50px' },
+            { line1: '80%', line2: '45%', meta: '70px' },
+            { line1: '60%', line2: '55%', meta: '90px' }
+        ];
+
+        for (var i = 0; i < opts.count; i++) {
+            var row = document.createElement('div');
+            row.className = 'skel-row';
+
+            // 图标占位（可选）
+            if (opts.hasIcon) {
+                var icon = createSkel('skel-circle', {
+                    width: '32px',
+                    height: '32px'
+                });
+                row.appendChild(icon);
+            }
+
+            // 文本区域
+            var textArea = document.createElement('div');
+            textArea.style.flex = '1';
+            textArea.style.display = 'flex';
+            textArea.style.flexDirection = 'column';
+            textArea.style.gap = '6px';
+
+            var pattern = textWidths[i % textWidths.length];
+
+            var line1 = createSkel('skel-line', { width: pattern.line1 });
+            textArea.appendChild(line1);
+
+            var line2 = createSkel('skel-line', { width: pattern.line2 });
+            line2.style.height = '10px';
+            textArea.appendChild(line2);
+
+            row.appendChild(textArea);
+
+            // 元信息占位
+            var meta = createSkel('skel-line skel-line--short', { width: pattern.meta });
+            meta.style.height = '10px';
+            row.appendChild(meta);
+
+            container.appendChild(row);
+        }
+
+        markContainer(container);
+    }
+
+    /**
+     * 渲染骨架统计网格
+     * 模拟 2x2 统计卡片布局，每项包含大数字 + 标签
+     * 
+     * @param {HTMLElement} container - 目标容器
+     * @param {Object} [options] - 配置选项
+     * @param {number} [options.count=4] - 统计项数量（建议为 4 的倍数）
+     */
+    function renderStats(container, options) {
+        if (!container) return;
+        injectStyles();
+
+        var opts = mergeOptions({
+            count: 4
+        }, options);
+
+        var grid = document.createElement('div');
+        grid.className = 'skel-stats-grid';
+
+        for (var i = 0; i < opts.count; i++) {
+            var item = document.createElement('div');
+            item.className = 'skel-stat-item';
+
+            // 数字占位
+            var number = createSkel('skel skel-stat-number');
+            item.appendChild(number);
+
+            // 标签占位
+            var label = createSkel('skel skel-stat-label');
+            item.appendChild(label);
+
+            grid.appendChild(item);
+        }
+
+        container.appendChild(grid);
+        markContainer(container);
+    }
+
+    /**
+     * 渲染骨架文本块
+     * 模拟纯文本内容区域，多行随机宽度
+     * 
+     * @param {HTMLElement} container - 目标容器
+     * @param {Object} [options] - 配置选项
+     * @param {number} [options.lines=4] - 文本行数
+     */
+    function renderText(container, options) {
+        if (!container) return;
+        injectStyles();
+
+        var opts = mergeOptions({
+            lines: 4
+        }, options);
+
+        var wrapper = document.createElement('div');
+        wrapper.style.display = 'flex';
+        wrapper.style.flexDirection = 'column';
+        wrapper.style.gap = '10px';
+
+        for (var i = 0; i < opts.lines; i++) {
+            // 随机宽度在 40%-90% 之间
+            var width = randomWidth(40, 90);
+            var line = createSkel('skel-line', { width: width });
+            wrapper.appendChild(line);
+        }
+
+        container.appendChild(wrapper);
+        markContainer(container);
+    }
+
+    /**
+     * 移除容器中所有骨架元素
+     * 清理骨架屏状态，为真实内容腾出空间
+     * 
+     * @param {HTMLElement} container - 目标容器
+     */
+    function remove(container) {
+        if (!container) return;
+
+        // 移除所有骨架相关元素
+        var skeletons = container.querySelectorAll('.skel, .skel-card, .skel-row, .skel-stats-grid, .skel-stat-item, .skel-header, .skel-body, .skel-footer');
+        for (var i = 0; i < skeletons.length; i++) {
+            var parent = skeletons[i].parentNode;
+            if (parent) {
+                parent.removeChild(skeletons[i]);
+            }
+        }
+
+        // 清除骨架状态标记
+        container.removeAttribute('data-skeleton');
+    }
+
+    // ============================================================
+    // 公开 API
+    // ============================================================
+
+    return {
+        /** 渲染骨架卡片 */
+        renderCard: renderCard,
+
+        /** 渲染骨架列表 */
+        renderList: renderList,
+
+        /** 渲染骨架统计网格 */
+        renderStats: renderStats,
+
+        /** 渲染骨架文本块 */
+        renderText: renderText,
+
+        /** 移除骨架元素 */
+        remove: remove
+    };
+
+})();

--- a/frontend/js/workspace/pages/WorkspacePage.js
+++ b/frontend/js/workspace/pages/WorkspacePage.js
@@ -74,6 +74,10 @@ var WorkspacePage = (function () {
         if (typeof GestureManager !== 'undefined') {
             GestureManager.init(_desktopContainer);
         }
+        // 初始化右键菜单管理器
+        if (typeof ContextMenuManager !== 'undefined') {
+            ContextMenuManager.init(_desktopContainer);
+        }
 
         // 渲染桌面标签
         _renderDesktopTabs();
@@ -109,6 +113,9 @@ var WorkspacePage = (function () {
         // 销毁子管理器
         if (typeof GestureManager !== 'undefined' && GestureManager.destroy) {
             GestureManager.destroy();
+        }
+        if (typeof ContextMenuManager !== 'undefined' && ContextMenuManager.destroy) {
+            ContextMenuManager.destroy();
         }
         if (typeof ResizeManager !== 'undefined' && ResizeManager.destroy) {
             ResizeManager.destroy();

--- a/frontend/js/workspace/pages/WorkspacePage.js
+++ b/frontend/js/workspace/pages/WorkspacePage.js
@@ -78,6 +78,10 @@ var WorkspacePage = (function () {
         if (typeof ContextMenuManager !== 'undefined') {
             ContextMenuManager.init(_desktopContainer);
         }
+        // 初始化响应式布局管理器
+        if (typeof ResponsiveManager !== 'undefined') {
+            ResponsiveManager.init();
+        }
 
         // 渲染桌面标签
         _renderDesktopTabs();
@@ -116,6 +120,9 @@ var WorkspacePage = (function () {
         }
         if (typeof ContextMenuManager !== 'undefined' && ContextMenuManager.destroy) {
             ContextMenuManager.destroy();
+        }
+        if (typeof ResponsiveManager !== 'undefined' && ResponsiveManager.destroy) {
+            ResponsiveManager.destroy();
         }
         if (typeof ResizeManager !== 'undefined' && ResizeManager.destroy) {
             ResizeManager.destroy();

--- a/frontend/js/workspace/pages/WorkspacePage.js
+++ b/frontend/js/workspace/pages/WorkspacePage.js
@@ -1,350 +1,568 @@
 /**
- * WorkspacePage — 工作台主页面 (P2 增强)
+ * Hermes Workspace v17 - WorkspacePage (Rewrite)
  *
- * P2 增强:
- * - DesktopManager 协调多桌面
- * - DesktopContainer 管理桌面容器 + 滑动切换
- * - DesktopTabs 标签栏 + 右键菜单
- * - GestureManager 长按编辑 + 滑动切换
- *
- * 依赖: StateManager, DataService, DesktopManager, DesktopContainer, DesktopTabs,
- *       LayoutSwitcher, CardManager, CardWidget, ZIndexManager, GestureManager,
- *       Bus, Store, Logger (全局)
+ * 重写说明：
+ * - 不再作为 Router 页面，直接渲染到传入的 container
+ * - 保留所有现有功能（DesktopManager、CardManager、LayoutEngine 等）
+ * - 集成 CardOverlay：卡片点击时调用 CardOverlay.open() 而不是 CardWidget.toggleExpand()
+ * - 保留事件委托和 Bus 监听
+ * - 保留手势管理
+ * - 修改 render 方法签名：render(container) 接收容器参数
  */
-const WorkspacePage = (() => {
+var WorkspacePage = (function () {
     'use strict';
 
-    // ── Internal State ────────────────────────────────────
-    let _container = null;
-    let _destroyed = false;
-    let _busCleanupFns = [];
-    let _currentLayout = 'grid';
-    let _currentDesktopId = null;
+    // ==================== 内部状态 ====================
 
-    // ── Event Handlers ────────────────────────────────────
+    var _container = null;       // 主容器 DOM
+    var _desktopContainer = null; // 桌面容器 DOM
+    var _isEditMode = false;     // 编辑模式
+    var _isInitialized = false;  // 是否已初始化
 
-    function _handleAction(e) {
-        const target = e.target.closest('[data-action]');
-        if (!target) return;
-
-        const action = target.dataset.action;
-        const desktopId = target.dataset.desktopId;
-        const cardId = target.dataset.cardId;
-        const layout = target.dataset.layout;
-
-        switch (action) {
-            case 'switch-layout':
-                _switchLayout(layout);
-                break;
-            case 'reset-layout':
-                _resetLayout();
-                break;
-            case 'switch-desktop':
-                _switchDesktop(desktopId);
-                break;
-            case 'add-desktop':
-                _addDesktop();
-                break;
-            case 'rename-desktop':
-                _renameDesktop(desktopId);
-                break;
-            case 'delete-desktop':
-                _deleteDesktop(desktopId);
-                break;
-            case 'open-store':
-                Bus.emit('ws:store:open');
-                break;
-            case 'card-expand':
-                e.stopPropagation();
-                CardWidget.toggleExpand(cardId);
-                break;
-            case 'card-refresh':
-                e.stopPropagation();
-                _refreshCard(desktopId, cardId);
-                break;
-            case 'card-retry':
-                e.stopPropagation();
-                _refreshCard(desktopId, cardId);
-                break;
-            case 'card-delete':
-                e.stopPropagation();
-                _onCardDelete(desktopId, cardId);
-                break;
-            case 'card-more':
-                e.stopPropagation();
-                break;
-        }
-    }
-
-    function _switchLayout(layout) {
-        if (!layout || layout === _currentLayout) return;
-        _currentLayout = layout;
-        LayoutSwitcher.setActive(layout);
-        CardManager.switchLayout(_currentDesktopId, layout);
-        Logger.info('[WorkspacePage] Layout switched to:', layout);
-    }
-
-    function _resetLayout() {
-        LayoutEngine.clearPinned(_currentDesktopId);
-        DesktopContainer.refresh();
-        Logger.info('[WorkspacePage] Layout reset');
-    }
-
-    function _switchDesktop(desktopId) {
-        if (!desktopId || desktopId === _currentDesktopId) return;
-        DesktopManager.switchTo(desktopId);
-    }
-
-    function _addDesktop() {
-        const id = DesktopManager.createDesktop();
-        _currentDesktopId = id;
-        _currentLayout = StateManager.getDesktopLayout(id) || 'grid';
-        LayoutSwitcher.setActive(_currentLayout);
-        DesktopContainer.switchTo(id);
-        DesktopTabs.update();
-        Logger.info('[WorkspacePage] Created desktop:', id);
-    }
-
-    function _renameDesktop(desktopId) {
-        if (!desktopId) return;
-        const desktop = DesktopManager.getDesktop(desktopId);
-        if (!desktop) return;
-
-        // 使用内联编辑
-        const tabEl = _container.querySelector(`.ws-tabs__item[data-desktop-id="${desktopId}"]`);
-        if (!tabEl) return;
-
-        const currentName = desktop.name;
-        tabEl.contentEditable = true;
-        tabEl.focus();
-
-        // 选中文字
-        const range = document.createRange();
-        range.selectNodeContents(tabEl);
-        const sel = window.getSelection();
-        sel.removeAllRanges();
-        sel.addRange(range);
-
-        const finishEdit = () => {
-            tabEl.contentEditable = false;
-            const newName = tabEl.textContent.trim();
-            if (newName && newName !== currentName) {
-                DesktopManager.renameDesktop(desktopId, newName);
-            } else {
-                tabEl.textContent = currentName;
-            }
-            tabEl.removeEventListener('blur', finishEdit);
-            tabEl.removeEventListener('keydown', handleKey);
-        };
-
-        const handleKey = (e) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                tabEl.blur();
-            } else if (e.key === 'Escape') {
-                tabEl.textContent = currentName;
-                tabEl.blur();
-            }
-        };
-
-        tabEl.addEventListener('blur', finishEdit);
-        tabEl.addEventListener('keydown', handleKey);
-    }
-
-    function _deleteDesktop(desktopId) {
-        if (!desktopId) return;
-        if (DesktopManager.getCount() <= 1) {
-            Logger.warn('[WorkspacePage] Cannot delete the last desktop');
-            return;
-        }
-        DesktopManager.deleteDesktop(desktopId);
-        _currentDesktopId = DesktopManager.getActiveDesktop().id;
-        _currentLayout = StateManager.getDesktopLayout(_currentDesktopId) || 'grid';
-        LayoutSwitcher.setActive(_currentLayout);
-        DesktopContainer.switchTo(_currentDesktopId);
-        DesktopTabs.update();
-    }
-
-    function _refreshCard(desktopId, cardId) {
-        if (!desktopId || !cardId) return;
-        CardWidget.mountWidget(cardId, desktopId);
-    }
-
-    function _onCardDelete(desktopId, cardId) {
-        if (!desktopId || !cardId) return;
-        CardManager.deleteCard(desktopId, cardId);
-        // 检查是否空了
-        const remaining = StateManager.getCardIds(desktopId);
-        if (remaining.length === 0) {
-            DesktopContainer.refresh();
-        }
-    }
-
-    // ── Setup / Teardown ──────────────────────────────────
-
-    function _setupListeners() {
-        // 事件委托
-        _container.addEventListener('click', _handleAction);
-
-        // 监听桌面切换
-        const id1 = Bus.on('ws:desktop:switched', ({ desktopId }) => {
-            _currentDesktopId = desktopId;
-            _currentLayout = StateManager.getDesktopLayout(desktopId) || 'grid';
-            LayoutSwitcher.setActive(_currentLayout);
-            DesktopContainer.switchTo(desktopId);
-            DesktopTabs.setActive(desktopId);
-        });
-
-        const id2 = Bus.on('ws:desktop:created', () => {
-            DesktopTabs.update();
-        });
-
-        const id3 = Bus.on('ws:desktop:deleted', () => {
-            _currentDesktopId = DesktopManager.getActiveDesktop().id;
-            DesktopTabs.update();
-        });
-
-        const id4 = Bus.on('ws:desktop:renamed', () => {
-            DesktopTabs.update();
-        });
-
-        const id5 = Bus.on('ws:desktop:default-created', () => {
-            DesktopContainer.refresh();
-            DesktopTabs.update();
-        });
-
-        // 监听卡片变化
-        const id6 = Bus.on('ws:card:created', () => DesktopContainer.refresh());
-        const id7 = Bus.on('ws:card:deleted', () => DesktopContainer.refresh());
-
-        // 监听编辑模式
-        const id8 = Bus.on('ws:edit:enter', () => _toggleEditMode(true));
-        const id9 = Bus.on('ws:edit:exit', () => _toggleEditMode(false));
-
-        // 监听 z-index 变化
-        const id10 = Bus.on('ws:zindex:changed', ({ cardId, z }) => {
-            CardWidget.updateZIndex(cardId, z);
-        });
-
-        // 监听桌面滑动切换
-        const id11 = Bus.on('ws:desktop:switch-next', () => {
-            DesktopManager.switchNext();
-        });
-        const id12 = Bus.on('ws:desktop:switch-prev', () => {
-            DesktopManager.switchPrev();
-        });
-
-        _busCleanupFns = [
-            () => Bus.off('ws:desktop:switched', id1),
-            () => Bus.off('ws:desktop:created', id2),
-            () => Bus.off('ws:desktop:deleted', id3),
-            () => Bus.off('ws:desktop:renamed', id4),
-            () => Bus.off('ws:desktop:default-created', id5),
-            () => Bus.off('ws:card:created', id6),
-            () => Bus.off('ws:card:deleted', id7),
-            () => Bus.off('ws:edit:enter', id8),
-            () => Bus.off('ws:edit:exit', id9),
-            () => Bus.off('ws:zindex:changed', id10),
-            () => Bus.off('ws:desktop:switch-next', id11),
-            () => Bus.off('ws:desktop:switch-prev', id12)
-        ];
-    }
-
-    function _toggleEditMode(isEditing) {
-        if (!_container) return;
-        const cardIds = StateManager.getCardIds(_currentDesktopId);
-        for (const cardId of cardIds) {
-            CardWidget.setEditMode(cardId, isEditing);
-        }
-    }
-
-    // ── Public API ────────────────────────────────────────
+    // ==================== 生命周期 ====================
 
     /**
-     * 渲染页面
+     * 渲染工作台到指定容器
+     * @param {HTMLElement} container - 目标容器
      */
     function render(container) {
-        _container = container || document.getElementById('contentBody');
-        if (!_container) return;
-
-        _destroyed = false;
-
-        // 初始化 P2 模块
-        DesktopManager.init();
-        ZIndexManager.init();
-
-        _currentDesktopId = DesktopManager.getActiveDesktop().id;
-        _currentLayout = StateManager.getDesktopLayout(_currentDesktopId) || 'grid';
-
-        _container.innerHTML = `
-        <div class="ws-workspace" data-action="workspace">
-            ${LayoutSwitcher.render(_currentLayout)}
-            <div class="ws-desktops" id="wsDesktopsContainer">
-                <!-- DesktopContainer will render here -->
-            </div>
-            ${DesktopTabs.render()}
-        </div>`;
-
-        // 渲染桌面容器
-        const desktopsContainer = document.getElementById('wsDesktopsContainer');
-        if (desktopsContainer) {
-            DesktopContainer.render(desktopsContainer);
-            // 初始化 CardManager
-            CardManager.init(desktopsContainer);
+        if (!container) {
+            console.error('[WorkspacePage] render() called without container');
+            return;
         }
 
-        // 初始化 DesktopTabs
-        DesktopTabs.init();
+        _container = container;
+        _container.innerHTML = '';
 
-        // 初始化手势管理
-        GestureManager.init(_container);
-        GestureManager.onSwipe({
-            onLeft: () => DesktopManager.switchNext(),
-            onRight: () => DesktopManager.switchPrev()
-        });
+        // 创建桌面容器
+        _desktopContainer = document.createElement('div');
+        _desktopContainer.className = 'ws-desktop';
+        _desktopContainer.id = 'wsDesktop';
+        _container.appendChild(_desktopContainer);
 
-        _setupListeners();
-        Logger.info('[WorkspacePage] Rendered (P2)');
+        // 初始化桌面管理器
+        if (typeof DesktopManager !== 'undefined') {
+            DesktopManager.init(_desktopContainer);
+        }
+
+        // 初始化布局引擎
+        if (typeof LayoutEngine !== 'undefined') {
+            LayoutEngine.init(_desktopContainer);
+        }
+
+        // 初始化卡片管理器
+        if (typeof CardManager !== 'undefined') {
+            CardManager.init(_desktopContainer);
+        }
+
+        // 初始化拖拽管理器
+        if (typeof DragManager !== 'undefined') {
+            DragManager.init(_desktopContainer);
+        }
+
+        // 初始化 Resize 管理器
+        if (typeof ResizeManager !== 'undefined') {
+            ResizeManager.init(_desktopContainer);
+        }
+
+        // 初始化 Z-Index 管理器
+        if (typeof ZIndexManager !== 'undefined') {
+            ZIndexManager.init();
+        }
+
+        // 初始化手势管理器
+        if (typeof GestureManager !== 'undefined') {
+            GestureManager.init(_desktopContainer);
+        }
+
+        // 渲染桌面标签
+        _renderDesktopTabs();
+
+        // 渲染布局切换器
+        _renderLayoutSwitcher();
+
+        // 渲染卡片商店入口
+        _renderCardStoreTrigger();
+
+        // 加载桌面数据
+        _loadDesktop();
+
+        // 绑定事件
+        _bindEvents();
+
+        // 注册 Bus 监听
+        _subscribeBusEvents();
+
+        _isInitialized = true;
+        console.log('[WorkspacePage] Rendered successfully.');
     }
 
     /**
-     * 处理 SSE 事件
-     */
-    function onSSEEvent(event, data) {
-        Logger.debug('[WorkspacePage] SSE event:', event);
-    }
-
-    /**
-     * 销毁页面
+     * 销毁工作台
      */
     function destroy() {
-        _destroyed = true;
+        if (!_isInitialized) return;
 
-        for (const cleanup of _busCleanupFns) {
-            cleanup();
+        // 取消 Bus 监听
+        _unsubscribeBusEvents();
+
+        // 销毁子管理器
+        if (typeof GestureManager !== 'undefined' && GestureManager.destroy) {
+            GestureManager.destroy();
         }
-        _busCleanupFns = [];
-
-        GestureManager.destroy();
-        DesktopTabs.destroy();
-        CardManager.destroy();
-        ZIndexManager.destroy();
-
-        if (_container) {
-            _container.removeEventListener('click', _handleAction);
+        if (typeof ResizeManager !== 'undefined' && ResizeManager.destroy) {
+            ResizeManager.destroy();
+        }
+        if (typeof DragManager !== 'undefined' && DragManager.destroy) {
+            DragManager.destroy();
+        }
+        if (typeof CardManager !== 'undefined' && CardManager.destroy) {
+            CardManager.destroy();
+        }
+        if (typeof LayoutEngine !== 'undefined' && LayoutEngine.destroy) {
+            LayoutEngine.destroy();
+        }
+        if (typeof DesktopManager !== 'undefined' && DesktopManager.destroy) {
+            DesktopManager.destroy();
         }
 
+        // 清空容器
         if (_container) {
             _container.innerHTML = '';
         }
 
         _container = null;
-        Logger.info('[WorkspacePage] Destroyed');
+        _desktopContainer = null;
+        _isInitialized = false;
+
+        console.log('[WorkspacePage] Destroyed.');
     }
 
+    // ==================== 桌面渲染 ====================
+
+    /**
+     * 加载当前桌面
+     */
+    function _loadDesktop() {
+        if (typeof DesktopManager !== 'undefined' && DesktopManager.loadDesktop) {
+            DesktopManager.loadDesktop();
+        }
+    }
+
+    /**
+     * 刷新桌面数据
+     */
+    function refresh() {
+        if (typeof CardManager !== 'undefined' && CardManager.refreshAll) {
+            CardManager.refreshAll();
+        }
+    }
+
+    // ==================== UI 子组件渲染 ====================
+
+    /**
+     * 渲染桌面标签栏
+     */
+    function _renderDesktopTabs() {
+        if (typeof DesktopTabs !== 'undefined' && DesktopTabs.render) {
+            var tabsContainer = document.createElement('div');
+            tabsContainer.className = 'ws-desktop-tabs-container';
+            tabsContainer.id = 'wsDesktopTabs';
+            _container.appendChild(tabsContainer);
+            DesktopTabs.render(tabsContainer);
+        }
+    }
+
+    /**
+     * 渲染布局切换器
+     */
+    function _renderLayoutSwitcher() {
+        if (typeof LayoutSwitcher !== 'undefined' && LayoutSwitcher.render) {
+            var switcherContainer = document.createElement('div');
+            switcherContainer.className = 'ws-layout-switcher-container';
+            switcherContainer.id = 'wsLayoutSwitcher';
+            _container.appendChild(switcherContainer);
+            LayoutSwitcher.render(switcherContainer);
+        }
+    }
+
+    /**
+     * 渲染卡片商店触发按钮
+     */
+    function _renderCardStoreTrigger() {
+        if (typeof CardStore !== 'undefined' && CardStore.renderTrigger) {
+            var triggerContainer = document.createElement('div');
+            triggerContainer.className = 'ws-card-store-trigger-container';
+            triggerContainer.id = 'wsCardStoreTrigger';
+            _container.appendChild(triggerContainer);
+            CardStore.renderTrigger(triggerContainer);
+        }
+    }
+
+    // ==================== 事件处理 ====================
+
+    /**
+     * 绑定事件委托
+     */
+    function _bindEvents() {
+        if (!_container) return;
+
+        // 使用事件委托处理所有卡片动作
+        _container.addEventListener('click', _handleClick);
+        _container.addEventListener('dblclick', _handleDblClick);
+    }
+
+    /**
+     * 处理点击事件（事件委托）
+     * @param {Event} e
+     */
+    function _handleClick(e) {
+        var actionEl = e.target.closest('[data-action]');
+        if (!actionEl) return;
+
+        var action = actionEl.getAttribute('data-action');
+        var cardId = actionEl.closest('[data-card-id]');
+        cardId = cardId ? cardId.getAttribute('data-card-id') : null;
+
+        _handleAction(action, cardId, e);
+    }
+
+    /**
+     * 处理双击事件
+     * @param {Event} e
+     */
+    function _handleDblClick(e) {
+        // 双击卡片标题进入编辑模式
+        var titleEl = e.target.closest('.ws-card-title');
+        if (titleEl) {
+            var cardEl = titleEl.closest('[data-card-id]');
+            if (cardEl) {
+                var cardId = cardEl.getAttribute('data-card-id');
+                _handleAction('card-rename', cardId, e);
+            }
+        }
+    }
+
+    /**
+     * 处理卡片动作
+     * @param {string} action - 动作类型
+     * @param {string} cardId - 卡片 ID
+     * @param {Event} e - 原始事件
+     */
+    function _handleAction(action, cardId, e) {
+        if (!action) return;
+
+        switch (action) {
+            // ===== 卡片放大（核心修改：使用 CardOverlay） =====
+            case 'card-expand':
+                e.stopPropagation();
+                if (typeof CardOverlay !== 'undefined' && CardOverlay.open) {
+                    CardOverlay.open(cardId);
+                } else {
+                    // 降级：使用 CardWidget.toggleExpand
+                    if (typeof CardWidget !== 'undefined' && CardWidget.toggleExpand) {
+                        CardWidget.toggleExpand(cardId);
+                    }
+                }
+                break;
+
+            // ===== 卡片关闭（从放大状态缩回） =====
+            case 'card-collapse':
+                e.stopPropagation();
+                if (typeof CardOverlay !== 'undefined' && CardOverlay.close) {
+                    CardOverlay.close();
+                } else if (typeof CardWidget !== 'undefined' && CardWidget.toggleExpand) {
+                    CardWidget.toggleExpand(cardId);
+                }
+                break;
+
+            // ===== 卡片删除 =====
+            case 'card-delete':
+                e.stopPropagation();
+                if (typeof CardManager !== 'undefined' && CardManager.removeCard) {
+                    CardManager.removeCard(cardId);
+                }
+                break;
+
+            // ===== 卡片刷新 =====
+            case 'card-refresh':
+                e.stopPropagation();
+                if (typeof CardManager !== 'undefined' && CardManager.refreshCard) {
+                    CardManager.refreshCard(cardId);
+                }
+                break;
+
+            // ===== 卡片固定/取消固定 =====
+            case 'card-pin':
+                e.stopPropagation();
+                if (typeof CardManager !== 'undefined' && CardManager.togglePin) {
+                    CardManager.togglePin(cardId);
+                }
+                break;
+
+            // ===== 卡片重命名 =====
+            case 'card-rename':
+                e.stopPropagation();
+                // TODO: 实现重命名逻辑
+                break;
+
+            // ===== 卡片配置 =====
+            case 'card-config':
+                e.stopPropagation();
+                // TODO: 打开卡片配置面板
+                break;
+
+            // ===== 桌面切换 =====
+            case 'desktop-switch':
+                var desktopId = e.target.closest('[data-desktop-id]');
+                if (desktopId) {
+                    var targetId = desktopId.getAttribute('data-desktop-id');
+                    if (typeof DesktopManager !== 'undefined' && DesktopManager.switchDesktop) {
+                        DesktopManager.switchDesktop(targetId);
+                    }
+                }
+                break;
+
+            // ===== 新增桌面 =====
+            case 'desktop-add':
+                if (typeof DesktopManager !== 'undefined' && DesktopManager.addDesktop) {
+                    DesktopManager.addDesktop();
+                }
+                break;
+
+            // ===== 布局切换 =====
+            case 'layout-switch':
+                var layoutType = e.target.closest('[data-layout]');
+                if (layoutType) {
+                    var layout = layoutType.getAttribute('data-layout');
+                    if (typeof LayoutEngine !== 'undefined' && LayoutEngine.setLayout) {
+                        LayoutEngine.setLayout(layout);
+                    }
+                }
+                break;
+
+            // ===== 卡片商店 =====
+            case 'card-store-open':
+                if (typeof CardStore !== 'undefined' && CardStore.open) {
+                    CardStore.open();
+                }
+                break;
+
+            // ===== 编辑模式切换 =====
+            case 'edit-mode-toggle':
+                toggleEditMode();
+                break;
+
+            default:
+                // 透传给 Bus，让感兴趣的模块自行处理
+                if (typeof Bus !== 'undefined') {
+                    Bus.emit('workspace:action', { action: action, cardId: cardId, event: e });
+                }
+                break;
+        }
+    }
+
+    // ==================== 编辑模式 ====================
+
+    /**
+     * 切换编辑模式
+     */
+    function toggleEditMode() {
+        _isEditMode = !_isEditMode;
+
+        if (_container) {
+            _container.classList.toggle('ws-edit-mode', _isEditMode);
+        }
+
+        // 通知子管理器
+        if (typeof CardManager !== 'undefined' && CardManager.setEditMode) {
+            CardManager.setEditMode(_isEditMode);
+        }
+        if (typeof DragManager !== 'undefined' && DragManager.setEditMode) {
+            DragManager.setEditMode(_isEditMode);
+        }
+        if (typeof ResizeManager !== 'undefined' && ResizeManager.setEditMode) {
+            ResizeManager.setEditMode(_isEditMode);
+        }
+
+        // 广播编辑模式变化
+        if (typeof Bus !== 'undefined') {
+            Bus.emit('workspace:edit-mode', { isEditMode: _isEditMode });
+        }
+
+        console.log('[WorkspacePage] Edit mode:', _isEditMode ? 'ON' : 'OFF');
+    }
+
+    /**
+     * 获取编辑模式状态
+     * @returns {boolean}
+     */
+    function isEditMode() {
+        return _isEditMode;
+    }
+
+    // ==================== Bus 事件 ====================
+
+    /**
+     * 注册 Bus 事件监听
+     */
+    function _subscribeBusEvents() {
+        if (typeof Bus === 'undefined') return;
+
+        Bus.on('card:click', _onCardClick);
+        Bus.on('card:dblclick', _onCardDblClick);
+        Bus.on('desktop:switched', _onDesktopSwitched);
+        Bus.on('layout:changed', _onLayoutChanged);
+        Bus.on('card:added', _onCardAdded);
+        Bus.on('card:removed', _onCardRemoved);
+    }
+
+    /**
+     * 取消 Bus 事件监听
+     */
+    function _unsubscribeBusEvents() {
+        if (typeof Bus === 'undefined') return;
+
+        Bus.off('card:click', _onCardClick);
+        Bus.off('card:dblclick', _onCardDblClick);
+        Bus.off('desktop:switched', _onDesktopSwitched);
+        Bus.off('layout:changed', _onLayoutChanged);
+        Bus.off('card:added', _onCardAdded);
+        Bus.off('card:removed', _onCardRemoved);
+    }
+
+    /**
+     * 卡片点击事件处理
+     * @param {Object} data - { cardId, event }
+     */
+    function _onCardClick(data) {
+        // 在非编辑模式下，点击卡片放大
+        if (!_isEditMode && data.cardId) {
+            if (typeof CardOverlay !== 'undefined' && CardOverlay.open) {
+                CardOverlay.open(data.cardId);
+            } else if (typeof CardWidget !== 'undefined' && CardWidget.toggleExpand) {
+                CardWidget.toggleExpand(data.cardId);
+            }
+        }
+    }
+
+    /**
+     * 卡片双击事件处理
+     * @param {Object} data - { cardId, event }
+     */
+    function _onCardDblClick(data) {
+        // 双击进入编辑模式
+        if (!_isEditMode) {
+            toggleEditMode();
+        }
+    }
+
+    /**
+     * 桌面切换回调
+     * @param {Object} data - { desktopId }
+     */
+    function _onDesktopSwitched(data) {
+        // 更新桌面标签 UI
+        if (typeof DesktopTabs !== 'undefined' && DesktopTabs.updateActive) {
+            DesktopTabs.updateActive(data.desktopId);
+        }
+    }
+
+    /**
+     * 布局变化回调
+     * @param {Object} data - { layout }
+     */
+    function _onLayoutChanged(data) {
+        // 更新布局切换器 UI
+        if (typeof LayoutSwitcher !== 'undefined' && LayoutSwitcher.updateActive) {
+            LayoutSwitcher.updateActive(data.layout);
+        }
+    }
+
+    /**
+     * 卡片添加回调
+     * @param {Object} data - { cardId, widgetType }
+     */
+    function _onCardAdded(data) {
+        console.log('[WorkspacePage] Card added:', data.cardId, data.widgetType);
+    }
+
+    /**
+     * 卡片移除回调
+     * @param {Object} data - { cardId }
+     */
+    function _onCardRemoved(data) {
+        console.log('[WorkspacePage] Card removed:', data.cardId);
+    }
+
+    // ==================== SSE 事件处理 ====================
+
+    /**
+     * 处理 SSE 事件
+     * @param {string} event - SSE 事件名
+     * @param {Object} data - SSE 事件数据
+     */
+    function onSSEEvent(event, data) {
+        if (!_isInitialized) return;
+
+        console.log('[WorkspacePage] SSE event:', event, data);
+
+        // 根据事件类型刷新对应卡片
+        var eventType = event.replace('sse:', '');
+
+        switch (eventType) {
+            case 'knowledge.updated':
+                _refreshCardsByWidget('knowledge');
+                break;
+            case 'rules.updated':
+                _refreshCardsByWidget('rules');
+                break;
+            case 'experiences.updated':
+                _refreshCardsByWidget('experiences');
+                break;
+            case 'memories.updated':
+                _refreshCardsByWidget('memory');
+                break;
+            case 'reviews.updated':
+                _refreshCardsByWidget('reviews');
+                break;
+            case 'mcp.tool_call':
+            case 'mcp.tool_complete':
+                _refreshCardsByWidget('mcp-status');
+                break;
+            case 'session.message':
+                _refreshCardsByWidget('sessions');
+                break;
+            case 'alert.new':
+            case 'alert.resolved':
+                _refreshCardsByWidget('alerts');
+                break;
+            default:
+                // 未知事件，刷新所有卡片
+                refresh();
+                break;
+        }
+    }
+
+    /**
+     * 刷新指定 Widget 类型的所有卡片
+     * @param {string} widgetType - Widget 类型
+     */
+    function _refreshCardsByWidget(widgetType) {
+        if (typeof CardManager !== 'undefined' && CardManager.refreshByWidget) {
+            CardManager.refreshByWidget(widgetType);
+        }
+    }
+
+    // ==================== 公共 API ====================
+
     return {
-        render,
-        onSSEEvent,
-        destroy
+        render: render,
+        destroy: destroy,
+        refresh: refresh,
+        toggleEditMode: toggleEditMode,
+        isEditMode: isEditMode,
+        onSSEEvent: onSSEEvent
     };
+
 })();

--- a/frontend/js/workspace/widgets/cards/AgentCard.js
+++ b/frontend/js/workspace/widgets/cards/AgentCard.js
@@ -1,0 +1,716 @@
+;(function () {
+    'use strict';
+
+    /* ================================================================
+     *  AgentCard.js  —  Hermes Workspace V2  AI Agent 管理卡片
+     *  支持 4 种尺寸: small(1x1) / medium(2x1) / large(2x2) / xlarge(全屏)
+     * ================================================================ */
+
+    var PREFIX = 'ac';
+    var REFRESH_INTERVAL = 5000;
+    var DETAIL_REFRESH_INTERVAL = 3000;
+
+    /* ---------- 状态映射 ---------- */
+    var STATUS_MAP = {
+        running:   { label: '运行中', color: '#22c55e', cls: 'running' },
+        completed: { label: '已完成', color: '#3b82f6', cls: 'completed' },
+        failed:    { label: '已失败', color: '#ef4444', cls: 'failed' },
+        idle:      { label: '空闲',   color: '#eab308', cls: 'idle' },
+        pending:   { label: '等待中', color: '#eab308', cls: 'pending' },
+        stopped:   { label: '已停止', color: '#9ca3af', cls: 'stopped' }
+    };
+
+    /* ---------- 工具函数 ---------- */
+    function statusInfo(s) { return STATUS_MAP[s] || STATUS_MAP.idle; }
+
+    function esc(str) {
+        var d = document.createElement('div');
+        d.textContent = str || '';
+        return d.innerHTML;
+    }
+
+    function formatTime(iso) {
+        if (!iso) return '--';
+        var d = new Date(iso);
+        var pad = function (n) { return n < 10 ? '0' + n : n; };
+        return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+               ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
+    }
+
+    function truncate(str, len) {
+        if (!str) return '';
+        return str.length > len ? str.slice(0, len) + '...' : str;
+    }
+
+    function runningCount(agents) {
+        var c = 0;
+        for (var i = 0; i < agents.length; i++) {
+            if (agents[i].status === 'running') c++;
+        }
+        return c;
+    }
+
+    function progressColor(pct) {
+        if (pct >= 80) return '#22c55e';
+        if (pct >= 50) return '#3b82f6';
+        if (pct >= 20) return '#eab308';
+        return '#f97316';
+    }
+
+    /* ================================================================
+     *  CSS 注入
+     * ================================================================ */
+    function injectCSS() {
+        if (document.getElementById(PREFIX + '-style')) return;
+        var css = [
+            '.' + PREFIX + '-root { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 13px; color: #e2e8f0; line-height: 1.5; }',
+            '.' + PREFIX + '-root *, .' + PREFIX + '-root *::before, .' + PREFIX + '-root *::after { box-sizing: border-box; margin: 0; padding: 0; }',
+
+            /* small */
+            '.' + PREFIX + '-small { display: flex; align-items: center; justify-content: center; gap: 8px; height: 100%; cursor: pointer; user-select: none; }',
+            '.' + PREFIX + '-small-icon { font-size: 22px; }',
+            '.' + PREFIX + '-small-label { font-size: 13px; font-weight: 600; color: #cbd5e1; }',
+            '.' + PREFIX + '-small-badge { background: #22c55e; color: #fff; font-size: 11px; font-weight: 700; min-width: 18px; height: 18px; border-radius: 9px; display: flex; align-items: center; justify-content: center; padding: 0 5px; }',
+
+            /* medium */
+            '.' + PREFIX + '-medium { display: flex; flex-direction: column; height: 100%; overflow: hidden; }',
+            '.' + PREFIX + '-medium-header { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px 6px; border-bottom: 1px solid rgba(255,255,255,0.06); flex-shrink: 0; }',
+            '.' + PREFIX + '-medium-title { font-size: 13px; font-weight: 600; color: #e2e8f0; display: flex; align-items: center; gap: 6px; }',
+            '.' + PREFIX + '-medium-list { flex: 1; overflow-y: auto; padding: 6px 12px; }',
+            '.' + PREFIX + '-medium-item { display: flex; align-items: center; gap: 8px; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,0.04); cursor: pointer; }',
+            '.' + PREFIX + '-medium-item:last-child { border-bottom: none; }',
+            '.' + PREFIX + '-medium-item-name { font-size: 12px; color: #cbd5e1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 90px; }',
+            '.' + PREFIX + '-medium-item-bar { flex: 1; height: 6px; background: rgba(255,255,255,0.08); border-radius: 3px; overflow: hidden; }',
+            '.' + PREFIX + '-medium-item-bar-fill { height: 100%; border-radius: 3px; transition: width .4s ease; }',
+            '.' + PREFIX + '-medium-item-status { font-size: 10px; color: #94a3b8; white-space: nowrap; }',
+            '.' + PREFIX + '-medium-empty { display: flex; align-items: center; justify-content: center; height: 100%; color: #64748b; font-size: 12px; }',
+
+            /* large */
+            '.' + PREFIX + '-large { display: flex; flex-direction: column; height: 100%; overflow: hidden; }',
+            '.' + PREFIX + '-large-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px 8px; border-bottom: 1px solid rgba(255,255,255,0.06); flex-shrink: 0; }',
+            '.' + PREFIX + '-large-title { font-size: 14px; font-weight: 600; color: #e2e8f0; display: flex; align-items: center; gap: 6px; }',
+            '.' + PREFIX + '-large-tabs { display: flex; gap: 2px; background: rgba(255,255,255,0.06); border-radius: 6px; padding: 2px; }',
+            '.' + PREFIX + '-large-tab { font-size: 11px; padding: 3px 10px; border-radius: 4px; cursor: pointer; color: #94a3b8; border: none; background: none; transition: all .2s; }',
+            '.' + PREFIX + '-large-tab.active { background: rgba(255,255,255,0.12); color: #e2e8f0; }',
+            '.' + PREFIX + '-large-body { flex: 1; overflow-y: auto; padding: 8px 14px; }',
+            '.' + PREFIX + '-large-section-title { font-size: 11px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.5px; margin: 8px 0 6px; }',
+            '.' + PREFIX + '-large-section-title:first-child { margin-top: 0; }',
+            '.' + PREFIX + '-large-agent { display: flex; align-items: center; gap: 8px; padding: 7px 0; border-bottom: 1px solid rgba(255,255,255,0.04); cursor: pointer; }',
+            '.' + PREFIX + '-large-agent:last-child { border-bottom: none; }',
+            '.' + PREFIX + '-large-agent-info { flex: 1; min-width: 0; }',
+            '.' + PREFIX + '-large-agent-name { font-size: 12px; font-weight: 600; color: #e2e8f0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }',
+            '.' + PREFIX + '-large-agent-meta { display: flex; align-items: center; gap: 6px; margin-top: 2px; }',
+            '.' + PREFIX + '-large-agent-task { font-size: 11px; color: #94a3b8; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; }',
+            '.' + PREFIX + '-type-badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; background: rgba(168,85,247,0.15); color: #c084fc; white-space: nowrap; }',
+            '.' + PREFIX + '-large-agent-bar { height: 4px; background: rgba(255,255,255,0.08); border-radius: 2px; overflow: hidden; margin-top: 4px; }',
+            '.' + PREFIX + '-large-agent-bar-fill { height: 100%; border-radius: 2px; transition: width .4s ease; }',
+            '.' + PREFIX + '-large-agent-status { font-size: 10px; white-space: nowrap; display: flex; align-items: center; gap: 4px; }',
+            '.' + PREFIX + '-large-agent-time { font-size: 10px; color: #64748b; }',
+            '.' + PREFIX + '-btn-terminate { font-size: 10px; padding: 2px 8px; border-radius: 4px; border: 1px solid rgba(239,68,68,0.3); background: rgba(239,68,68,0.1); color: #f87171; cursor: pointer; white-space: nowrap; transition: all .2s; flex-shrink: 0; }',
+            '.' + PREFIX + '-btn-terminate:hover { background: rgba(239,68,68,0.25); }',
+
+            /* xlarge */
+            '.' + PREFIX + '-xlarge { display: flex; flex-direction: column; height: 100%; overflow: hidden; }',
+            '.' + PREFIX + '-xlarge-header { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px 12px; border-bottom: 1px solid rgba(255,255,255,0.06); flex-shrink: 0; }',
+            '.' + PREFIX + '-xlarge-title { font-size: 16px; font-weight: 700; color: #f1f5f9; display: flex; align-items: center; gap: 8px; }',
+            '.' + PREFIX + '-xlarge-actions { display: flex; align-items: center; gap: 8px; }',
+            '.' + PREFIX + '-btn-refresh { font-size: 12px; padding: 4px 12px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.06); color: #cbd5e1; cursor: pointer; transition: all .2s; display: flex; align-items: center; gap: 4px; }',
+            '.' + PREFIX + '-btn-refresh:hover { background: rgba(255,255,255,0.12); }',
+            '.' + PREFIX + '-xlarge-filters { display: flex; gap: 4px; padding: 10px 20px 0; flex-shrink: 0; }',
+            '.' + PREFIX + '-xlarge-filter { font-size: 12px; padding: 5px 14px; border-radius: 6px; cursor: pointer; color: #94a3b8; border: 1px solid transparent; background: none; transition: all .2s; }',
+            '.' + PREFIX + '-xlarge-filter.active { background: rgba(255,255,255,0.08); color: #e2e8f0; border-color: rgba(255,255,255,0.12); }',
+            '.' + PREFIX + '-xlarge-grid { flex: 1; overflow-y: auto; padding: 12px 20px; display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; align-content: start; }',
+            '.' + PREFIX + '-agent-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06); border-radius: 10px; padding: 14px; cursor: pointer; transition: all .2s; display: flex; flex-direction: column; gap: 8px; }',
+            '.' + PREFIX + '-agent-card:hover { background: rgba(255,255,255,0.07); border-color: rgba(255,255,255,0.12); }',
+            '.' + PREFIX + '-agent-card-head { display: flex; align-items: center; justify-content: space-between; }',
+            '.' + PREFIX + '-agent-card-name { font-size: 14px; font-weight: 600; color: #f1f5f9; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; }',
+            '.' + PREFIX + '-status-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; }',
+            '.' + PREFIX + '-agent-card-task { font-size: 12px; color: #94a3b8; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }',
+            '.' + PREFIX + '-agent-card-session { font-size: 11px; font-family: "SF Mono", "Fira Code", monospace; color: #64748b; }',
+            '.' + PREFIX + '-agent-card-time { font-size: 11px; color: #64748b; }',
+            '.' + PREFIX + '-agent-card-progress { height: 6px; background: rgba(255,255,255,0.08); border-radius: 3px; overflow: hidden; }',
+            '.' + PREFIX + '-agent-card-progress-fill { height: 100%; border-radius: 3px; transition: width .4s ease; }',
+            '.' + PREFIX + '-agent-card-actions { display: flex; justify-content: flex-end; margin-top: 4px; }',
+
+            /* detail */
+            '.' + PREFIX + '-detail { display: flex; flex-direction: column; height: 100%; overflow: hidden; }',
+            '.' + PREFIX + '-detail-header { display: flex; align-items: center; gap: 12px; padding: 16px 20px 12px; border-bottom: 1px solid rgba(255,255,255,0.06); flex-shrink: 0; }',
+            '.' + PREFIX + '-btn-back { font-size: 12px; padding: 4px 10px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.06); color: #cbd5e1; cursor: pointer; transition: all .2s; display: flex; align-items: center; gap: 4px; }',
+            '.' + PREFIX + '-btn-back:hover { background: rgba(255,255,255,0.12); }',
+            '.' + PREFIX + '-detail-name { font-size: 16px; font-weight: 700; color: #f1f5f9; flex: 1; }',
+            '.' + PREFIX + '-detail-body { flex: 1; overflow-y: auto; padding: 20px; }',
+            '.' + PREFIX + '-detail-section { margin-bottom: 20px; }',
+            '.' + PREFIX + '-detail-section-title { font-size: 11px; font-weight: 600; color: #64748b; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }',
+            '.' + PREFIX + '-detail-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; }',
+            '.' + PREFIX + '-detail-label { font-size: 12px; color: #94a3b8; min-width: 80px; }',
+            '.' + PREFIX + '-detail-value { font-size: 13px; color: #e2e8f0; flex: 1; word-break: break-all; }',
+            '.' + PREFIX + '-detail-progress { height: 10px; background: rgba(255,255,255,0.08); border-radius: 5px; overflow: hidden; margin-top: 4px; }',
+            '.' + PREFIX + '-detail-progress-fill { height: 100%; border-radius: 5px; transition: width .4s ease; }',
+            '.' + PREFIX + '-detail-progress-text { font-size: 12px; color: #94a3b8; margin-top: 4px; text-align: right; }',
+            '.' + PREFIX + '-detail-terminate { margin-top: 20px; display: flex; justify-content: flex-end; }',
+            '.' + PREFIX + '-btn-terminate-lg { font-size: 13px; padding: 8px 20px; border-radius: 8px; border: 1px solid rgba(239,68,68,0.3); background: rgba(239,68,68,0.12); color: #f87171; cursor: pointer; transition: all .2s; }',
+            '.' + PREFIX + '-btn-terminate-lg:hover { background: rgba(239,68,68,0.25); }',
+
+            /* confirm bar */
+            '.' + PREFIX + '-confirm-bar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: rgba(239,68,68,0.08); border: 1px solid rgba(239,68,68,0.2); border-radius: 6px; margin-top: 6px; }',
+            '.' + PREFIX + '-confirm-text { font-size: 11px; color: #fca5a5; flex: 1; }',
+            '.' + PREFIX + '-confirm-yes { font-size: 11px; padding: 3px 10px; border-radius: 4px; border: none; background: #ef4444; color: #fff; cursor: pointer; }',
+            '.' + PREFIX + '-confirm-no { font-size: 11px; padding: 3px 10px; border-radius: 4px; border: 1px solid rgba(255,255,255,0.15); background: none; color: #cbd5e1; cursor: pointer; }',
+
+            /* dot */
+            '.' + PREFIX + '-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }',
+
+            /* states */
+            '.' + PREFIX + '-loading { display: flex; align-items: center; justify-content: center; height: 100%; color: #64748b; font-size: 12px; }',
+            '.' + PREFIX + '-error { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; color: #f87171; font-size: 12px; gap: 6px; }',
+            '.' + PREFIX + '-error-btn { font-size: 11px; padding: 3px 10px; border-radius: 4px; border: 1px solid rgba(239,68,68,0.3); background: rgba(239,68,68,0.1); color: #f87171; cursor: pointer; }',
+            '.' + PREFIX + '-empty { display: flex; align-items: center; justify-content: center; height: 100%; color: #64748b; font-size: 12px; }'
+        ].join('\n');
+        var style = document.createElement('style');
+        style.id = PREFIX + '-style';
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    /* ================================================================
+     *  数据层
+     * ================================================================ */
+    function fetchAgents(cb) {
+        HermesClient.cachedGet('agents:list', function () {
+            return HermesClient.get('/api/agents');
+        }).then(function (res) {
+            var agents = Array.isArray(res) ? res : (res && res.agents ? res.agents : []);
+            cb(null, agents);
+        }).catch(function (err) {
+            cb(err);
+        });
+    }
+
+    function terminateAgent(id, cb) {
+        HermesClient.post('/api/agents/' + id + '/terminate').then(function () {
+            HermesClient.invalidateCache && HermesClient.invalidateCache('agents:list');
+            cb(null);
+        }).catch(function (err) {
+            cb(err);
+        });
+    }
+
+    /* ================================================================
+     *  Small (1x1)
+     * ================================================================ */
+    function renderSmall(container, agents) {
+        var count = runningCount(agents);
+        container.innerHTML =
+            '<div class="' + PREFIX + '-small" data-action="open-overlay">' +
+                '<span class="' + PREFIX + '-small-icon">\u{1F916}</span>' +
+                '<span class="' + PREFIX + '-small-label">AI\u52A9\u624B</span>' +
+                (count > 0 ? '<span class="' + PREFIX + '-small-badge">' + count + '</span>' : '') +
+            '</div>';
+    }
+
+    /* ================================================================
+     *  Medium (2x1)
+     * ================================================================ */
+    function renderMedium(container, agents) {
+        var running = [];
+        for (var i = 0; i < agents.length; i++) {
+            if (agents[i].status === 'running') running.push(agents[i]);
+        }
+
+        var html = '<div class="' + PREFIX + '-medium">';
+        html += '<div class="' + PREFIX + '-medium-header">';
+        html += '<div class="' + PREFIX + '-medium-title"><span>\u{1F916}</span> AI\u52A9\u624B</div>';
+        html += '<span style="font-size:11px;color:#64748b">' + running.length + ' \u8FD0\u884C\u4E2D</span>';
+        html += '</div>';
+
+        if (running.length === 0) {
+            html += '<div class="' + PREFIX + '-medium-empty">\u6682\u65E0\u8FD0\u884C\u4E2D\u7684 Agent</div>';
+        } else {
+            html += '<div class="' + PREFIX + '-medium-list">';
+            for (var j = 0; j < running.length; j++) {
+                var a = running[j];
+                var pct = typeof a.progress === 'number' ? a.progress : 0;
+                html += '<div class="' + PREFIX + '-medium-item" data-action="open-detail" data-agent-id="' + esc(a.id) + '">';
+                html += '<span class="' + PREFIX + '-medium-item-name">' + esc(a.name) + '</span>';
+                html += '<div class="' + PREFIX + '-medium-item-bar"><div class="' + PREFIX + '-medium-item-bar-fill" style="width:' + pct + '%;background:' + progressColor(pct) + '"></div></div>';
+                html += '<span class="' + PREFIX + '-medium-item-status">' + pct + '%</span>';
+                html += '</div>';
+            }
+            html += '</div>';
+        }
+        html += '</div>';
+        container.innerHTML = html;
+    }
+
+    /* ================================================================
+     *  Large (2x2)
+     * ================================================================ */
+    function renderLarge(container, agents, tab) {
+        var running = [];
+        var others = [];
+        for (var i = 0; i < agents.length; i++) {
+            if (agents[i].status === 'running') running.push(agents[i]);
+            else others.push(agents[i]);
+        }
+
+        var showRunning = tab === 'running';
+        var list = showRunning ? running : agents;
+
+        var html = '<div class="' + PREFIX + '-large">';
+        html += '<div class="' + PREFIX + '-large-header">';
+        html += '<div class="' + PREFIX + '-large-title"><span>\u{1F916}</span> AI\u52A9\u624B</div>';
+        html += '<div class="' + PREFIX + '-large-tabs">';
+        html += '<button class="' + PREFIX + '-large-tab' + (showRunning ? ' active' : '') + '" data-action="tab" data-tab="running">\u8FD0\u884C\u4E2D (' + running.length + ')</button>';
+        html += '<button class="' + PREFIX + '-large-tab' + (!showRunning ? ' active' : '') + '" data-action="tab" data-tab="all">\u5168\u90E8 (' + agents.length + ')</button>';
+        html += '</div></div>';
+
+        html += '<div class="' + PREFIX + '-large-body">';
+        if (list.length === 0) {
+            html += '<div class="' + PREFIX + '-empty">' + (showRunning ? '\u6682\u65E0\u8FD0\u884C\u4E2D\u7684 Agent' : '\u6682\u65E0 Agent') + '</div>';
+        } else {
+            if (showRunning) {
+                html += '<div class="' + PREFIX + '-large-section-title">\u8FD0\u884C\u4E2D</div>';
+                for (var r = 0; r < list.length; r++) {
+                    html += renderLargeAgentItem(list[r], true);
+                }
+            } else {
+                if (running.length > 0) {
+                    html += '<div class="' + PREFIX + '-large-section-title">\u8FD0\u884C\u4E2D</div>';
+                    for (var r2 = 0; r2 < running.length; r2++) {
+                        html += renderLargeAgentItem(running[r2], true);
+                    }
+                }
+                if (others.length > 0) {
+                    html += '<div class="' + PREFIX + '-large-section-title">\u5176\u4ED6</div>';
+                    for (var o = 0; o < others.length; o++) {
+                        html += renderLargeAgentItem(others[o], false);
+                    }
+                }
+            }
+        }
+        html += '</div></div>';
+        container.innerHTML = html;
+    }
+
+    function renderLargeAgentItem(a, isRunning) {
+        var si = statusInfo(a.status);
+        var pct = typeof a.progress === 'number' ? a.progress : 0;
+        var html = '<div class="' + PREFIX + '-large-agent" data-action="open-detail" data-agent-id="' + esc(a.id) + '">';
+        html += '<div class="' + PREFIX + '-large-agent-info">';
+        html += '<div class="' + PREFIX + '-large-agent-name">' + esc(a.name) + '</div>';
+        html += '<div class="' + PREFIX + '-large-agent-meta">';
+        html += '<span class="' + PREFIX + '-type-badge">' + esc(a.type) + '</span>';
+        if (a.currentTask) {
+            html += '<span class="' + PREFIX + '-large-agent-task">' + esc(truncate(a.currentTask, 30)) + '</span>';
+        }
+        html += '</div>';
+        if (isRunning) {
+            html += '<div class="' + PREFIX + '-large-agent-bar"><div class="' + PREFIX + '-large-agent-bar-fill" style="width:' + pct + '%;background:' + progressColor(pct) + '"></div></div>';
+        }
+        html += '</div>';
+        html += '<div class="' + PREFIX + '-large-agent-status">';
+        html += '<span class="' + PREFIX + '-dot" style="background:' + si.color + '"></span>';
+        html += '<span style="color:' + si.color + '">' + si.label + '</span>';
+        if (!isRunning && a.startTime) {
+            html += '<span class="' + PREFIX + '-large-agent-time">' + formatTime(a.startTime) + '</span>';
+        }
+        html += '</div>';
+        if (isRunning) {
+            html += '<button class="' + PREFIX + '-btn-terminate" data-action="terminate" data-agent-id="' + esc(a.id) + '" onclick="event.stopPropagation()">\u7EC8\u6B62</button>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    /* ================================================================
+     *  XLarge (full overlay) — list state
+     * ================================================================ */
+    function renderXLargeList(container, agents, filter) {
+        var filtered = agents;
+        if (filter === 'running') {
+            filtered = [];
+            for (var i = 0; i < agents.length; i++) {
+                if (agents[i].status === 'running') filtered.push(agents[i]);
+            }
+        } else if (filter === 'completed') {
+            filtered = [];
+            for (var j = 0; j < agents.length; j++) {
+                if (agents[j].status === 'completed') filtered.push(agents[j]);
+            }
+        } else if (filter === 'failed') {
+            filtered = [];
+            for (var k = 0; k < agents.length; k++) {
+                if (agents[k].status === 'failed') filtered.push(agents[k]);
+            }
+        }
+
+        var rc = runningCount(agents);
+
+        var html = '<div class="' + PREFIX + '-xlarge">';
+        html += '<div class="' + PREFIX + '-xlarge-header">';
+        html += '<div class="' + PREFIX + '-xlarge-title"><span>\u{1F916}</span> AI \u52A9\u624B';
+        if (rc > 0) html += '<span class="' + PREFIX + '-small-badge">' + rc + '</span>';
+        html += '</div>';
+        html += '<div class="' + PREFIX + '-xlarge-actions">';
+        html += '<button class="' + PREFIX + '-btn-refresh" data-action="refresh">\u{1F504} \u5237\u65B0</button>';
+        html += '</div></div>';
+
+        html += '<div class="' + PREFIX + '-xlarge-filters">';
+        var filters = [
+            { key: 'all', label: '\u5168\u90E8' },
+            { key: 'running', label: '\u8FD0\u884C\u4E2D' },
+            { key: 'completed', label: '\u5DF2\u5B8C\u6210' },
+            { key: 'failed', label: '\u5DF2\u5931\u8D25' }
+        ];
+        for (var f = 0; f < filters.length; f++) {
+            var fc = filters[f];
+            html += '<button class="' + PREFIX + '-xlarge-filter' + (filter === fc.key ? ' active' : '') + '" data-action="filter" data-filter="' + fc.key + '">' + fc.label + '</button>';
+        }
+        html += '</div>';
+
+        html += '<div class="' + PREFIX + '-xlarge-grid">';
+        if (filtered.length === 0) {
+            html += '<div class="' + PREFIX + '-empty" style="grid-column:1/-1">\u6682\u65E0\u6570\u636E</div>';
+        } else {
+            for (var m = 0; m < filtered.length; m++) {
+                html += renderXLargeAgentCard(filtered[m]);
+            }
+        }
+        html += '</div></div>';
+        container.innerHTML = html;
+    }
+
+    function renderXLargeAgentCard(a) {
+        var si = statusInfo(a.status);
+        var pct = typeof a.progress === 'number' ? a.progress : 0;
+        var isRunning = a.status === 'running';
+
+        var html = '<div class="' + PREFIX + '-agent-card" data-action="view-detail" data-agent-id="' + esc(a.id) + '">';
+        html += '<div class="' + PREFIX + '-agent-card-head">';
+        html += '<span class="' + PREFIX + '-agent-card-name">' + esc(a.name) + '</span>';
+        html += '<span class="' + PREFIX + '-status-badge" style="background:' + si.color + '22;color:' + si.color + '">' + si.label + '</span>';
+        html += '</div>';
+        html += '<span class="' + PREFIX + '-type-badge">' + esc(a.type) + '</span>';
+        if (a.currentTask) {
+            html += '<div class="' + PREFIX + '-agent-card-task">' + esc(truncate(a.currentTask, 50)) + '</div>';
+        }
+        if (a.sessionId) {
+            html += '<div class="' + PREFIX + '-agent-card-session">Session: ' + esc(a.sessionId) + '</div>';
+        }
+        if (a.startTime) {
+            html += '<div class="' + PREFIX + '-agent-card-time">' + formatTime(a.startTime) + '</div>';
+        }
+        if (isRunning) {
+            html += '<div class="' + PREFIX + '-agent-card-progress"><div class="' + PREFIX + '-agent-card-progress-fill" style="width:' + pct + '%;background:' + progressColor(pct) + '"></div></div>';
+            html += '<div class="' + PREFIX + '-agent-card-actions">';
+            html += '<button class="' + PREFIX + '-btn-terminate" data-action="terminate" data-agent-id="' + esc(a.id) + '" onclick="event.stopPropagation()">\u7EC8\u6B62</button>';
+            html += '</div>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    /* ================================================================
+     *  XLarge — detail state
+     * ================================================================ */
+    function renderXLargeDetail(container, agent) {
+        if (!agent) {
+            container.innerHTML = '<div class="' + PREFIX + '-empty">\u672A\u627E\u5230 Agent \u4FE1\u606F</div>';
+            return;
+        }
+        var si = statusInfo(agent.status);
+        var pct = typeof agent.progress === 'number' ? agent.progress : 0;
+        var isRunning = agent.status === 'running';
+
+        var html = '<div class="' + PREFIX + '-detail">';
+        html += '<div class="' + PREFIX + '-detail-header">';
+        html += '<button class="' + PREFIX + '-btn-back" data-action="back">\u2190 \u8FD4\u56DE</button>';
+        html += '<span class="' + PREFIX + '-detail-name">' + esc(agent.name) + '</span>';
+        html += '<span class="' + PREFIX + '-status-badge" style="background:' + si.color + '22;color:' + si.color + '">' + si.label + '</span>';
+        html += '</div>';
+
+        html += '<div class="' + PREFIX + '-detail-body">';
+        html += '<div class="' + PREFIX + '-detail-section">';
+        html += '<div class="' + PREFIX + '-detail-section-title">\u57FA\u672C\u4FE1\u606F</div>';
+        html += '<div class="' + PREFIX + '-detail-row"><span class="' + PREFIX + '-detail-label">\u7C7B\u578B</span><span class="' + PREFIX + '-type-badge">' + esc(agent.type) + '</span></div>';
+        html += '<div class="' + PREFIX + '-detail-row"><span class="' + PREFIX + '-detail-label">\u5F53\u524D\u4EFB\u52A1</span><span class="' + PREFIX + '-detail-value">' + (esc(agent.currentTask) || '--') + '</span></div>';
+        html += '<div class="' + PREFIX + '-detail-row"><span class="' + PREFIX + '-detail-label">Session ID</span><span class="' + PREFIX + '-detail-value" style="font-family:monospace;font-size:12px">' + (esc(agent.sessionId) || '--') + '</span></div>';
+        html += '<div class="' + PREFIX + '-detail-row"><span class="' + PREFIX + '-detail-label">\u542F\u52A8\u65F6\u95F4</span><span class="' + PREFIX + '-detail-value">' + formatTime(agent.startTime) + '</span></div>';
+        html += '</div>';
+
+        html += '<div class="' + PREFIX + '-detail-section">';
+        html += '<div class="' + PREFIX + '-detail-section-title">\u8FDB\u5EA6</div>';
+        html += '<div class="' + PREFIX + '-detail-progress"><div class="' + PREFIX + '-detail-progress-fill" style="width:' + pct + '%;background:' + progressColor(pct) + '"></div></div>';
+        html += '<div class="' + PREFIX + '-detail-progress-text">' + pct + '%</div>';
+        html += '</div>';
+
+        if (isRunning) {
+            html += '<div class="' + PREFIX + '-detail-terminate">';
+            html += '<button class="' + PREFIX + '-btn-terminate-lg" data-action="terminate" data-agent-id="' + esc(agent.id) + '">\u7EC8\u6B62 Agent</button>';
+            html += '</div>';
+        }
+        html += '</div></div>';
+        container.innerHTML = html;
+    }
+
+    /* ================================================================
+     *  Card 实例管理
+     * ================================================================ */
+    var instances = {};
+
+    function CardInstance(el, size) {
+        this.el = el;
+        this.size = size;
+        this.agents = [];
+        this.loading = false;
+        this.error = null;
+        this.timer = null;
+        this.detailTimer = null;
+        /* large tab */
+        this.tab = 'running';
+        /* xlarge state */
+        this.filter = 'all';
+        this.state = 'list';
+        this.detailAgentId = null;
+        this.confirmId = null;
+    }
+
+    CardInstance.prototype.init = function () {
+        var self = this;
+        this.el.addEventListener('click', function (e) {
+            self.handleClick(e);
+        });
+        this.refresh();
+        this._sseHandler = function () { self.refresh(); };
+        Bus.on('sse:agent.*', this._sseHandler);
+    };
+
+    CardInstance.prototype.destroy = function () {
+        if (this.timer) { clearInterval(this.timer); this.timer = null; }
+        if (this.detailTimer) { clearInterval(this.detailTimer); this.detailTimer = null; }
+        if (this._sseHandler) { Bus.off('sse:agent.*', this._sseHandler); }
+    };
+
+    CardInstance.prototype.refresh = function () {
+        var self = this;
+        if (this.loading) return;
+        this.loading = true;
+        this.renderLoading();
+        fetchAgents(function (err, agents) {
+            self.loading = false;
+            if (err) {
+                self.error = err;
+                self.renderError();
+                return;
+            }
+            self.error = null;
+            self.agents = agents;
+            self.render();
+            self.manageAutoRefresh();
+        });
+    };
+
+    CardInstance.prototype.refreshDetail = function () {
+        var self = this;
+        if (!this.detailAgentId) return;
+        fetchAgents(function (err, agents) {
+            if (err) return;
+            self.agents = agents;
+            var agent = null;
+            for (var i = 0; i < agents.length; i++) {
+                if (agents[i].id === self.detailAgentId) { agent = agents[i]; break; }
+            }
+            if (agent && agent.status === 'running') {
+                renderXLargeDetail(self.el, agent);
+            } else if (agent) {
+                renderXLargeDetail(self.el, agent);
+                if (self.detailTimer) { clearInterval(self.detailTimer); self.detailTimer = null; }
+            }
+        });
+    };
+
+    CardInstance.prototype.manageAutoRefresh = function () {
+        var hasRunning = runningCount(this.agents) > 0;
+        if (hasRunning && !this.timer && (this.size === 'medium' || this.size === 'large')) {
+            var self = this;
+            this.timer = setInterval(function () { self.refresh(); }, REFRESH_INTERVAL);
+        } else if (!hasRunning && this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    };
+
+    CardInstance.prototype.renderLoading = function () {
+        this.el.innerHTML = '<div class="' + PREFIX + '-loading">\u52A0\u8F7D\u4E2D...</div>';
+    };
+
+    CardInstance.prototype.renderError = function () {
+        this.el.innerHTML =
+            '<div class="' + PREFIX + '-error">' +
+                '<span>\u52A0\u8F7D\u5931\u8D25</span>' +
+                '<button class="' + PREFIX + '-error-btn" data-action="retry">\u91CD\u8BD5</button>' +
+            '</div>';
+    };
+
+    CardInstance.prototype.render = function () {
+        switch (this.size) {
+            case 'small':  renderSmall(this.el, this.agents); break;
+            case 'medium': renderMedium(this.el, this.agents); break;
+            case 'large':  renderLarge(this.el, this.agents, this.tab); break;
+            case 'xlarge':
+                if (this.state === 'list') renderXLargeList(this.el, this.agents, this.filter);
+                break;
+        }
+    };
+
+    CardInstance.prototype.handleClick = function (e) {
+        var target = e.target.closest('[data-action]');
+        if (!target) return;
+        var action = target.getAttribute('data-action');
+        var agentId = target.getAttribute('data-agent-id');
+
+        switch (action) {
+            case 'open-overlay':
+                CardOverlay.open('agent-card');
+                break;
+            case 'open-detail':
+                if (agentId) CardOverlay.open('agent-card', { agentId: agentId });
+                break;
+            case 'tab':
+                this.tab = target.getAttribute('data-tab') || 'running';
+                this.render();
+                break;
+            case 'filter':
+                this.filter = target.getAttribute('data-filter') || 'all';
+                this.state = 'list';
+                this.render();
+                break;
+            case 'refresh':
+                this.refresh();
+                break;
+            case 'retry':
+                this.refresh();
+                break;
+            case 'view-detail':
+                if (agentId) this.showDetail(agentId);
+                break;
+            case 'back':
+                this.hideDetail();
+                break;
+            case 'terminate':
+                if (agentId) this.handleTerminate(agentId, target);
+                break;
+            case 'confirm-terminate':
+                this.doTerminate(this.confirmId);
+                break;
+            case 'cancel-terminate':
+                this.confirmId = null;
+                this.render();
+                break;
+        }
+    };
+
+    CardInstance.prototype.showDetail = function (agentId) {
+        this.state = 'detail';
+        this.detailAgentId = agentId;
+        var agent = null;
+        for (var i = 0; i < this.agents.length; i++) {
+            if (this.agents[i].id === agentId) { agent = this.agents[i]; break; }
+        }
+        renderXLargeDetail(this.el, agent);
+
+        if (CardOverlay && CardOverlay.pushView) {
+            CardOverlay.pushView({ onBack: function () {}.bind(this) });
+        }
+
+        if (agent && agent.status === 'running') {
+            var self = this;
+            if (this.detailTimer) clearInterval(this.detailTimer);
+            this.detailTimer = setInterval(function () { self.refreshDetail(); }, DETAIL_REFRESH_INTERVAL);
+        }
+    };
+
+    CardInstance.prototype.hideDetail = function () {
+        if (this.detailTimer) { clearInterval(this.detailTimer); this.detailTimer = null; }
+        this.state = 'list';
+        this.detailAgentId = null;
+        this.confirmId = null;
+        this.render();
+
+        if (CardOverlay && CardOverlay.popView) {
+            CardOverlay.popView();
+        }
+    };
+
+    CardInstance.prototype.handleTerminate = function (agentId, btn) {
+        var self = this;
+        this.confirmId = agentId;
+        /* Insert inline confirm bar after button */
+        var existing = btn.parentNode.querySelector('.' + PREFIX + '-confirm-bar');
+        if (existing) { existing.remove(); }
+        var bar = document.createElement('div');
+        bar.className = PREFIX + '-confirm-bar';
+        bar.innerHTML =
+            '<span class="' + PREFIX + '-confirm-text">\u786E\u5B9A\u8981\u7EC8\u6B62\u8BE5 Agent \u5417\uFF1F</span>' +
+            '<button class="' + PREFIX + '-confirm-yes" data-action="confirm-terminate">\u786E\u5B9A</button>' +
+            '<button class="' + PREFIX + '-confirm-no" data-action="cancel-terminate">\u53D6\u6D88</button>';
+        btn.parentNode.appendChild(bar);
+    };
+
+    CardInstance.prototype.doTerminate = function (agentId) {
+        var self = this;
+        this.confirmId = null;
+        terminateAgent(agentId, function (err) {
+            if (err) {
+                /* show error inline or just refresh */
+            }
+            self.refresh();
+        });
+    };
+
+    /* ================================================================
+     *  Mount 函数
+     * ================================================================ */
+    function mount(el, opts) {
+        injectCSS();
+        var size = (opts && opts.size) || 'medium';
+        var inst = new CardInstance(el, size);
+        instances[inst._uid = '_' + Math.random().toString(36).slice(2, 9)] = inst;
+        inst.init();
+        return {
+            destroy: function () { inst.destroy(); delete instances[inst._uid]; },
+            resize: function (newSize) { inst.size = newSize; inst.render(); }
+        };
+    }
+
+    /* ================================================================
+     *  Entry mount (small)
+     * ================================================================ */
+    function mountEntry(el) {
+        return mount(el, { size: 'small' });
+    }
+
+    /* ================================================================
+     *  Registration
+     * ================================================================ */
+    WidgetRegistry.register('agent-card', {
+        type: 'data',
+        label: 'AI\u52A9\u624B',
+        icon: '\u{1F916}',
+        description: 'AI Agent \u7BA1\u7406\uFF0C\u67E5\u770B\u8FD0\u884C\u72B6\u6001\u548C\u7EC8\u6B62\u4EFB\u52A1',
+        defaultSize: { w: 2, h: 1 },
+        category: 'data',
+        mount: mount
+    });
+
+    WidgetRegistry.register('agent-entry', {
+        type: 'entry',
+        label: 'AI\u52A9\u624B\u5165\u53E3',
+        icon: '\u{1F916}',
+        description: 'AI\u52A9\u624B\u5FEB\u901F\u5165\u53E3',
+        defaultSize: { w: 1, h: 1 },
+        category: 'entries',
+        mount: mountEntry
+    });
+
+})();

--- a/frontend/js/workspace/widgets/cards/CronCard.js
+++ b/frontend/js/workspace/widgets/cards/CronCard.js
@@ -1,0 +1,604 @@
+;(function() {
+  'use strict';
+
+  var CSS_ID = 'cron-card-css';
+  var PREFIX = 'cc';
+
+  // ── CSS ──────────────────────────────────────────────────────────
+  var css = [
+    '.' + PREFIX + '-wrap{font-family:var(--font-body,system-ui,sans-serif);color:var(--text-primary,#e0e0e0);height:100%;display:flex;flex-direction:column;overflow:hidden;background:var(--card-bg,#1a1a2e);border-radius:12px;padding:12px;box-sizing:border-box;position:relative}',
+    '.' + PREFIX + '-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;flex-shrink:0}',
+    '.' + PREFIX + '-header h3{margin:0;font-size:14px;font-weight:600;display:flex;align-items:center;gap:6px}',
+    '.' + PREFIX + '-header .count{font-size:11px;color:var(--text-secondary,#888);background:var(--bg-tertiary,#2a2a3e);padding:2px 8px;border-radius:10px}',
+    '.' + PREFIX + '-small{display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;gap:4px;transition:transform .15s}',
+    '.' + PREFIX + '-small:hover{transform:scale(1.05)}',
+    '.' + PREFIX + '-small .icon{font-size:28px}',
+    '.' + PREFIX + '-small .label{font-size:12px;color:var(--text-secondary,#888)}',
+    '.' + PREFIX + '-small .num{font-size:20px;font-weight:700}',
+    '.' + PREFIX + '-list{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px}',
+    '.' + PREFIX + '-list::-webkit-scrollbar{width:4px}',
+    '.' + PREFIX + '-list::-webkit-scrollbar-thumb{background:var(--bg-tertiary,#2a2a3e);border-radius:2px}',
+    '.' + PREFIX + '-item{background:var(--bg-secondary,#22223a);border-radius:8px;padding:8px 10px;display:flex;flex-direction:column;gap:4px;transition:background .15s}',
+    '.' + PREFIX + '-item:hover{background:var(--bg-hover,#2e2e4a)}',
+    '.' + PREFIX + '-item .row{display:flex;align-items:center;justify-content:space-between;gap:6px}',
+    '.' + PREFIX + '-item .name{font-size:12px;font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+    '.' + PREFIX + '-item .cron{font-size:10px;color:var(--text-secondary,#888);font-family:var(--font-mono,monospace)}',
+    '.' + PREFIX + '-item .meta{display:flex;align-items:center;gap:6px;font-size:10px;color:var(--text-secondary,#888)}',
+    '.' + PREFIX + '-dot{width:7px;height:7px;border-radius:50%;flex-shrink:0}',
+    '.' + PREFIX + '-dot-active{background:#6ecf6e;box-shadow:0 0 4px #6ecf6e}',
+    '.' + PREFIX + '-dot-paused{background:#cfcf6e;box-shadow:0 0 4px #cfcf6e}',
+    '.' + PREFIX + '-dot-error{background:#cf6e6e;box-shadow:0 0 4px #cf6e6e}',
+    '.' + PREFIX + '-status{font-size:9px;padding:1px 6px;border-radius:8px;font-weight:600;text-transform:uppercase}',
+    '.' + PREFIX + '-status-active{background:#2d4a2d;color:#6ecf6e}',
+    '.' + PREFIX + '-status-paused{background:#4a4a2d;color:#cfcf6e}',
+    '.' + PREFIX + '-status-error{background:#4a2d2d;color:#cf6e6e}',
+    '.' + PREFIX + '-msg-preview{font-size:10px;color:var(--text-secondary,#888);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px}',
+    '.' + PREFIX + '-toolbar{display:flex;gap:6px;margin-bottom:8px;flex-shrink:0;flex-wrap:wrap}',
+    '.' + PREFIX + '-tabs{display:flex;gap:4px}',
+    '.' + PREFIX + '-tab{font-size:10px;padding:3px 8px;border-radius:6px;border:1px solid var(--border,#333);background:transparent;color:var(--text-secondary,#888);cursor:pointer;transition:all .15s}',
+    '.' + PREFIX + '-tab.active{background:var(--accent,#6c63ff);color:#fff;border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-actions{display:flex;gap:4px;flex-wrap:wrap}',
+    '.' + PREFIX + '-btn{font-size:10px;padding:3px 8px;border-radius:6px;border:1px solid var(--border,#333);background:transparent;color:var(--text-secondary,#888);cursor:pointer;transition:all .15s;white-space:nowrap}',
+    '.' + PREFIX + '-btn:hover{background:var(--bg-hover,#2e2e4a);color:var(--text-primary,#e0e0e0)}',
+    '.' + PREFIX + '-btn-primary{background:var(--accent,#6c63ff);color:#fff;border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-btn-primary:hover{opacity:.85}',
+    '.' + PREFIX + '-btn-danger{color:#cf6e6e;border-color:#4a2d2d}',
+    '.' + PREFIX + '-btn-danger:hover{background:#4a2d2d;color:#ff8888}',
+    '.' + PREFIX + '-btn-warning{color:#cfcf6e;border-color:#4a4a2d}',
+    '.' + PREFIX + '-btn-warning:hover{background:#4a4a2d}',
+    '.' + PREFIX + '-detail{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:10px}',
+    '.' + PREFIX + '-detail-header{display:flex;align-items:center;gap:8px;margin-bottom:4px}',
+    '.' + PREFIX + '-detail-header .back{cursor:pointer;font-size:14px;padding:4px 8px;border-radius:6px;background:var(--bg-secondary,#22223a);border:none;color:var(--text-primary,#e0e0e0);transition:background .15s}',
+    '.' + PREFIX + '-detail-header .back:hover{background:var(--bg-hover,#2e2e4a)}',
+    '.' + PREFIX + '-form{display:flex;flex-direction:column;gap:8px;padding:10px;background:var(--bg-secondary,#22223a);border-radius:8px}',
+    '.' + PREFIX + '-form label{font-size:11px;color:var(--text-secondary,#888);display:flex;flex-direction:column;gap:3px}',
+    '.' + PREFIX + '-form input,' + '.' + PREFIX + '-form textarea,' + '.' + PREFIX + '-form select{background:var(--bg-tertiary,#2a2a3e);border:1px solid var(--border,#333);border-radius:6px;padding:6px 8px;font-size:12px;color:var(--text-primary,#e0e0e0);outline:none;box-sizing:border-box;font-family:inherit;resize:vertical}',
+    '.' + PREFIX + '-form textarea{min-height:60px}',
+    '.' + PREFIX + '-form input:focus,' + '.' + PREFIX + '-form textarea:focus,' + '.' + PREFIX + '-form select:focus{border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-form-actions{display:flex;gap:6px;justify-content:flex-end;margin-top:4px}',
+    '.' + PREFIX + '-confirm-bar{display:flex;align-items:center;gap:8px;padding:8px 10px;background:#4a2d2d;border-radius:8px;font-size:12px}',
+    '.' + PREFIX + '-confirm-bar span{flex:1}',
+    '.' + PREFIX + '-confirm-bar-warn{background:#4a4a2d}',
+    '.' + PREFIX + '-empty{flex:1;display:flex;align-items:center;justify-content:center;color:var(--text-secondary,#888);font-size:12px}',
+    '.' + PREFIX + '-loading{flex:1;display:flex;align-items:center;justify-content:center}',
+    '.' + PREFIX + '-loading .spinner{width:24px;height:24px;border:2px solid var(--border,#333);border-top-color:var(--accent,#6c63ff);border-radius:50%;animation:' + PREFIX + '-spin .6s linear infinite}',
+    '@keyframes ' + PREFIX + '-spin{to{transform:rotate(360deg)}}',
+    '.' + PREFIX + '-error{flex:1;display:flex;align-items:center;justify-content:center;color:#cf6e6e;font-size:12px}'
+  ].join('\n');
+
+  // ── Helpers ──────────────────────────────────────────────────────
+  function injectCSS() {
+    if (document.getElementById(CSS_ID)) return;
+    var el = document.createElement('style');
+    el.id = CSS_ID;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+
+  function truncate(str, len) {
+    if (!str) return '';
+    return str.length > len ? str.substring(0, len) + '...' : str;
+  }
+
+  function formatTime(ts) {
+    if (!ts) return '--';
+    var d = new Date(ts);
+    return d.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+  }
+
+  function escHtml(s) {
+    if (!s) return '';
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  function statusLabel(s) {
+    var map = { active: '活跃', paused: '暂停', error: '错误' };
+    return map[s] || s || '未知';
+  }
+
+  // ── Card ─────────────────────────────────────────────────────────
+  function CronCard(container, options) {
+    this.container = container;
+    this.options = options || {};
+    this.size = this.options.size || 'medium';
+    this.jobs = [];
+    this.loading = false;
+    this.error = null;
+    this.filter = 'all';
+    this.selectedId = null;
+    this.editing = false;
+    this.showForm = false;
+    this.confirmDelete = false;
+    this.confirmToggle = false;
+    this.confirmTrigger = false;
+    this.formData = { name: '', cron_expression: '', message: '', timezone: 'Asia/Shanghai' };
+    this.sseSub = null;
+    this._bound = {};
+  }
+
+  CronCard.prototype.init = function() {
+    injectCSS();
+    this.container.innerHTML = '';
+    this.container.classList.add(PREFIX + '-wrap');
+    this.container.setAttribute('data-widget', 'cron-card');
+    this.bindEvents();
+    this.loadData();
+    this.subscribeSSE();
+  };
+
+  CronCard.prototype.bindEvents = function() {
+    var self = this;
+    this._bound.handleClick = function(e) {
+      var action = e.target.closest('[data-action]');
+      if (!action) return;
+      var act = action.getAttribute('data-action');
+      var id = action.getAttribute('data-id');
+      self.handleAction(act, id, e);
+    };
+    this.container.addEventListener('click', this._bound.handleClick);
+  };
+
+  CronCard.prototype.handleAction = function(action, id, e) {
+    switch (action) {
+      case 'open-overlay':
+        CardOverlay.open({ widget: 'cron-card', title: '定时任务管理' });
+        break;
+      case 'back':
+        this.selectedId = null;
+        this.editing = false;
+        this.showForm = false;
+        this.confirmDelete = false;
+        this.confirmToggle = false;
+        this.confirmTrigger = false;
+        this.render();
+        break;
+      case 'new':
+        this.formData = { name: '', cron_expression: '', message: '', timezone: 'Asia/Shanghai' };
+        this.showForm = true;
+        this.selectedId = null;
+        this.editing = false;
+        this.confirmDelete = false;
+        this.confirmToggle = false;
+        this.confirmTrigger = false;
+        this.render();
+        break;
+      case 'edit':
+        var job = this.getById(id);
+        if (job) {
+          this.formData = { name: job.name, cron_expression: job.cron_expression, message: job.message || '', timezone: job.timezone || 'Asia/Shanghai' };
+          this.selectedId = id;
+          this.editing = true;
+          this.showForm = false;
+          this.confirmDelete = false;
+          this.confirmToggle = false;
+          this.confirmTrigger = false;
+          this.render();
+        }
+        break;
+      case 'save':
+        this.saveJob();
+        break;
+      case 'cancel-form':
+        this.showForm = false;
+        this.editing = false;
+        this.selectedId = null;
+        this.render();
+        break;
+      case 'delete':
+        this.confirmDelete = true;
+        this.confirmToggle = false;
+        this.confirmTrigger = false;
+        this.render();
+        break;
+      case 'confirm-delete':
+        this.deleteJob(id);
+        break;
+      case 'cancel-delete':
+        this.confirmDelete = false;
+        this.render();
+        break;
+      case 'toggle':
+        this.confirmToggle = true;
+        this.confirmDelete = false;
+        this.confirmTrigger = false;
+        this.render();
+        break;
+      case 'confirm-toggle':
+        this.toggleJob(id);
+        break;
+      case 'cancel-toggle':
+        this.confirmToggle = false;
+        this.render();
+        break;
+      case 'trigger':
+        this.confirmTrigger = true;
+        this.confirmDelete = false;
+        this.confirmToggle = false;
+        this.render();
+        break;
+      case 'confirm-trigger':
+        this.triggerJob(id);
+        break;
+      case 'cancel-trigger':
+        this.confirmTrigger = false;
+        this.render();
+        break;
+      case 'filter':
+        this.filter = id;
+        this.render();
+        break;
+    }
+  };
+
+  CronCard.prototype.getById = function(id) {
+    for (var i = 0; i < this.jobs.length; i++) {
+      if (this.jobs[i].id === id) return this.jobs[i];
+    }
+    return null;
+  };
+
+  CronCard.prototype.getFiltered = function() {
+    if (this.filter === 'all') return this.jobs;
+    var f = this.filter;
+    return this.jobs.filter(function(j) { return j.status === f; });
+  };
+
+  CronCard.prototype.getActiveCount = function() {
+    var c = 0;
+    for (var i = 0; i < this.jobs.length; i++) {
+      if (this.jobs[i].status === 'active') c++;
+    }
+    return c;
+  };
+
+  // ── Data ─────────────────────────────────────────────────────────
+  CronCard.prototype.loadData = function() {
+    var self = this;
+    this.loading = true;
+    this.error = null;
+    this.render();
+
+    DataService.fetch('/api/cron').then(function(data) {
+      self.jobs = data || [];
+      self.loading = false;
+      self.render();
+    }).catch(function(err) {
+      self.error = '加载定时任务失败: ' + (err.message || '未知错误');
+      self.loading = false;
+      self.render();
+    });
+  };
+
+  CronCard.prototype.saveJob = function() {
+    var self = this;
+    var form = this.container.querySelector('.' + PREFIX + '-form');
+    if (!form) return;
+    var name = form.querySelector('[name="name"]').value.trim();
+    var cron_expression = form.querySelector('[name="cron_expression"]').value.trim();
+    var message = form.querySelector('[name="message"]').value.trim();
+    var timezone = form.querySelector('[name="timezone"]').value;
+
+    if (!name || !cron_expression) return;
+
+    var payload = { name: name, cron_expression: cron_expression, message: message || undefined, timezone: timezone || 'Asia/Shanghai' };
+
+    var isEdit = this.editing && this.selectedId;
+    var url = isEdit ? '/api/cron/' + this.selectedId : '/api/cron';
+    var method = isEdit ? 'PUT' : 'POST';
+
+    DataService.fetch(url, { method: method, body: JSON.stringify(payload) }).then(function() {
+      self.showForm = false;
+      self.editing = false;
+      self.selectedId = null;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '保存失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  CronCard.prototype.deleteJob = function(id) {
+    var self = this;
+    DataService.fetch('/api/cron/' + id, { method: 'DELETE' }).then(function() {
+      self.confirmDelete = false;
+      self.selectedId = null;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '删除失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  CronCard.prototype.toggleJob = function(id) {
+    var self = this;
+    var job = this.getById(id);
+    if (!job) return;
+    var endpoint = job.enabled ? '/api/cron/' + id + '/pause' : '/api/cron/' + id + '/resume';
+    DataService.fetch(endpoint, { method: 'PUT' }).then(function() {
+      self.confirmToggle = false;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '操作失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  CronCard.prototype.triggerJob = function(id) {
+    var self = this;
+    DataService.fetch('/api/cron/' + id + '/trigger', { method: 'POST' }).then(function() {
+      self.confirmTrigger = false;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '触发失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  // ── SSE ──────────────────────────────────────────────────────────
+  CronCard.prototype.subscribeSSE = function() {
+    var self = this;
+    if (typeof Bus === 'undefined' || !Bus.subscribe) return;
+    this.sseSub = Bus.subscribe('cron', function(data) {
+      if (data && data.type === 'update') {
+        self.loadData();
+      }
+    });
+  };
+
+  // ── Render ───────────────────────────────────────────────────────
+  CronCard.prototype.render = function() {
+    if (this.loading) {
+      this.container.innerHTML = '<div class="' + PREFIX + '-loading"><div class="spinner"></div></div>';
+      return;
+    }
+    if (this.error) {
+      this.container.innerHTML = '<div class="' + PREFIX + '-error">' + escHtml(this.error) + '</div>';
+      return;
+    }
+    switch (this.size) {
+      case 'small': this.renderSmall(); break;
+      case 'medium': this.renderMedium(); break;
+      case 'large': this.renderLarge(); break;
+      case 'xlarge': this.renderXLarge(); break;
+      default: this.renderMedium();
+    }
+  };
+
+  CronCard.prototype.renderSmall = function() {
+    var count = this.getActiveCount();
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-small" data-action="open-overlay">' +
+        '<span class="icon">⏰</span>' +
+        '<span class="label">定时任务</span>' +
+        '<span class="num">' + count + '</span>' +
+      '</div>';
+  };
+
+  CronCard.prototype.renderMedium = function() {
+    var active = this.jobs.filter(function(j) { return j.status === 'active'; });
+    var items = '';
+    for (var i = 0; i < active.length; i++) {
+      var j = active[i];
+      items +=
+        '<div class="' + PREFIX + '-item">' +
+          '<div class="row">' +
+            '<span class="name">' + escHtml(j.name) + '</span>' +
+            '<span class="' + PREFIX + '-dot ' + PREFIX + '-dot-' + (j.status || 'active') + '"></span>' +
+          '</div>' +
+          '<div class="meta">' +
+            '<span class="cron">' + escHtml(j.cron_expression) + '</span>' +
+            '<span>下次: ' + formatTime(j.next_run) + '</span>' +
+          '</div>' +
+        '</div>';
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header">' +
+        '<h3>⏰ 定时任务 <span class="count">' + this.getActiveCount() + ' 活跃</span></h3>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无活跃任务</div>') + '</div>';
+  };
+
+  CronCard.prototype.renderLarge = function() {
+    var filtered = this.getFiltered();
+    var items = '';
+    for (var i = 0; i < filtered.length; i++) {
+      var j = filtered[i];
+      var status = j.status || 'active';
+      items +=
+        '<div class="' + PREFIX + '-item">' +
+          '<div class="row">' +
+            '<span class="name">' + escHtml(j.name) + '</span>' +
+            '<span class="' + PREFIX + '-status ' + PREFIX + '-status-' + status + '">' + statusLabel(status) + '</span>' +
+          '</div>' +
+          '<div class="meta">' +
+            '<span class="cron">' + escHtml(j.cron_expression) + '</span>' +
+            '<span>上次: ' + formatTime(j.last_run) + '</span>' +
+            '<span>下次: ' + formatTime(j.next_run) + '</span>' +
+          '</div>' +
+          '<div class="actions" style="margin-top:4px">' +
+            '<button class="' + PREFIX + '-btn" data-action="toggle" data-id="' + j.id + '">' + (j.enabled ? '暂停' : '恢复') + '</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-warning" data-action="trigger" data-id="' + j.id + '">触发</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="delete" data-id="' + j.id + '">删除</button>' +
+          '</div>' +
+        '</div>';
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header"><h3>⏰ 定时任务 <span class="count">' + this.jobs.length + '</span></h3></div>' +
+      '<div class="' + PREFIX + '-toolbar">' +
+        '<div class="' + PREFIX + '-tabs">' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'all' ? ' active' : '') + '" data-action="filter" data-id="all">全部</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'active' ? ' active' : '') + '" data-action="filter" data-id="active">活跃</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'paused' ? ' active' : '') + '" data-action="filter" data-id="paused">暂停</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'error' ? ' active' : '') + '" data-action="filter" data-id="error">错误</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无定时任务</div>') + '</div>';
+  };
+
+  CronCard.prototype.renderXLarge = function() {
+    if (this.showForm || this.editing) {
+      this.renderForm();
+      return;
+    }
+    this.renderXList();
+  };
+
+  CronCard.prototype.renderXList = function() {
+    var filtered = this.getFiltered();
+    var items = '';
+    for (var i = 0; i < filtered.length; i++) {
+      var j = filtered[i];
+      var status = j.status || 'active';
+      items +=
+        '<div class="' + PREFIX + '-item">' +
+          '<div class="row">' +
+            '<span class="name">' + escHtml(j.name) + '</span>' +
+            '<span class="' + PREFIX + '-status ' + PREFIX + '-status-' + status + '">' + statusLabel(status) + '</span>' +
+          '</div>' +
+          '<div class="meta">' +
+            '<span class="cron">' + escHtml(j.cron_expression) + '</span>' +
+            (j.message ? '<span class="' + PREFIX + '-msg-preview">' + escHtml(truncate(j.message, 40)) + '</span>' : '') +
+          '</div>' +
+          '<div class="meta">' +
+            '<span>上次: ' + formatTime(j.last_run) + '</span>' +
+            '<span>下次: ' + formatTime(j.next_run) + '</span>' +
+            (j.timezone ? '<span>时区: ' + escHtml(j.timezone) + '</span>' : '') +
+          '</div>' +
+          '<div class="actions" style="margin-top:4px">' +
+            '<button class="' + PREFIX + '-btn" data-action="toggle" data-id="' + j.id + '">' + (j.enabled ? '暂停' : '恢复') + '</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-warning" data-action="trigger" data-id="' + j.id + '">手动触发</button>' +
+            '<button class="' + PREFIX + '-btn" data-action="edit" data-id="' + j.id + '">编辑</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="delete" data-id="' + j.id + '">删除</button>' +
+          '</div>' +
+        '</div>';
+
+      if (this.confirmDelete && this.selectedId === j.id) {
+        items +=
+          '<div class="' + PREFIX + '-confirm-bar">' +
+            '<span>确认删除任务 "' + escHtml(j.name) + '"？</span>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="confirm-delete" data-id="' + j.id + '">确认</button>' +
+            '<button class="' + PREFIX + '-btn" data-action="cancel-delete">取消</button>' +
+          '</div>';
+      }
+      if (this.confirmToggle && this.selectedId === j.id) {
+        var toggleLabel = j.enabled ? '暂停' : '恢复';
+        items +=
+          '<div class="' + PREFIX + '-confirm-bar ' + PREFIX + '-confirm-bar-warn">' +
+            '<span>确认' + toggleLabel + '任务 "' + escHtml(j.name) + '"？</span>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-warning" data-action="confirm-toggle" data-id="' + j.id + '">确认</button>' +
+            '<button class="' + PREFIX + '-btn" data-action="cancel-toggle">取消</button>' +
+          '</div>';
+      }
+      if (this.confirmTrigger && this.selectedId === j.id) {
+        items +=
+          '<div class="' + PREFIX + '-confirm-bar ' + PREFIX + '-confirm-bar-warn">' +
+            '<span>确认手动触发 "' + escHtml(j.name) + '"？</span>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-warning" data-action="confirm-trigger" data-id="' + j.id + '">确认</button>' +
+            '<button class="' + PREFIX + '-btn" data-action="cancel-trigger">取消</button>' +
+          '</div>';
+      }
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header">' +
+        '<h3>⏰ 定时任务管理 <span class="count">' + this.jobs.length + '</span></h3>' +
+        '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-primary" data-action="new">新建</button>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-toolbar">' +
+        '<div class="' + PREFIX + '-tabs">' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'all' ? ' active' : '') + '" data-action="filter" data-id="all">全部</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'active' ? ' active' : '') + '" data-action="filter" data-id="active">活跃</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'paused' ? ' active' : '') + '" data-action="filter" data-id="paused">暂停</button>' +
+          '<button class="' + PREFIX + '-tab' + (this.filter === 'error' ? ' active' : '') + '" data-action="filter" data-id="error">错误</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无定时任务</div>') + '</div>';
+  };
+
+  CronCard.prototype.renderForm = function() {
+    var title = this.editing ? '编辑任务' : '新建任务';
+    var fd = this.formData;
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-detail">' +
+        '<div class="' + PREFIX + '-detail-header">' +
+          '<button class="back" data-action="cancel-form">← 返回</button>' +
+          '<h3>' + title + '</h3>' +
+        '</div>' +
+        '<div class="' + PREFIX + '-form">' +
+          '<label>任务名称<input name="name" value="' + escHtml(fd.name) + '" placeholder="例如: 每日摘要"></label>' +
+          '<label>Cron 表达式<input name="cron_expression" value="' + escHtml(fd.cron_expression) + '" placeholder="例如: 0 8 * * *"></label>' +
+          '<label>任务消息<textarea name="message">' + escHtml(fd.message) + '</textarea></label>' +
+          '<label>时区<select name="timezone">' +
+            '<option value="Asia/Shanghai"' + (fd.timezone === 'Asia/Shanghai' ? ' selected' : '') + '>Asia/Shanghai</option>' +
+            '<option value="Asia/Tokyo"' + (fd.timezone === 'Asia/Tokyo' ? ' selected' : '') + '>Asia/Tokyo</option>' +
+            '<option value="America/New_York"' + (fd.timezone === 'America/New_York' ? ' selected' : '') + '>America/New_York</option>' +
+            '<option value="America/Los_Angeles"' + (fd.timezone === 'America/Los_Angeles' ? ' selected' : '') + '>America/Los_Angeles</option>' +
+            '<option value="Europe/London"' + (fd.timezone === 'Europe/London' ? ' selected' : '') + '>Europe/London</option>' +
+            '<option value="UTC"' + (fd.timezone === 'UTC' ? ' selected' : '') + '>UTC</option>' +
+          '</select></label>' +
+          '<div class="' + PREFIX + '-form-actions">' +
+            '<button class="' + PREFIX + '-btn" data-action="cancel-form">取消</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-primary" data-action="save">保存</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+  };
+
+  // ── Resize ───────────────────────────────────────────────────────
+  CronCard.prototype.setSize = function(size) {
+    this.size = size;
+    this.selectedId = null;
+    this.editing = false;
+    this.showForm = false;
+    this.confirmDelete = false;
+    this.confirmToggle = false;
+    this.confirmTrigger = false;
+    this.render();
+  };
+
+  // ── Destroy ──────────────────────────────────────────────────────
+  CronCard.prototype.destroy = function() {
+    if (this._bound.handleClick) {
+      this.container.removeEventListener('click', this._bound.handleClick);
+    }
+    if (this.sseSub && typeof Bus !== 'undefined' && Bus.unsubscribe) {
+      Bus.unsubscribe('cron', this.sseSub);
+    }
+    this.container.innerHTML = '';
+    this.container.classList.remove(PREFIX + '-wrap');
+  };
+
+  // ── Mount ────────────────────────────────────────────────────────
+  function mount(container, options) {
+    var card = new CronCard(container, options);
+    card.init();
+    return card;
+  }
+
+  function mountEntry(container, options) {
+    var entry = new CronCard(container, Object.assign({}, options, { size: 'small' }));
+    entry.init();
+    return entry;
+  }
+
+  // ── Register ─────────────────────────────────────────────────────
+  WidgetRegistry.register('cron-card', {
+    type: 'data',
+    label: '定时任务',
+    icon: '⏰',
+    defaultSize: { w: 2, h: 1 },
+    category: 'data',
+    mount: mount
+  });
+
+  WidgetRegistry.register('cron-entry', {
+    type: 'entry',
+    label: '定时任务入口',
+    icon: '⏰',
+    defaultSize: { w: 1, h: 1 },
+    category: 'entries',
+    mount: mountEntry
+  });
+
+})();

--- a/frontend/js/workspace/widgets/cards/ExperienceCard.js
+++ b/frontend/js/workspace/widgets/cards/ExperienceCard.js
@@ -1,0 +1,590 @@
+;(function() {
+  'use strict';
+
+  var CSS_ID = 'experience-card-css';
+  var PREFIX = 'ec';
+  var API = '/api/experiences';
+  var instanceCount = 0;
+
+  /* ── CSS ─────────────────────────────────────────────── */
+  var css = [
+    '.ec-wrap{font-family:system-ui,-apple-system,sans-serif;height:100%;display:flex;flex-direction:column;overflow:hidden;color:#e0e0e0;background:#1a1a2e;border-radius:8px;box-sizing:border-box}',
+    '.ec-header{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0}',
+    '.ec-header h3{margin:0;font-size:13px;font-weight:600;display:flex;align-items:center;gap:6px}',
+    '.ec-header .ec-count{font-size:11px;color:#888;background:rgba(255,255,255,.06);padding:1px 7px;border-radius:10px}',
+    '.ec-body{flex:1;overflow-y:auto;padding:6px 8px}',
+    '.ec-body::-webkit-scrollbar{width:4px}',
+    '.ec-body::-webkit-scrollbar-thumb{background:rgba(255,255,255,.12);border-radius:2px}',
+    '.ec-search{display:flex;gap:6px;padding:6px 8px;flex-shrink:0}',
+    '.ec-search input{flex:1;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:5px 10px;color:#e0e0e0;font-size:12px;outline:none}',
+    '.ec-search input:focus{border-color:#f0a050}',
+    '.ec-filters{display:flex;gap:4px;padding:0 8px 6px;flex-shrink:0;flex-wrap:wrap}',
+    '.ec-filter-btn{font-size:11px;padding:2px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:transparent;color:#aaa;cursor:pointer;transition:.2s}',
+    '.ec-filter-btn:hover,.ec-filter-btn.active{background:#f0a050;color:#fff;border-color:#f0a050}',
+    '.ec-item{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:6px;cursor:pointer;transition:.15s;border:1px solid transparent}',
+    '.ec-item:hover{background:rgba(255,255,255,.05);border-color:rgba(255,255,255,.08)}',
+    '.ec-item .ec-title{flex:1;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
+    '.ec-severity{font-size:10px;padding:1px 6px;border-radius:8px;font-weight:600;flex-shrink:0}',
+    '.ec-severity-high{background:rgba(255,77,77,.15);color:#ff6b6b}',
+    '.ec-severity-medium{background:rgba(255,193,7,.15);color:#ffc107}',
+    '.ec-severity-low{background:rgba(76,175,80,.15);color:#66bb6a}',
+    '.ec-tool{font-size:10px;color:#888;max-width:80px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex-shrink:0}',
+    '.ec-time{font-size:10px;color:#666;flex-shrink:0}',
+    '.ec-context{font-size:11px;color:#999;max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+    '.ec-actions{display:flex;gap:4px;flex-shrink:0}',
+    '.ec-actions button{background:none;border:none;color:#888;cursor:pointer;font-size:13px;padding:2px 4px;border-radius:4px;transition:.15s}',
+    '.ec-actions button:hover{color:#e0e0e0;background:rgba(255,255,255,.1)}',
+    '.ec-actions button.danger:hover{color:#ff6b6b}',
+    '.ec-btn{font-size:11px;padding:4px 12px;border-radius:6px;border:1px solid rgba(255,255,255,.15);background:rgba(255,255,255,.06);color:#ccc;cursor:pointer;transition:.2s}',
+    '.ec-btn:hover{background:#f0a050;color:#fff;border-color:#f0a050}',
+    '.ec-btn.primary{background:#f0a050;color:#fff;border-color:#f0a050}',
+    '.ec-btn.primary:hover{background:#e09040}',
+    '.ec-btn.danger{color:#ff6b6b;border-color:rgba(255,77,77,.3)}',
+    '.ec-btn.danger:hover{background:rgba(255,77,77,.15)}',
+    '.ec-detail{padding:12px;flex:1;overflow-y:auto}',
+    '.ec-detail .ec-back{display:flex;align-items:center;gap:4px;background:none;border:none;color:#f0a050;cursor:pointer;font-size:12px;margin-bottom:10px;padding:4px 8px;border-radius:6px;transition:.15s}',
+    '.ec-detail .ec-back:hover{background:rgba(240,160,80,.1)}',
+    '.ec-detail .ec-meta{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:10px 0;font-size:12px}',
+    '.ec-detail .ec-meta dt{color:#888}',
+    '.ec-detail .ec-meta dd{color:#ccc;margin:0}',
+    '.ec-detail .ec-content{font-size:12px;line-height:1.7;color:#bbb;padding:10px;background:rgba(255,255,255,.03);border-radius:6px;margin:10px 0;white-space:pre-wrap}',
+    '.ec-form{display:flex;flex-direction:column;gap:8px;margin-top:10px}',
+    '.ec-form label{font-size:11px;color:#888}',
+    '.ec-form input,.ec-form textarea,.ec-form select{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:6px 10px;color:#e0e0e0;font-size:12px;outline:none;font-family:inherit}',
+    '.ec-form input:focus,.ec-form textarea:focus,.ec-form select:focus{border-color:#f0a050}',
+    '.ec-form textarea{resize:vertical;min-height:80px}',
+    '.ec-form select option{background:#1a1a2e;color:#e0e0e0}',
+    '.ec-confirm{display:flex;align-items:center;gap:8px;padding:8px 12px;background:rgba(255,77,77,.08);border-radius:6px;margin-top:8px;font-size:12px}',
+    '.ec-confirm .ec-confirm-text{flex:1;color:#ff6b6b}',
+    '.ec-tags{display:flex;gap:4px;flex-wrap:wrap}',
+    '.ec-tag{font-size:10px;padding:1px 7px;border-radius:8px;background:rgba(240,160,80,.12);color:#f0a050}',
+    '.ec-empty,.ec-loading,.ec-error{text-align:center;padding:20px;font-size:12px;color:#888}',
+    '.ec-loading::after{content:"";display:inline-block;width:16px;height:16px;border:2px solid rgba(255,255,255,.1);border-top-color:#f0a050;border-radius:50%;animation:ec-spin .6s linear infinite;margin-left:6px;vertical-align:middle}',
+    '@keyframes ec-spin{to{transform:rotate(360deg)}}',
+    '.ec-small{display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;gap:8px;font-size:14px;font-weight:600;transition:.15s}',
+    '.ec-small:hover{background:rgba(240,160,80,.08)}',
+    '.ec-small .ec-badge{font-size:11px;background:#f0a050;color:#fff;padding:1px 8px;border-radius:10px}'
+  ].join('\n');
+
+  function injectCSS() {
+    if (document.getElementById(CSS_ID)) return;
+    var s = document.createElement('style');
+    s.id = CSS_ID;
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  /* ── Helpers ─────────────────────────────────────────── */
+  function escapeHTML(str) {
+    var d = document.createElement('div');
+    d.textContent = str || '';
+    return d.innerHTML;
+  }
+
+  function timeAgo(ts) {
+    if (!ts) return '';
+    var diff = Date.now() - new Date(ts).getTime();
+    var m = Math.floor(diff / 60000);
+    if (m < 1) return '\u521A\u521A';
+    if (m < 60) return m + '\u5206\u949F\u524D';
+    var h = Math.floor(m / 60);
+    if (h < 24) return h + '\u5C0F\u65F6\u524D';
+    var d = Math.floor(h / 24);
+    if (d < 30) return d + '\u5929\u524D';
+    return new Date(ts).toLocaleDateString('zh-CN');
+  }
+
+  /* ── Card ────────────────────────────────────────────── */
+  function createCard(container, opts) {
+    injectCSS();
+    var uid = ++instanceCount;
+    var size = (opts && opts.size) || 'medium';
+    var el = document.createElement('div');
+    el.className = 'ec-wrap';
+    el.setAttribute('data-uid', uid);
+    container.appendChild(el);
+
+    var state = {
+      data: [],
+      stats: null,
+      loading: true,
+      error: null,
+      search: '',
+      filter: 'all',
+      view: 'list',
+      current: null,
+      editing: false,
+      creating: false,
+      deleting: false,
+      sseId: null
+    };
+
+    /* ── API ── */
+    function fetchList() {
+      state.loading = true;
+      state.error = null;
+      DataService.get(API).then(function(res) {
+        state.data = (res && res.data) ? res.data : (Array.isArray(res) ? res : []);
+        state.loading = false;
+        render();
+      }).catch(function(err) {
+        state.loading = false;
+        state.error = err.message || '\u52A0\u8F7D\u5931\u8D25';
+        render();
+      });
+    }
+
+    function fetchStats() {
+      DataService.get(API + '/stats').then(function(res) {
+        state.stats = res;
+        if (size === 'small') render();
+      }).catch(function() {});
+    }
+
+    function createExperience(data) {
+      return DataService.post(API, data).then(function(res) {
+        fetchList();
+        fetchStats();
+        return res;
+      });
+    }
+
+    function updateExperience(id, data) {
+      return DataService.put(API + '/' + id, data).then(function(res) {
+        fetchList();
+        fetchStats();
+        return res;
+      });
+    }
+
+    function deleteExperience(id) {
+      return DataService.delete(API + '/' + id).then(function() {
+        fetchList();
+        fetchStats();
+        state.view = 'list';
+        state.current = null;
+        state.deleting = false;
+      });
+    }
+
+    /* ── SSE ── */
+    function subscribeSSE() {
+      if (typeof HermesClient === 'undefined' || !HermesClient.sse) return;
+      state.sseId = HermesClient.sse.subscribe('experiences', function(event) {
+        if (event.type === 'update' || event.type === 'create' || event.type === 'delete') {
+          fetchList();
+          fetchStats();
+        }
+      });
+    }
+
+    function unsubscribeSSE() {
+      if (state.sseId && typeof HermesClient !== 'undefined' && HermesClient.sse) {
+        HermesClient.sse.unsubscribe(state.sseId);
+        state.sseId = null;
+      }
+    }
+
+    /* ── Filter ── */
+    function filtered() {
+      var list = state.data;
+      if (state.search) {
+        var q = state.search.toLowerCase();
+        list = list.filter(function(r) {
+          return (r.title || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.content || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.context || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.tool_name || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.error_type || '').toLowerCase().indexOf(q) !== -1;
+        });
+      }
+      if (state.filter !== 'all') {
+        list = list.filter(function(r) { return r.severity === state.filter; });
+      }
+      return list;
+    }
+
+    /* ── Render ── */
+    function render() {
+      if (size === 'small') { renderSmall(); return; }
+      if (size === 'xlarge') {
+        if (state.view === 'detail') renderXlDetail();
+        else renderXlList();
+        return;
+      }
+      if (size === 'large') { renderLarge(); return; }
+      renderMedium();
+    }
+
+    function renderSmall() {
+      el.innerHTML =
+        '<div class="ec-small" data-action="open-overlay">' +
+          '<span>\u{1F4A1}</span>' +
+          '<span>\u7ECF\u9A8C</span>' +
+          '<span class="ec-badge">' + state.data.length + '</span>' +
+        '</div>';
+    }
+
+    function renderMedium() {
+      var list = filtered().slice(0, 8);
+      var h = '<div class="ec-header"><h3>\u{1F4A1} \u7ECF\u9A8C <span class="ec-count">' + state.data.length + '</span></h3></div>';
+      h += '<div class="ec-body">';
+      if (state.loading) { h += '<div class="ec-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="ec-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="ec-empty">\u6682\u65E0\u7ECF\u9A8C</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="ec-item" data-action="open-detail" data-id="' + r.id + '">' +
+            '<span class="ec-title">' + escapeHTML(r.title) + '</span>' +
+            '<span class="ec-severity ec-severity-' + (r.severity || 'medium') + '">' + escapeHTML(r.severity || 'medium') + '</span>' +
+            '<span class="ec-tool">' + escapeHTML(r.tool_name || '') + '</span>' +
+            '<span class="ec-time">' + timeAgo(r.created_at) + '</span>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderLarge() {
+      var list = filtered().slice(0, 20);
+      var h = '<div class="ec-header"><h3>\u{1F4A1} \u7ECF\u9A8C <span class="ec-count">' + state.data.length + '</span></h3></div>';
+      h += '<div class="ec-search"><input placeholder="\u641C\u7D22\u7ECF\u9A8C..." data-action="search" value="' + escapeHTML(state.search) + '"></div>';
+      h += '<div class="ec-filters">' +
+        '<button class="ec-filter-btn ' + (state.filter === 'all' ? 'active' : '') + '" data-action="filter" data-val="all">\u5168\u90E8</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'high' ? 'active' : '') + '" data-action="filter" data-val="high">\u9AD8</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'medium' ? 'active' : '') + '" data-action="filter" data-val="medium">\u4E2D</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'low' ? 'active' : '') + '" data-action="filter" data-val="low">\u4F4E</button>' +
+      '</div>';
+      h += '<div class="ec-body">';
+      if (state.loading) { h += '<div class="ec-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="ec-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="ec-empty">\u6682\u65E0\u7ECF\u9A8C</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="ec-item" data-action="open-detail" data-id="' + r.id + '">' +
+            '<span class="ec-title">' + escapeHTML(r.title) + '</span>' +
+            '<span class="ec-severity ec-severity-' + (r.severity || 'medium') + '">' + escapeHTML(r.severity || 'medium') + '</span>' +
+            '<span class="ec-context">' + escapeHTML(r.context || '') + '</span>' +
+            '<span class="ec-tool">' + escapeHTML(r.tool_name || '') + '</span>' +
+            '<span class="ec-time">' + timeAgo(r.created_at) + '</span>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderXlList() {
+      var list = filtered();
+      var h = '<div class="ec-header"><h3>\u{1F4A1} \u7ECF\u9A8C\u5E93 <span class="ec-count">' + state.data.length + '</span></h3>' +
+        '<button class="ec-btn primary" data-action="create">\u65B0\u5EFA</button></div>';
+      h += '<div class="ec-search"><input placeholder="\u641C\u7D22\u7ECF\u9A8C..." data-action="search" value="' + escapeHTML(state.search) + '"></div>';
+      h += '<div class="ec-filters">' +
+        '<button class="ec-filter-btn ' + (state.filter === 'all' ? 'active' : '') + '" data-action="filter" data-val="all">\u5168\u90E8</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'high' ? 'active' : '') + '" data-action="filter" data-val="high">\u9AD8</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'medium' ? 'active' : '') + '" data-action="filter" data-val="medium">\u4E2D</button>' +
+        '<button class="ec-filter-btn ' + (state.filter === 'low' ? 'active' : '') + '" data-action="filter" data-val="low">\u4F4E</button>' +
+      '</div>';
+      h += '<div class="ec-body">';
+      if (state.loading) { h += '<div class="ec-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="ec-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="ec-empty">\u6682\u65E0\u7ECF\u9A8C</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="ec-item">' +
+            '<span class="ec-title" data-action="open-detail" data-id="' + r.id + '">' + escapeHTML(r.title) + '</span>' +
+            '<span class="ec-severity ec-severity-' + (r.severity || 'medium') + '">' + escapeHTML(r.severity || 'medium') + '</span>' +
+            '<span class="ec-context">' + escapeHTML(r.context || '') + '</span>' +
+            '<span class="ec-tool">' + escapeHTML(r.tool_name || '') + '</span>';
+          if (r.tags && r.tags.length) {
+            h += '<span class="ec-tags">';
+            r.tags.slice(0, 3).forEach(function(t) { h += '<span class="ec-tag">' + escapeHTML(t) + '</span>'; });
+            if (r.tags.length > 3) h += '<span class="ec-tag">+' + (r.tags.length - 3) + '</span>';
+            h += '</span>';
+          }
+          h += '<div class="ec-actions">' +
+              '<button data-action="edit" data-id="' + r.id + '" title="\u7F16\u8F91">\u270F\uFE0F</button>' +
+              '<button class="danger" data-action="delete" data-id="' + r.id + '" title="\u5220\u9664">\u{1F5D1}</button>' +
+            '</div>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderXlDetail() {
+      var r = state.current;
+      if (!r) { state.view = 'list'; renderXlList(); return; }
+      var h = '<div class="ec-detail">';
+      h += '<button class="ec-back" data-action="back">\u2190 \u8FD4\u56DE</button>';
+      h += '<div class="ec-header"><h3>' + escapeHTML(r.title) + '</h3></div>';
+      h += '<div class="ec-meta">' +
+        '<div><dt>\u4E25\u91CD\u7A0B\u5EA6</dt><dd><span class="ec-severity ec-severity-' + (r.severity || 'medium') + '">' + escapeHTML(r.severity || 'medium') + '</span></dd></div>' +
+        '<div><dt>\u5DE5\u5177</dt><dd>' + escapeHTML(r.tool_name || '-') + '</dd></div>' +
+        '<div><dt>\u9519\u8BEF\u7C7B\u578B</dt><dd>' + escapeHTML(r.error_type || '-') + '</dd></div>' +
+        '<div><dt>\u521B\u5EFA\u65F6\u95F4</dt><dd>' + timeAgo(r.created_at) + '</dd></div>' +
+        '<div style="grid-column:1/-1"><dt>\u4E0A\u4E0B\u6587</dt><dd>' + escapeHTML(r.context || '-') + '</dd></div>' +
+      '</div>';
+      if (r.tags && r.tags.length) {
+        h += '<div class="ec-tags" style="margin:8px 0">';
+        r.tags.forEach(function(t) { h += '<span class="ec-tag">' + escapeHTML(t) + '</span>'; });
+        h += '</div>';
+      }
+      h += '<div class="ec-content">' + escapeHTML(r.content || '') + '</div>';
+
+      if (state.editing) {
+        h += '<div class="ec-form">' +
+          '<label>\u6807\u9898</label><input id="ec-edit-title" value="' + escapeHTML(r.title) + '">' +
+          '<label>\u4E25\u91CD\u7A0B\u5EA6</label><select id="ec-edit-severity">' +
+            '<option value="low"' + (r.severity === 'low' ? ' selected' : '') + '>\u4F4E</option>' +
+            '<option value="medium"' + (r.severity === 'medium' ? ' selected' : '') + '>\u4E2D</option>' +
+            '<option value="high"' + (r.severity === 'high' ? ' selected' : '') + '>\u9AD8</option>' +
+          '</select>' +
+          '<label>\u4E0A\u4E0B\u6587</label><input id="ec-edit-context" value="' + escapeHTML(r.context || '') + '">' +
+          '<label>\u5DE5\u5177\u540D\u79F0</label><input id="ec-edit-tool" value="' + escapeHTML(r.tool_name || '') + '">' +
+          '<label>\u9519\u8BEF\u7C7B\u578B</label><input id="ec-edit-error" value="' + escapeHTML(r.error_type || '') + '">' +
+          '<label>\u5185\u5BB9</label><textarea id="ec-edit-content">' + escapeHTML(r.content || '') + '</textarea>' +
+          '<div style="display:flex;gap:6px;justify-content:flex-end">' +
+            '<button class="ec-btn" data-action="cancel-edit">\u53D6\u6D88</button>' +
+            '<button class="ec-btn primary" data-action="save-edit">\u4FDD\u5B58</button>' +
+          '</div>' +
+        '</div>';
+      } else if (state.creating) {
+        h += '<div class="ec-form">' +
+          '<label>\u6807\u9898</label><input id="ec-edit-title" placeholder="\u7ECF\u9A8C\u6807\u9898">' +
+          '<label>\u4E25\u91CD\u7A0B\u5EA6</label><select id="ec-edit-severity">' +
+            '<option value="low">\u4F4E</option><option value="medium" selected>\u4E2D</option><option value="high">\u9AD8</option>' +
+          '</select>' +
+          '<label>\u4E0A\u4E0B\u6587</label><input id="ec-edit-context" placeholder="\u4E0A\u4E0B\u6587\u63CF\u8FF0">' +
+          '<label>\u5DE5\u5177\u540D\u79F0</label><input id="ec-edit-tool" placeholder="\u76F8\u5173\u5DE5\u5177">' +
+          '<label>\u9519\u8BEF\u7C7B\u578B</label><input id="ec-edit-error" placeholder="\u9519\u8BEF\u7C7B\u578B">' +
+          '<label>\u5185\u5BB9</label><textarea id="ec-edit-content" placeholder="\u7ECF\u9A8C\u5185\u5BB9..."></textarea>' +
+          '<div style="display:flex;gap:6px;justify-content:flex-end">' +
+            '<button class="ec-btn" data-action="cancel-create">\u53D6\u6D88</button>' +
+            '<button class="ec-btn primary" data-action="save-create">\u521B\u5EFA</button>' +
+          '</div>' +
+        '</div>';
+      } else {
+        h += '<div style="display:flex;gap:6px;flex-wrap:wrap;padding-top:8px">' +
+          '<button class="ec-btn" data-action="start-edit">\u7F16\u8F91</button>' +
+          '<button class="ec-btn danger" data-action="confirm-delete">\u5220\u9664</button>' +
+        '</div>';
+        if (state.deleting) {
+          h += '<div class="ec-confirm">' +
+            '<span class="ec-confirm-text">\u786E\u5B9A\u5220\u9664\u8FD9\u6761\u7ECF\u9A8C\uFF1F</span>' +
+            '<button class="ec-btn danger" data-action="do-delete">\u5220\u9664</button>' +
+            '<button class="ec-btn" data-action="cancel-delete">\u53D6\u6D88</button>' +
+          '</div>';
+        }
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    /* ── Events ── */
+    el.addEventListener('click', function(e) {
+      var target = e.target.closest('[data-action]');
+      if (!target) return;
+      var action = target.getAttribute('data-action');
+      var id = target.getAttribute('data-id');
+
+      switch (action) {
+        case 'open-overlay':
+          if (typeof CardOverlay !== 'undefined') {
+            CardOverlay.open('experience-card', { size: 'xlarge' });
+          }
+          break;
+        case 'open-detail':
+          var item = state.data.find(function(r) { return r.id == id; });
+          if (item) {
+            state.current = item;
+            state.view = 'detail';
+            state.editing = false;
+            state.creating = false;
+            state.deleting = false;
+            render();
+          }
+          break;
+        case 'back':
+          state.view = 'list';
+          state.current = null;
+          state.editing = false;
+          state.creating = false;
+          state.deleting = false;
+          render();
+          break;
+        case 'create':
+          state.view = 'detail';
+          state.current = { id: null, title: '', content: '', severity: 'medium', context: '', tool_name: '', error_type: '', tags: [] };
+          state.creating = true;
+          state.editing = false;
+          state.deleting = false;
+          render();
+          break;
+        case 'save-create':
+          var titleEl = el.querySelector('#ec-edit-title');
+          var sevEl = el.querySelector('#ec-edit-severity');
+          var ctxEl = el.querySelector('#ec-edit-context');
+          var toolEl = el.querySelector('#ec-edit-tool');
+          var errEl = el.querySelector('#ec-edit-error');
+          var contEl = el.querySelector('#ec-edit-content');
+          if (titleEl && titleEl.value.trim()) {
+            createExperience({
+              title: titleEl.value.trim(),
+              severity: sevEl ? sevEl.value : 'medium',
+              context: ctxEl ? ctxEl.value.trim() : '',
+              tool_name: toolEl ? toolEl.value.trim() : '',
+              error_type: errEl ? errEl.value.trim() : '',
+              content: contEl ? contEl.value.trim() : ''
+            }).then(function() {
+              state.view = 'list';
+              state.creating = false;
+              render();
+            });
+          }
+          break;
+        case 'edit':
+          var editItem = state.data.find(function(r) { return r.id == id; });
+          if (editItem) {
+            state.current = editItem;
+            state.view = 'detail';
+            state.editing = true;
+            state.creating = false;
+            state.deleting = false;
+            render();
+          }
+          break;
+        case 'start-edit':
+          state.editing = true;
+          render();
+          break;
+        case 'save-edit':
+          var etEl = el.querySelector('#ec-edit-title');
+          var esEl = el.querySelector('#ec-edit-severity');
+          var ectEl = el.querySelector('#ec-edit-context');
+          var etoEl = el.querySelector('#ec-edit-tool');
+          var eerEl = el.querySelector('#ec-edit-error');
+          var ecoEl = el.querySelector('#ec-edit-content');
+          if (etEl && etEl.value.trim() && state.current) {
+            updateExperience(state.current.id, {
+              title: etEl.value.trim(),
+              severity: esEl ? esEl.value : state.current.severity,
+              context: ectEl ? ectEl.value.trim() : state.current.context,
+              tool_name: etoEl ? etoEl.value.trim() : state.current.tool_name,
+              error_type: eerEl ? eerEl.value.trim() : state.current.error_type,
+              content: ecoEl ? ecoEl.value.trim() : state.current.content
+            }).then(function() {
+              state.editing = false;
+              render();
+            });
+          }
+          break;
+        case 'cancel-edit':
+          state.editing = false;
+          render();
+          break;
+        case 'cancel-create':
+          state.creating = false;
+          state.view = 'list';
+          state.current = null;
+          render();
+          break;
+        case 'confirm-delete':
+          state.deleting = true;
+          render();
+          break;
+        case 'do-delete':
+          if (state.current) {
+            deleteExperience(state.current.id).then(function() { render(); });
+          }
+          break;
+        case 'cancel-delete':
+          state.deleting = false;
+          render();
+          break;
+      }
+    });
+
+    el.addEventListener('input', function(e) {
+      if (e.target.getAttribute('data-action') === 'search') {
+        state.search = e.target.value;
+        render();
+        var input = el.querySelector('[data-action="search"]');
+        if (input) { input.focus(); input.selectionStart = input.selectionEnd = input.value.length; }
+      }
+    });
+
+    el.addEventListener('click', function(e) {
+      var target = e.target.closest('[data-action="filter"]');
+      if (target) {
+        state.filter = target.getAttribute('data-val');
+        render();
+      }
+    });
+
+    /* ── Bus ── */
+    if (typeof Bus !== 'undefined') {
+      Bus.on('experiences:refresh', fetchList);
+    }
+
+    /* ── Init ── */
+    fetchList();
+    fetchStats();
+    subscribeSSE();
+
+    /* ── Destroy ── */
+    return {
+      destroy: function() {
+        unsubscribeSSE();
+        if (typeof Bus !== 'undefined') {
+          Bus.off('experiences:refresh', fetchList);
+        }
+        if (el.parentNode) el.parentNode.removeChild(el);
+        el.innerHTML = '';
+      },
+      resize: function(newSize) {
+        size = newSize;
+        state.view = 'list';
+        state.current = null;
+        state.editing = false;
+        state.creating = false;
+        state.deleting = false;
+        render();
+      }
+    };
+  }
+
+  /* ── Entry (small) ── */
+  function mountEntry(container, opts) {
+    return createCard(container, { size: 'small' });
+  }
+
+  /* ── Mount ── */
+  function mount(container, opts) {
+    var size = (opts && opts.size) || 'medium';
+    return createCard(container, { size: size });
+  }
+
+  /* ── Register ── */
+  if (typeof WidgetRegistry !== 'undefined') {
+    WidgetRegistry.register('experience-card', {
+      type: 'data',
+      label: '\u7ECF\u9A8C',
+      icon: '\u{1F4A1}',
+      defaultSize: { w: 2, h: 1 },
+      category: 'data',
+      mount: mount
+    });
+    WidgetRegistry.register('experience-entry', {
+      type: 'entry',
+      label: '\u7ECF\u9A8C\u5165\u53E3',
+      icon: '\u{1F4A1}',
+      defaultSize: { w: 1, h: 1 },
+      category: 'entries',
+      mount: mountEntry
+    });
+  }
+
+})();

--- a/frontend/js/workspace/widgets/cards/KnowledgeCard.js
+++ b/frontend/js/workspace/widgets/cards/KnowledgeCard.js
@@ -1,0 +1,1145 @@
+/**
+ * KnowledgeCard.js - 统一知识库卡片
+ *
+ * 支持 4 种尺寸: small(1x1) / medium(2x1) / large(2x2) / xlarge(全屏覆盖)
+ * xlarge 模式支持卡片内导航: 列表 <-> 详情 <-> 编辑/新建
+ *
+ * 依赖全局: WidgetRegistry, HermesClient, DataService, CardOverlay, Components, Bus
+ */
+var KnowledgeCard = (() => {
+    'use strict';
+
+    // ========== 常量 ==========
+    var API_BASE = '/api/knowledge/items';
+    var CACHE_KEY = 'knowledge:list';
+    var MAX_ITEMS_SMALL = 0;       // small 不显示列表
+    var MAX_ITEMS_MEDIUM = 5;
+    var MAX_ITEMS_LARGE = 8;
+    var TRUNCATE_TITLE_MEDIUM = 25;
+    var TRUNCATE_SUMMARY_LARGE = 50;
+    var SEARCH_DEBOUNCE_MS = 300;
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (document.getElementById('kc-styles')) return;
+        var style = document.createElement('style');
+        style.id = 'kc-styles';
+        style.textContent = [
+            /* ===== 基础布局 ===== */
+            '.kc-root { display:flex; flex-direction:column; height:100%; overflow:hidden; }',
+            '.kc-header { display:flex; align-items:center; gap:8px; padding:12px 14px 8px; flex-shrink:0; }',
+            '.kc-header__icon { font-size:18px; flex-shrink:0; }',
+            '.kc-header__title { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; }',
+            '.kc-header__count { font-size:var(--text-xs, 11px); color:var(--text-tertiary); flex-shrink:0; }',
+            '.kc-body { flex:1; overflow-y:auto; overflow-x:hidden; padding:0 14px 12px; -webkit-overflow-scrolling:touch; }',
+            '.kc-body::-webkit-scrollbar { width:4px; }',
+            '.kc-body::-webkit-scrollbar-thumb { background:rgba(0,0,0,0.12); border-radius:2px; }',
+
+            /* ===== Small 尺寸 ===== */
+            '.kc-small { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; cursor:pointer; padding:16px 8px; text-align:center; transition:opacity 0.15s; }',
+            '.kc-small:hover { opacity:0.85; }',
+            '.kc-small__emoji { font-size:32px; margin-bottom:6px; }',
+            '.kc-small__label { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); }',
+            '.kc-small__count { font-size:var(--text-2xl, 20px); font-weight:700; color:var(--accent); margin-top:4px; }',
+            '.kc-small__unit { font-size:var(--text-xs, 11px); color:var(--text-tertiary); margin-top:2px; }',
+
+            /* ===== Medium 列表 ===== */
+            '.kc-medium-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:2px; }',
+            '.kc-medium-item { display:flex; align-items:center; justify-content:space-between; padding:6px 8px; border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s; gap:8px; }',
+            '.kc-medium-item:hover { background:var(--bg-tertiary, rgba(0,0,0,0.04)); }',
+            '.kc-medium-item__title { font-size:var(--text-sm, 13px); color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; }',
+            '.kc-medium-item__time { font-size:var(--text-xs, 11px); color:var(--text-tertiary); flex-shrink:0; }',
+
+            /* ===== Large 搜索 & 筛选 ===== */
+            '.kc-search { display:flex; align-items:center; gap:6px; padding:0 14px 8px; flex-shrink:0; }',
+            '.kc-search__input { flex:1; padding:5px 10px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:var(--bg-secondary, #f5f5f5); color:var(--text-primary); font-size:var(--text-xs, 11px); outline:none; transition:border-color 0.15s; }',
+            '.kc-search__input:focus { border-color:var(--accent); }',
+            '.kc-search__input::placeholder { color:var(--text-tertiary); }',
+
+            '.kc-filters { display:flex; gap:4px; padding:0 14px 8px; flex-shrink:0; overflow-x:auto; -webkit-overflow-scrolling:touch; }',
+            '.kc-filters::-webkit-scrollbar { display:none; }',
+            '.kc-filter-btn { padding:3px 10px; border:1px solid var(--border); border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs, 11px); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.kc-filter-btn:hover { border-color:var(--accent); color:var(--accent); }',
+            '.kc-filter-btn.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+
+            /* ===== Large 列表项 ===== */
+            '.kc-large-list { display:flex; flex-direction:column; gap:6px; }',
+            '.kc-large-item { padding:8px 10px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s, box-shadow 0.15s; }',
+            '.kc-large-item:hover { background:var(--bg-tertiary, rgba(0,0,0,0.03)); box-shadow:var(--shadow, 0 1px 3px rgba(0,0,0,0.08)); }',
+            '.kc-large-item__top { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:4px; }',
+            '.kc-large-item__title { font-size:var(--text-sm, 13px); font-weight:500; color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; }',
+            '.kc-large-item__badge { font-size:10px; padding:1px 6px; border-radius:var(--radius-xs, 4px); background:var(--bg-tertiary, rgba(0,0,0,0.06)); color:var(--text-secondary); flex-shrink:0; }',
+            '.kc-large-item__summary { font-size:var(--text-xs, 11px); color:var(--text-tertiary); margin-bottom:4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }',
+            '.kc-large-item__tags { display:flex; gap:4px; flex-wrap:wrap; }',
+
+            /* ===== 标签 ===== */
+            '.kc-tag { font-size:10px; padding:1px 6px; border-radius:var(--radius-xs, 4px); background:rgba(99,102,241,0.1); color:#6366f1; }',
+
+            /* ===== Xlarge 全屏覆盖 ===== */
+            '.kc-xl { display:flex; flex-direction:column; height:100%; }',
+            '.kc-xl__header { display:flex; align-items:center; gap:10px; padding:16px 20px 12px; flex-shrink:0; border-bottom:1px solid var(--border); }',
+            '.kc-xl__title { font-size:var(--text-lg, 16px); font-weight:700; color:var(--text-primary); flex:1; }',
+            '.kc-xl__search { flex:1; max-width:320px; padding:7px 12px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-sm); outline:none; transition:border-color 0.15s; }',
+            '.kc-xl__search:focus { border-color:var(--accent); }',
+            '.kc-xl__search::placeholder { color:var(--text-tertiary); }',
+            '.kc-xl__body { flex:1; overflow-y:auto; padding:16px 20px; -webkit-overflow-scrolling:touch; }',
+
+            /* ===== Xlarge 分类标签页 ===== */
+            '.kc-xl__tabs { display:flex; gap:6px; padding:12px 20px 0; flex-shrink:0; overflow-x:auto; -webkit-overflow-scrolling:touch; }',
+            '.kc-xl__tabs::-webkit-scrollbar { display:none; }',
+            '.kc-xl__tab { padding:5px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-sm); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.kc-xl__tab:hover { border-color:var(--accent); color:var(--accent); }',
+            '.kc-xl__tab.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+
+            /* ===== Xlarge 列表卡片 ===== */
+            '.kc-xl__list { display:flex; flex-direction:column; gap:10px; margin-top:12px; }',
+            '.kc-xl__card { padding:14px 16px; border:1px solid var(--border); border-radius:var(--radius-sm, 8px); transition:background 0.15s, box-shadow 0.15s; cursor:pointer; }',
+            '.kc-xl__card:hover { background:var(--bg-tertiary); box-shadow:var(--shadow); }',
+            '.kc-xl__card-top { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:6px; }',
+            '.kc-xl__card-title { font-size:var(--text-sm); font-weight:600; color:var(--text-primary); flex:1; line-height:1.4; }',
+            '.kc-xl__card-actions { display:flex; gap:4px; flex-shrink:0; }',
+            '.kc-xl__card-action { width:28px; height:28px; display:flex; align-items:center; justify-content:center; border:none; border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-tertiary); cursor:pointer; font-size:14px; transition:all 0.15s; }',
+            '.kc-xl__card-action:hover { background:var(--bg-tertiary); color:var(--text-primary); }',
+            '.kc-xl__card-action.danger:hover { background:rgba(239,68,68,0.1); color:var(--red, #ef4444); }',
+            '.kc-xl__card-summary { font-size:var(--text-xs); color:var(--text-secondary); margin-bottom:8px; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; line-height:1.5; }',
+            '.kc-xl__card-meta { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }',
+            '.kc-xl__card-badge { font-size:10px; padding:2px 8px; border-radius:var(--radius-xs, 4px); background:rgba(99,102,241,0.1); color:#6366f1; }',
+            '.kc-xl__card-confidence { font-size:10px; padding:2px 8px; border-radius:var(--radius-xs, 4px); }',
+            '.kc-xl__card-confidence.high { background:rgba(34,197,94,0.1); color:var(--green, #22c55e); }',
+            '.kc-xl__card-confidence.medium { background:rgba(234,179,8,0.1); color:var(--yellow, #eab308); }',
+            '.kc-xl__card-confidence.low { background:rgba(239,68,68,0.1); color:var(--red, #ef4444); }',
+            '.kc-xl__card-time { font-size:10px; color:var(--text-tertiary); margin-left:auto; }',
+
+            /* ===== Xlarge 详情视图 ===== */
+            '.kc-detail { display:flex; flex-direction:column; height:100%; }',
+            '.kc-detail__back { display:flex; align-items:center; gap:6px; padding:0 0 12px; cursor:pointer; color:var(--text-secondary); font-size:var(--text-sm); border:none; background:none; transition:color 0.15s; flex-shrink:0; }',
+            '.kc-detail__back:hover { color:var(--text-primary); }',
+            '.kc-detail__back-arrow { font-size:16px; }',
+            '.kc-detail__title { font-size:var(--text-lg, 18px); font-weight:700; color:var(--text-primary); margin-bottom:16px; line-height:1.4; padding-bottom:12px; border-bottom:1px solid var(--border); }',
+            '.kc-detail__content { font-size:var(--text-sm); color:var(--text-primary); line-height:1.7; margin-bottom:20px; flex:1; overflow-y:auto; }',
+            '.kc-detail__content h1, .kc-detail__content h2, .kc-detail__content h3 { margin:16px 0 8px; font-weight:600; }',
+            '.kc-detail__content h1 { font-size:var(--text-lg); }',
+            '.kc-detail__content h2 { font-size:var(--text-sm); }',
+            '.kc-detail__content h3 { font-size:var(--text-sm); }',
+            '.kc-detail__content p { margin:8px 0; }',
+            '.kc-detail__content code { font-family:var(--font-mono, monospace); background:var(--bg-tertiary); padding:1px 4px; border-radius:3px; font-size:0.9em; }',
+            '.kc-detail__content pre { background:var(--bg-tertiary); padding:12px; border-radius:var(--radius-sm); overflow-x:auto; margin:8px 0; }',
+            '.kc-detail__content pre code { background:none; padding:0; }',
+            '.kc-detail__content ul, .kc-detail__content ol { padding-left:20px; margin:8px 0; }',
+            '.kc-detail__content blockquote { border-left:3px solid var(--accent); padding-left:12px; margin:8px 0; color:var(--text-secondary); }',
+            '.kc-detail__meta { display:grid; grid-template-columns:repeat(auto-fill, minmax(160px, 1fr)); gap:10px; margin-bottom:16px; padding:14px; background:var(--bg-secondary); border-radius:var(--radius-sm, 8px); }',
+            '.kc-detail__meta-item { display:flex; flex-direction:column; gap:2px; }',
+            '.kc-detail__meta-label { font-size:10px; color:var(--text-tertiary); text-transform:uppercase; letter-spacing:0.5px; }',
+            '.kc-detail__meta-value { font-size:var(--text-sm); color:var(--text-primary); font-weight:500; }',
+            '.kc-detail__tags { display:flex; gap:6px; flex-wrap:wrap; margin-bottom:16px; }',
+            '.kc-detail__actions { display:flex; gap:8px; padding-top:12px; border-top:1px solid var(--border); flex-shrink:0; }',
+
+            /* ===== Xlarge 编辑/新建表单 ===== */
+            '.kc-form { display:flex; flex-direction:column; gap:14px; }',
+            '.kc-form__group { display:flex; flex-direction:column; gap:4px; }',
+            '.kc-form__label { font-size:var(--text-xs); font-weight:600; color:var(--text-secondary); }',
+            '.kc-form__input, .kc-form__textarea, .kc-form__select { padding:8px 12px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-sm); outline:none; transition:border-color 0.15s; font-family:inherit; }',
+            '.kc-form__input:focus, .kc-form__textarea:focus, .kc-form__select:focus { border-color:var(--accent); }',
+            '.kc-form__textarea { min-height:120px; resize:vertical; line-height:1.6; }',
+            '.kc-form__actions { display:flex; gap:8px; justify-content:flex-end; padding-top:8px; }',
+
+            /* ===== 状态提示 ===== */
+            '.kc-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:40px 20px; color:var(--text-tertiary); text-align:center; }',
+            '.kc-empty__icon { font-size:40px; margin-bottom:10px; opacity:0.5; }',
+            '.kc-empty__text { font-size:var(--text-sm); }',
+            '.kc-error { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:30px 20px; text-align:center; gap:10px; }',
+            '.kc-error__icon { font-size:32px; }',
+            '.kc-error__text { font-size:var(--text-sm); color:var(--red, #ef4444); }',
+            '.kc-loading { display:flex; align-items:center; justify-content:center; padding:30px; }',
+            '.kc-loading__spinner { width:24px; height:24px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:kc-spin 0.6s linear infinite; }',
+            '@keyframes kc-spin { to { transform:rotate(360deg); } }',
+
+            /* ===== 骨架屏 ===== */
+            '.kc-skeleton { display:flex; flex-direction:column; gap:8px; padding:12px 14px; }',
+            '.kc-skeleton__line { height:12px; border-radius:4px; background:linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-secondary) 50%, var(--bg-tertiary) 75%); background-size:200% 100%; animation:kc-shimmer 1.5s infinite; }',
+            '.kc-skeleton__line.short { width:60%; }',
+            '.kc-skeleton__line.medium { width:80%; }',
+            '@keyframes kc-shimmer { 0% { background-position:200% 0; } 100% { background-position:-200% 0; } }'
+        ].join('\n');
+        document.head.appendChild(style);
+    }
+
+    // ========== 工具函数 ==========
+
+    /** HTML 转义 */
+    function _esc(str) {
+        if (!str) return '';
+        return Components.escapeHtml ? Components.escapeHtml(str) : str.replace(/[&<>"']/g, function(c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
+    /** 截断文本 */
+    function _truncate(str, len) {
+        if (!str) return '';
+        return str.length > len ? str.slice(0, len) + '...' : str;
+    }
+
+    /** 格式化时间 */
+    function _formatTime(ts) {
+        if (!ts) return '';
+        if (Components.formatDateTime) return Components.formatDateTime(ts);
+        try {
+            var d = new Date(ts);
+            var now = new Date();
+            var diff = now - d;
+            if (diff < 60000) return '刚刚';
+            if (diff < 3600000) return Math.floor(diff / 60000) + '分钟前';
+            if (diff < 86400000) return Math.floor(diff / 3600000) + '小时前';
+            if (diff < 604800000) return Math.floor(diff / 86400000) + '天前';
+            return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+        } catch (e) {
+            return String(ts);
+        }
+    }
+
+    /** 渲染 Markdown */
+    function _renderMd(text) {
+        if (!text) return '';
+        if (Components.renderMarkdown) return Components.renderMarkdown(text);
+        return _esc(text).replace(/\n/g, '<br>');
+    }
+
+    /** 置信度样式类 */
+    function _confidenceClass(confidence) {
+        if (!confidence) return '';
+        var c = String(confidence).toLowerCase();
+        if (c === 'high' || c === '高') return 'high';
+        if (c === 'medium' || c === '中') return 'medium';
+        if (c === 'low' || c === '低') return 'low';
+        return '';
+    }
+
+    /** 置信度显示文本 */
+    function _confidenceLabel(confidence) {
+        if (!confidence) return '';
+        var c = String(confidence).toLowerCase();
+        var map = { 'high': '高', 'medium': '中', 'low': '低', '高': '高', '中': '中', '低': '低' };
+        return map[c] || confidence;
+    }
+
+    /** 从数据中提取唯一分类 */
+    function _extractCategories(items) {
+        var set = {};
+        var result = [];
+        if (!Array.isArray(items)) return result;
+        for (var i = 0; i < items.length; i++) {
+            var cat = items[i].category;
+            if (cat && !set[cat]) {
+                set[cat] = true;
+                result.push(cat);
+            }
+        }
+        return result;
+    }
+
+    /** 搜索过滤 */
+    function _filterItems(items, keyword, category) {
+        if (!Array.isArray(items)) return [];
+        var result = [];
+        var kw = (keyword || '').toLowerCase().trim();
+        for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            // 分类过滤
+            if (category && category !== '全部' && item.category !== category) continue;
+            // 关键词搜索
+            if (kw) {
+                var haystack = ((item.title || '') + ' ' + (item.summary || '') + ' ' + (item.content || '') + ' ' + (item.tags || []).join(' ')).toLowerCase();
+                if (haystack.indexOf(kw) === -1) continue;
+            }
+            result.push(item);
+        }
+        return result;
+    }
+
+    /** 骨架屏 HTML */
+    function _skeletonHtml(lines) {
+        var html = '<div class="kc-skeleton">';
+        for (var i = 0; i < (lines || 4); i++) {
+            var cls = i === lines - 1 ? ' kc-skeleton__line short' : (i % 2 === 0 ? '' : ' kc-skeleton__line medium');
+            html += '<div class="kc-skeleton__line' + cls + '"></div>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    /** 加载中 HTML */
+    function _loadingHtml() {
+        return '<div class="kc-loading"><div class="kc-loading__spinner"></div></div>';
+    }
+
+    /** 空状态 HTML */
+    function _emptyHtml(text) {
+        return '<div class="kc-empty"><div class="kc-empty__icon">📭</div><div class="kc-empty__text">' + (text || '暂无数据') + '</div></div>';
+    }
+
+    /** 错误状态 HTML */
+    function _errorHtml(msg) {
+        return '<div class="kc-error"><div class="kc-error__icon">⚠️</div><div class="kc-error__text">' + _esc(msg || '加载失败') + '</div><button class="btn btn-sm btn-ghost" data-action="retry">重试</button></div>';
+    }
+
+    /** 渲染标签列表 */
+    function _renderTags(tags) {
+        if (!Array.isArray(tags) || tags.length === 0) return '';
+        return tags.map(function(t) { return '<span class="kc-tag">' + _esc(t) + '</span>'; }).join('');
+    }
+
+    // ========== 数据获取 ==========
+
+    /** 获取知识列表（带缓存） */
+    function _fetchItems() {
+        return HermesClient.cachedGet(CACHE_KEY, function() {
+            return HermesClient.get(API_BASE, { limit: 100 });
+        });
+    }
+
+    /** 获取统计数据 */
+    function _fetchStats() {
+        return HermesClient.get(API_BASE + '/stats').catch(function() { return null; });
+    }
+
+    /** 获取单条详情 */
+    function _fetchItem(id) {
+        return HermesClient.get(API_BASE + '/' + id);
+    }
+
+    /** 创建知识条目 */
+    function _createItem(data) {
+        return HermesClient.post(API_BASE, data);
+    }
+
+    /** 更新知识条目 */
+    function _updateItem(id, data) {
+        return HermesClient.put(API_BASE + '/' + id, data);
+    }
+
+    /** 删除知识条目 */
+    function _deleteItem(id) {
+        return HermesClient.del(API_BASE + '/' + id);
+    }
+
+    // ========== 判断尺寸 ==========
+
+    function _getSize(props) {
+        var config = props.config || {};
+        var w = config.w || 2;
+        var h = config.h || 1;
+        if (w <= 1 && h <= 1) return 'small';
+        if (w <= 2 && h <= 1) return 'medium';
+        if (w <= 2 && h <= 2) return 'large';
+        return 'xlarge';
+    }
+
+    // ========== 主挂载函数 ==========
+
+    async function mount(container, props) {
+        var cardId = props.cardId;
+        var desktopId = props.desktopId;
+        var size = _getSize(props);
+
+        // 注入样式
+        _injectStyles();
+
+        // 内部状态
+        var items = [];
+        var loading = true;
+        var error = null;
+        var searchKeyword = '';
+        var activeCategory = '全部';
+        var categories = [];
+        var currentItemId = null;   // xlarge 详情视图当前查看的条目 ID
+        var xlState = 'list';       // xlarge 状态: 'list' | 'detail' | 'edit' | 'create'
+        var editItem = null;        // 编辑中的条目副本
+        var debounceTimer = null;
+
+        // 事件处理函数引用（用于清理）
+        var _clickHandler = null;
+        var _inputHandler = null;
+        var _sseHandlers = {};
+
+        // ---------- 数据加载 ----------
+        async function loadData() {
+            loading = true;
+            error = null;
+            _render();
+
+            try {
+                items = await _fetchItems();
+                if (!Array.isArray(items)) items = [];
+                categories = _extractCategories(items);
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                loading = false;
+                error = e.message || '加载失败';
+                _render();
+            }
+        }
+
+        // ---------- 刷新（SSE 触发） ----------
+        async function refresh() {
+            // 清除缓存后重新加载
+            try {
+                items = await _fetchItems();
+                if (!Array.isArray(items)) items = [];
+                categories = _extractCategories(items);
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                error = e.message || '刷新失败';
+                _render();
+            }
+        }
+
+        // ---------- 渲染分发 ----------
+        function _render() {
+            switch (size) {
+                case 'small':  _renderSmall(); break;
+                case 'medium': _renderMedium(); break;
+                case 'large':  _renderLarge(); break;
+                case 'xlarge': _renderXlarge(); break;
+            }
+        }
+
+        // ========== Small 渲染 ==========
+        function _renderSmall() {
+            var count = items.length;
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="kc-small" data-action="open-overlay">' +
+                        '<div class="kc-small__emoji">📖</div>' +
+                        '<div class="kc-small__label">知识库</div>' +
+                        (loading
+                            ? '<div class="kc-loading" style="padding:8px 0;"><div class="kc-loading__spinner" style="width:18px;height:18px;border-width:2px;"></div></div>'
+                            : '<div class="kc-small__count">' + count + '</div>' +
+                              '<div class="kc-small__unit">条知识</div>') +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== Medium 渲染 ==========
+        function _renderMedium() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="kc-header"><span class="kc-header__icon">📖</span><span class="kc-header__title">知识库</span></div>' + _skeletonHtml(5) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="kc-header"><span class="kc-header__icon">📖</span><span class="kc-header__title">知识库</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            var list = items.slice(0, MAX_ITEMS_MEDIUM);
+            var listHtml = '';
+            if (list.length === 0) {
+                listHtml = _emptyHtml('暂无知识条目');
+            } else {
+                listHtml = '<ul class="kc-medium-list">' +
+                    list.map(function(item) {
+                        return '<li class="kc-medium-item" data-action="open-detail" data-id="' + _esc(item.id) + '">' +
+                            '<span class="kc-medium-item__title">' + _esc(_truncate(item.title, TRUNCATE_TITLE_MEDIUM)) + '</span>' +
+                            '<span class="kc-medium-item__time">' + _formatTime(item.updated_at) + '</span>' +
+                        '</li>';
+                    }).join('') +
+                '</ul>';
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="kc-header">' +
+                        '<span class="kc-header__icon">📖</span>' +
+                        '<span class="kc-header__title">知识库</span>' +
+                        '<span class="kc-header__count">' + items.length + '条</span>' +
+                    '</div>' +
+                    '<div class="kc-body">' + listHtml + '</div>' +
+                '</div>';
+        }
+
+        // ========== Large 渲染 ==========
+        function _renderLarge() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="kc-header"><span class="kc-header__icon">📖</span><span class="kc-header__title">知识库</span></div>' + _skeletonHtml(6) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="kc-header"><span class="kc-header__icon">📖</span><span class="kc-header__title">知识库</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            var filtered = _filterItems(items, searchKeyword, activeCategory);
+            var list = filtered.slice(0, MAX_ITEMS_LARGE);
+
+            // 分类按钮
+            var filterHtml = '<div class="kc-filters">' +
+                '<button class="kc-filter-btn' + (activeCategory === '全部' ? ' active' : '') + '" data-action="filter" data-category="全部">全部</button>' +
+                categories.map(function(cat) {
+                    return '<button class="kc-filter-btn' + (activeCategory === cat ? ' active' : '') + '" data-action="filter" data-category="' + _esc(cat) + '">' + _esc(cat) + '</button>';
+                }).join('') +
+            '</div>';
+
+            // 列表
+            var listHtml = '';
+            if (list.length === 0) {
+                listHtml = _emptyHtml(searchKeyword ? '未找到匹配的知识条目' : '暂无知识条目');
+            } else {
+                listHtml = '<div class="kc-large-list">' +
+                    list.map(function(item) {
+                        return '<div class="kc-large-item" data-action="open-detail" data-id="' + _esc(item.id) + '">' +
+                            '<div class="kc-large-item__top">' +
+                                '<span class="kc-large-item__title">' + _esc(item.title) + '</span>' +
+                                (item.category ? '<span class="kc-large-item__badge">' + _esc(item.category) + '</span>' : '') +
+                            '</div>' +
+                            '<div class="kc-large-item__summary">' + _esc(_truncate(item.summary, TRUNCATE_SUMMARY_LARGE)) + '</div>' +
+                            '<div class="kc-large-item__tags">' + _renderTags(item.tags) + '</div>' +
+                        '</div>';
+                    }).join('') +
+                '</div>';
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="kc-header">' +
+                        '<span class="kc-header__icon">📖</span>' +
+                        '<span class="kc-header__title">知识库</span>' +
+                        '<span class="kc-header__count">' + items.length + '条</span>' +
+                    '</div>' +
+                    '<div class="kc-search">' +
+                        '<input class="kc-search__input" type="text" placeholder="搜索知识..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+                    '</div>' +
+                    filterHtml +
+                    '<div class="kc-body">' + listHtml + '</div>' +
+                '</div>';
+        }
+
+        // ========== Xlarge 渲染 ==========
+        function _renderXlarge() {
+            switch (xlState) {
+                case 'list':   _renderXlList(); break;
+                case 'detail': _renderXlDetail(); break;
+                case 'edit':   _renderXlEdit(); break;
+                case 'create': _renderXlCreate(); break;
+            }
+        }
+
+        // ----- Xlarge 列表视图 -----
+        function _renderXlList() {
+            if (loading) {
+                container.innerHTML = '<div class="kc-xl">' +
+                    '<div class="kc-xl__header"><span class="kc-xl__title">知识库</span></div>' +
+                    _loadingHtml() +
+                '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="kc-xl">' +
+                    '<div class="kc-xl__header"><span class="kc-xl__title">知识库</span></div>' +
+                    _errorHtml(error) +
+                '</div>';
+                return;
+            }
+
+            var filtered = _filterItems(items, searchKeyword, activeCategory);
+
+            // 分类标签页
+            var tabsHtml = '<div class="kc-xl__tabs">' +
+                '<button class="kc-xl__tab' + (activeCategory === '全部' ? ' active' : '') + '" data-action="filter" data-category="全部">全部</button>' +
+                categories.map(function(cat) {
+                    return '<button class="kc-xl__tab' + (activeCategory === cat ? ' active' : '') + '" data-action="filter" data-category="' + _esc(cat) + '">' + _esc(cat) + '</button>';
+                }).join('') +
+            '</div>';
+
+            // 列表
+            var listHtml = '';
+            if (filtered.length === 0) {
+                listHtml = _emptyHtml(searchKeyword ? '未找到匹配的知识条目' : '暂无知识条目，点击右上角新建');
+            } else {
+                listHtml = '<div class="kc-xl__list">' +
+                    filtered.map(function(item) {
+                        var confCls = _confidenceClass(item.confidence);
+                        return '<div class="kc-xl__card" data-action="view-item" data-id="' + _esc(item.id) + '">' +
+                            '<div class="kc-xl__card-top">' +
+                                '<span class="kc-xl__card-title">' + _esc(item.title) + '</span>' +
+                                '<div class="kc-xl__card-actions">' +
+                                    '<button class="kc-xl__card-action" data-action="edit-item" data-id="' + _esc(item.id) + '" title="编辑">✏️</button>' +
+                                    '<button class="kc-xl__card-action danger" data-action="delete-item" data-id="' + _esc(item.id) + '" title="删除">🗑️</button>' +
+                                '</div>' +
+                            '</div>' +
+                            (item.summary ? '<div class="kc-xl__card-summary">' + _esc(item.summary) + '</div>' : '') +
+                            '<div class="kc-xl__card-meta">' +
+                                (item.category ? '<span class="kc-xl__card-badge">' + _esc(item.category) + '</span>' : '') +
+                                (item.confidence ? '<span class="kc-xl__card-confidence ' + confCls + '">置信度: ' + _esc(_confidenceLabel(item.confidence)) + '</span>' : '') +
+                                _renderTags(item.tags) +
+                                '<span class="kc-xl__card-time">' + _formatTime(item.updated_at) + '</span>' +
+                            '</div>' +
+                        '</div>';
+                    }).join('') +
+                '</div>';
+            }
+
+            container.innerHTML =
+                '<div class="kc-xl">' +
+                    '<div class="kc-xl__header">' +
+                        '<span class="kc-xl__title">知识库</span>' +
+                        '<input class="kc-xl__search" type="text" placeholder="搜索知识..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+                        '<button class="btn btn-sm btn-primary" data-action="create-item">新建</button>' +
+                    '</div>' +
+                    tabsHtml +
+                    '<div class="kc-xl__body">' + listHtml + '</div>' +
+                '</div>';
+        }
+
+        // ----- Xlarge 详情视图 -----
+        function _renderXlDetail() {
+            var item = null;
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].id === currentItemId) { item = items[i]; break; }
+            }
+
+            if (!item) {
+                // 条目不在缓存中，尝试从 API 获取
+                container.innerHTML = '<div class="kc-xl"><div class="kc-xl__body">' + _loadingHtml() + '</div></div>';
+                _fetchItem(currentItemId).then(function(data) {
+                    if (data) {
+                        items.push(data);
+                        _renderXlDetail();
+                    } else {
+                        container.innerHTML = '<div class="kc-xl"><div class="kc-xl__body">' + _errorHtml('知识条目不存在') + '</div></div>';
+                    }
+                }).catch(function() {
+                    container.innerHTML = '<div class="kc-xl"><div class="kc-xl__body">' + _errorHtml('加载详情失败') + '</div></div>';
+                });
+                return;
+            }
+
+            container.innerHTML =
+                '<div class="kc-xl">' +
+                    '<div class="kc-xl__body">' +
+                        '<div class="kc-detail">' +
+                            '<button class="kc-detail__back" data-action="back-to-list"><span class="kc-detail__back-arrow">←</span> 返回列表</button>' +
+                            '<div class="kc-detail__title">' + _esc(item.title) + '</div>' +
+                            '<div class="kc-detail__content">' + _renderMd(item.content) + '</div>' +
+                            '<div class="kc-detail__meta">' +
+                                '<div class="kc-detail__meta-item"><span class="kc-detail__meta-label">分类</span><span class="kc-detail__meta-value">' + _esc(item.category || '-') + '</span></div>' +
+                                '<div class="kc-detail__meta-item"><span class="kc-detail__meta-label">置信度</span><span class="kc-detail__meta-value">' + _esc(_confidenceLabel(item.confidence) || '-') + '</span></div>' +
+                                '<div class="kc-detail__meta-item"><span class="kc-detail__meta-label">来源</span><span class="kc-detail__meta-value">' + _esc(item.source || '-') + '</span></div>' +
+                                '<div class="kc-detail__meta-item"><span class="kc-detail__meta-label">创建时间</span><span class="kc-detail__meta-value">' + _formatTime(item.created_at) + '</span></div>' +
+                                '<div class="kc-detail__meta-item"><span class="kc-detail__meta-label">更新时间</span><span class="kc-detail__meta-value">' + _formatTime(item.updated_at) + '</span></div>' +
+                            '</div>' +
+                            (Array.isArray(item.tags) && item.tags.length > 0
+                                ? '<div class="kc-detail__tags">' + _renderTags(item.tags) + '</div>'
+                                : '') +
+                            '<div class="kc-detail__actions">' +
+                                '<button class="btn btn-sm btn-primary" data-action="edit-item" data-id="' + _esc(item.id) + '">编辑</button>' +
+                                '<button class="btn btn-sm btn-danger" data-action="delete-item" data-id="' + _esc(item.id) + '">删除</button>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ----- Xlarge 编辑视图 -----
+        function _renderXlEdit() {
+            if (!editItem) {
+                xlState = 'list';
+                _renderXlarge();
+                return;
+            }
+
+            container.innerHTML =
+                '<div class="kc-xl">' +
+                    '<div class="kc-xl__body">' +
+                        '<div class="kc-detail">' +
+                            '<button class="kc-detail__back" data-action="back-to-list"><span class="kc-detail__back-arrow">←</span> 返回列表</button>' +
+                            '<div class="kc-detail__title">编辑知识条目</div>' +
+                            '<div class="kc-form">' +
+                                '<div class="kc-form__group"><label class="kc-form__label">标题</label><input class="kc-form__input" type="text" data-field="title" value="' + _esc(editItem.title || '') + '" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">分类</label><input class="kc-form__input" type="text" data-field="category" value="' + _esc(editItem.category || '') + '" placeholder="例如: 技术、产品、运营" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">摘要</label><textarea class="kc-form__textarea" data-field="summary" rows="2">' + _esc(editItem.summary || '') + '</textarea></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">内容（支持 Markdown）</label><textarea class="kc-form__textarea" data-field="content" rows="8">' + _esc(editItem.content || '') + '</textarea></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">标签（逗号分隔）</label><input class="kc-form__input" type="text" data-field="tags" value="' + _esc((editItem.tags || []).join(', ')) + '" placeholder="标签1, 标签2" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">置信度</label><select class="kc-form__select" data-field="confidence"><option value="high"' + (editItem.confidence === 'high' ? ' selected' : '') + '>高</option><option value="medium"' + (editItem.confidence === 'medium' ? ' selected' : '') + '>中</option><option value="low"' + (editItem.confidence === 'low' ? ' selected' : '') + '>低</option></select></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">来源</label><input class="kc-form__input" type="text" data-field="source" value="' + _esc(editItem.source || '') + '" /></div>' +
+                                '<div class="kc-form__actions">' +
+                                    '<button class="btn btn-sm btn-ghost" data-action="cancel-edit">取消</button>' +
+                                    '<button class="btn btn-sm btn-primary" data-action="save-edit">保存</button>' +
+                                '</div>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ----- Xlarge 新建视图 -----
+        function _renderXlCreate() {
+            container.innerHTML =
+                '<div class="kc-xl">' +
+                    '<div class="kc-xl__body">' +
+                        '<div class="kc-detail">' +
+                            '<button class="kc-detail__back" data-action="back-to-list"><span class="kc-detail__back-arrow">←</span> 返回列表</button>' +
+                            '<div class="kc-detail__title">新建知识条目</div>' +
+                            '<div class="kc-form">' +
+                                '<div class="kc-form__group"><label class="kc-form__label">标题 *</label><input class="kc-form__input" type="text" data-field="title" placeholder="请输入知识标题" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">分类</label><input class="kc-form__input" type="text" data-field="category" placeholder="例如: 技术、产品、运营" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">摘要</label><textarea class="kc-form__textarea" data-field="summary" rows="2" placeholder="简要描述这条知识..."></textarea></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">内容（支持 Markdown）</label><textarea class="kc-form__textarea" data-field="content" rows="8" placeholder="详细内容..."></textarea></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">标签（逗号分隔）</label><input class="kc-form__input" type="text" data-field="tags" placeholder="标签1, 标签2" /></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">置信度</label><select class="kc-form__select" data-field="confidence"><option value="high">高</option><option value="medium" selected>中</option><option value="low">低</option></select></div>' +
+                                '<div class="kc-form__group"><label class="kc-form__label">来源</label><input class="kc-form__input" type="text" data-field="source" placeholder="知识来源" /></div>' +
+                                '<div class="kc-form__actions">' +
+                                    '<button class="btn btn-sm btn-ghost" data-action="cancel-create">取消</button>' +
+                                    '<button class="btn btn-sm btn-primary" data-action="save-create">创建</button>' +
+                                '</div>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== 表单数据收集 ==========
+
+        function _collectFormData() {
+            var data = {};
+            var fields = container.querySelectorAll('[data-field]');
+            for (var i = 0; i < fields.length; i++) {
+                var field = fields[i];
+                var key = field.getAttribute('data-field');
+                var val = field.value;
+                if (key === 'tags') {
+                    // 标签字段: 逗号分隔转数组
+                    data[key] = val ? val.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+                } else {
+                    data[key] = val;
+                }
+            }
+            return data;
+        }
+
+        // ========== 事件处理 ==========
+
+        function _handleClick(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+
+            var action = target.getAttribute('data-action');
+            var id = target.getAttribute('data-id');
+            var category = target.getAttribute('data-category');
+
+            switch (action) {
+                // ----- 通用: 打开覆盖层 -----
+                case 'open-overlay':
+                    e.preventDefault();
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('knowledge-card');
+                    }
+                    break;
+
+                // ----- Medium/Large: 打开详情覆盖层 -----
+                case 'open-detail':
+                    e.preventDefault();
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('knowledge-card', { itemId: id });
+                    }
+                    break;
+
+                // ----- Large: 分类筛选 -----
+                case 'filter':
+                    e.preventDefault();
+                    activeCategory = category || '全部';
+                    _render();
+                    break;
+
+                // ----- Xlarge: 查看条目详情（卡片内导航） -----
+                case 'view-item':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    currentItemId = id;
+                    xlState = 'detail';
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.pushView(function(body) {
+                            // pushView 会替换 body 内容，但我们的 xlarge 模式
+                            // 直接在 container 内切换状态，不需要 pushView
+                        });
+                    }
+                    _renderXlarge();
+                    break;
+
+                // ----- Xlarge: 编辑条目 -----
+                case 'edit-item':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var editTarget = null;
+                    for (var i = 0; i < items.length; i++) {
+                        if (items[i].id === id) { editTarget = items[i]; break; }
+                    }
+                    if (editTarget) {
+                        editItem = JSON.parse(JSON.stringify(editTarget));
+                        currentItemId = id;
+                        xlState = 'edit';
+                        _renderXlarge();
+                    }
+                    break;
+
+                // ----- Xlarge: 删除条目 -----
+                case 'delete-item':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _confirmDelete(id);
+                    break;
+
+                // ----- Xlarge: 新建条目 -----
+                case 'create-item':
+                    e.preventDefault();
+                    editItem = null;
+                    xlState = 'create';
+                    _renderXlarge();
+                    break;
+
+                // ----- Xlarge: 返回列表 -----
+                case 'back-to-list':
+                    e.preventDefault();
+                    // 如果在 overlay 内使用了 pushView，先 popView
+                    if (typeof CardOverlay !== 'undefined' && CardOverlay.isOpen()) {
+                        CardOverlay.popView();
+                    }
+                    xlState = 'list';
+                    currentItemId = null;
+                    editItem = null;
+                    _renderXlarge();
+                    break;
+
+                // ----- Xlarge: 取消编辑 -----
+                case 'cancel-edit':
+                    e.preventDefault();
+                    xlState = 'detail';
+                    _renderXlarge();
+                    break;
+
+                // ----- Xlarge: 保存编辑 -----
+                case 'save-edit':
+                    e.preventDefault();
+                    _handleSaveEdit();
+                    break;
+
+                // ----- Xlarge: 取消新建 -----
+                case 'cancel-create':
+                    e.preventDefault();
+                    xlState = 'list';
+                    _renderXlarge();
+                    break;
+
+                // ----- Xlarge: 保存新建 -----
+                case 'save-create':
+                    e.preventDefault();
+                    _handleSaveCreate();
+                    break;
+
+                // ----- 重试 -----
+                case 'retry':
+                    e.preventDefault();
+                    loadData();
+                    break;
+            }
+        }
+
+        // ---------- 搜索输入处理 ----------
+        function _handleInput(e) {
+            var input = e.target.closest('[data-role="search-input"]');
+            if (!input) return;
+
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(function() {
+                searchKeyword = input.value;
+                _render();
+            }, SEARCH_DEBOUNCE_MS);
+        }
+
+        // ---------- 确认删除 ----------
+        function _confirmDelete(id) {
+            var item = null;
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].id === id) { item = items[i]; break; }
+            }
+            if (!item) return;
+
+            var msg = '确定要删除知识条目「' + (item.title || '未命名') + '」吗？此操作不可撤销。';
+            if (typeof Components !== 'undefined' && Components.showToast) {
+                // 使用 toast + 内联确认方式
+                _showDeleteConfirm(id, msg);
+            } else if (confirm) {
+                // 回退到原生 confirm
+                if (confirm(msg)) {
+                    _doDelete(id);
+                }
+            }
+        }
+
+        // ---------- 内联删除确认 ----------
+        function _showDeleteConfirm(id, msg) {
+            // 在容器顶部插入确认条
+            var confirmBar = document.createElement('div');
+            confirmBar.className = 'kc-delete-confirm';
+            confirmBar.style.cssText = 'display:flex;align-items:center;gap:10px;padding:10px 14px;background:rgba(239,68,68,0.08);border:1px solid rgba(239,68,68,0.2);border-radius:var(--radius-sm,6px);margin-bottom:10px;font-size:var(--text-xs);color:var(--text-primary);';
+            confirmBar.innerHTML =
+                '<span style="flex:1;">' + _esc(msg) + '</span>' +
+                '<button class="btn btn-sm btn-danger" data-action="confirm-delete" data-id="' + _esc(id) + '">确认删除</button>' +
+                '<button class="btn btn-sm btn-ghost" data-action="cancel-delete">取消</button>';
+
+            var body = container.querySelector('.kc-xl__body');
+            if (body) {
+                body.insertBefore(confirmBar, body.firstChild);
+            }
+
+            // 自动消失定时器
+            var autoClose = setTimeout(function() {
+                if (confirmBar.parentNode) confirmBar.parentNode.removeChild(confirmBar);
+            }, 10000);
+
+            // 绑定确认/取消事件
+            confirmBar.addEventListener('click', function(ev) {
+                var btn = ev.target.closest('[data-action]');
+                if (!btn) return;
+                var act = btn.getAttribute('data-action');
+                clearTimeout(autoClose);
+                if (act === 'confirm-delete') {
+                    _doDelete(btn.getAttribute('data-id'));
+                }
+                if (confirmBar.parentNode) confirmBar.parentNode.removeChild(confirmBar);
+            });
+        }
+
+        // ---------- 执行删除 ----------
+        async function _doDelete(id) {
+            try {
+                await _deleteItem(id);
+                // 从本地列表移除
+                items = items.filter(function(item) { return item.id !== id; });
+                categories = _extractCategories(items);
+                // 清除缓存
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_KEY);
+                }
+                if (Components.showToast) Components.showToast('删除成功', 'success');
+                // 返回列表
+                xlState = 'list';
+                currentItemId = null;
+                editItem = null;
+                _renderXlarge();
+            } catch (e) {
+                if (Components.showToast) Components.showToast('删除失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- 保存编辑 ----------
+        async function _handleSaveEdit() {
+            var data = _collectFormData();
+            if (!data.title || !data.title.trim()) {
+                if (Components.showToast) Components.showToast('标题不能为空', 'error');
+                return;
+            }
+
+            try {
+                var updated = await _updateItem(currentItemId, data);
+                // 更新本地列表
+                for (var i = 0; i < items.length; i++) {
+                    if (items[i].id === currentItemId) {
+                        items[i] = Object.assign({}, items[i], updated || data);
+                        break;
+                    }
+                }
+                categories = _extractCategories(items);
+                // 清除缓存
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_KEY);
+                }
+                if (Components.showToast) Components.showToast('保存成功', 'success');
+                editItem = null;
+                xlState = 'detail';
+                _renderXlarge();
+            } catch (e) {
+                if (Components.showToast) Components.showToast('保存失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- 保存新建 ----------
+        async function _handleSaveCreate() {
+            var data = _collectFormData();
+            if (!data.title || !data.title.trim()) {
+                if (Components.showToast) Components.showToast('标题不能为空', 'error');
+                return;
+            }
+
+            try {
+                var created = await _createItem(data);
+                // 添加到本地列表
+                if (created) {
+                    items.unshift(created);
+                } else {
+                    items.unshift(data);
+                }
+                categories = _extractCategories(items);
+                // 清除缓存
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_KEY);
+                }
+                if (Components.showToast) Components.showToast('创建成功', 'success');
+                xlState = 'list';
+                editItem = null;
+                _renderXlarge();
+            } catch (e) {
+                if (Components.showToast) Components.showToast('创建失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ========== 事件绑定 ==========
+        _clickHandler = _handleClick;
+        _inputHandler = _handleInput;
+        container.addEventListener('click', _clickHandler);
+        container.addEventListener('input', _inputHandler);
+
+        // SSE 事件订阅
+        if (typeof Bus !== 'undefined') {
+            _sseHandlers['sse:knowledge.updated'] = refresh;
+            _sseHandlers['sse:knowledge.created'] = refresh;
+            _sseHandlers['sse:knowledge.deleted'] = refresh;
+            Bus.on('sse:knowledge.updated', refresh);
+            Bus.on('sse:knowledge.created', refresh);
+            Bus.on('sse:knowledge.deleted', refresh);
+        }
+
+        // 初始加载数据
+        loadData();
+
+        // ========== 返回接口 ==========
+        return {
+            destroy: function() {
+                // 移除 DOM 事件
+                if (_clickHandler) container.removeEventListener('click', _clickHandler);
+                if (_inputHandler) container.removeEventListener('input', _inputHandler);
+
+                // 取消搜索防抖
+                if (debounceTimer) clearTimeout(debounceTimer);
+
+                // 取消 SSE 订阅
+                if (typeof Bus !== 'undefined') {
+                    Bus.off('sse:knowledge.updated', refresh);
+                    Bus.off('sse:knowledge.created', refresh);
+                    Bus.off('sse:knowledge.deleted', refresh);
+                }
+
+                // 清空内容
+                container.innerHTML = '';
+            },
+            refresh: function() {
+                loadData();
+            }
+        };
+    }
+
+    // ========== 入口卡片（简化版 1x1） ==========
+    async function mountEntry(container, props) {
+        _injectStyles();
+
+        var count = 0;
+        var loaded = false;
+
+        async function loadCount() {
+            try {
+                var data = await _fetchItems();
+                if (Array.isArray(data)) {
+                    count = data.length;
+                } else if (data && typeof data.total === 'number') {
+                    count = data.total;
+                }
+                loaded = true;
+                _renderEntry();
+            } catch (e) {
+                loaded = true;
+                _renderEntry();
+            }
+        }
+
+        function _renderEntry() {
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="kc-small" data-action="open-overlay">' +
+                        '<div class="kc-small__emoji">📖</div>' +
+                        '<div class="kc-small__label">知识库</div>' +
+                        (loaded
+                            ? '<div class="kc-small__count">' + count + '</div><div class="kc-small__unit">条知识</div>'
+                            : '<div class="kc-loading" style="padding:8px 0;"><div class="kc-loading__spinner" style="width:18px;height:18px;border-width:2px;"></div></div>') +
+                    '</div>' +
+                '</div>';
+        }
+
+        var _clickHandler = function(e) {
+            var target = e.target.closest('[data-action="open-overlay"]');
+            if (target && typeof CardOverlay !== 'undefined') {
+                CardOverlay.open('knowledge-card');
+            }
+        };
+        container.addEventListener('click', _clickHandler);
+
+        _renderEntry();
+        loadCount();
+
+        // SSE 事件订阅
+        if (typeof Bus !== 'undefined') {
+            var _sseRefresh = function() { loadCount(); };
+            Bus.on('sse:knowledge.created', _sseRefresh);
+            Bus.on('sse:knowledge.deleted', _sseRefresh);
+
+            return {
+                destroy: function() {
+                    container.removeEventListener('click', _clickHandler);
+                    if (typeof Bus !== 'undefined') {
+                        Bus.off('sse:knowledge.created', _sseRefresh);
+                        Bus.off('sse:knowledge.deleted', _sseRefresh);
+                    }
+                    container.innerHTML = '';
+                },
+                refresh: function() { loadCount(); }
+            };
+        }
+
+        return {
+            destroy: function() {
+                container.removeEventListener('click', _clickHandler);
+                container.innerHTML = '';
+            },
+            refresh: function() { loadCount(); }
+        };
+    }
+
+    // ========== 注册卡片 ==========
+    WidgetRegistry.register('knowledge-card', {
+        type: 'data',
+        label: '知识库',
+        icon: '📖',
+        description: '知识库管理，支持查看/创建/编辑/删除知识条目',
+        defaultSize: { w: 2, h: 1 },
+        category: 'data',
+        mount: mount
+    });
+
+    WidgetRegistry.register('knowledge-entry', {
+        type: 'entry',
+        label: '知识库入口',
+        icon: '📖',
+        description: '知识库快速入口',
+        defaultSize: { w: 1, h: 1 },
+        category: 'entries',
+        mount: mountEntry
+    });
+
+    // ========== 公开接口（调试用） ==========
+    return {
+        mount: mount,
+        mountEntry: mountEntry
+    };
+})();

--- a/frontend/js/workspace/widgets/cards/LogsCard.js
+++ b/frontend/js/workspace/widgets/cards/LogsCard.js
@@ -1,0 +1,444 @@
+;(function() {
+  'use strict';
+
+  /* ========== CSS ========== */
+  var STYLE_ID = 'hermes-logs-card-css';
+  var PFX = 'lc';
+
+  function injectCSS() {
+    if (document.getElementById(STYLE_ID)) return;
+    var s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = [
+      '.' + PFX + '-root { width:100%; height:100%; display:flex; flex-direction:column; font-family:inherit; color:var(--text-primary,#e0e0e0); background:var(--card-bg,#1e1e2e); border-radius:12px; overflow:hidden; }',
+      '.' + PFX + '-header { display:flex; align-items:center; justify-content:space-between; padding:10px 14px; background:var(--card-header-bg,#2a2a3e); border-bottom:1px solid var(--border,#333); flex-shrink:0; }',
+      '.' + PFX + '-header-title { font-size:14px; font-weight:600; display:flex; align-items:center; gap:6px; }',
+      '.' + PFX + '-header-title span.icon { font-size:16px; }',
+      '.' + PFX + '-body { flex:1; overflow-y:auto; padding:12px; }',
+      '.' + PFX + '-body::-webkit-scrollbar { width:4px; }',
+      '.' + PFX + '-body::-webkit-scrollbar-thumb { background:var(--scrollbar,#555); border-radius:2px; }',
+
+      /* Small */
+      '.' + PFX + '-small { display:flex; flex-direction:column; align-items:center; justify-content:center; cursor:pointer; gap:6px; transition:background .2s; position:relative; }',
+      '.' + PFX + '-small:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-small-icon { font-size:28px; }',
+      '.' + PFX + '-small-label { font-size:12px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-badge { position:absolute; top:6px; right:6px; background:#e74c3c; color:#fff; font-size:10px; font-weight:700; min-width:18px; height:18px; border-radius:9px; display:flex; align-items:center; justify-content:center; padding:0 5px; }',
+
+      /* Log item */
+      '.' + PFX + '-log-item { display:flex; align-items:flex-start; gap:8px; padding:6px 8px; border-bottom:1px solid var(--border,#333); font-size:11px; line-height:1.4; }',
+      '.' + PFX + '-log-item:last-child { border-bottom:none; }',
+      '.' + PFX + '-log-level { flex-shrink:0; padding:1px 6px; border-radius:3px; font-size:9px; font-weight:700; text-transform:uppercase; min-width:42px; text-align:center; }',
+      '.' + PFX + '-level-DEBUG { background:rgba(150,150,150,.2); color:#999; }',
+      '.' + PFX + '-level-INFO { background:rgba(52,152,219,.2); color:#3498db; }',
+      '.' + PFX + '-level-WARNING { background:rgba(243,156,18,.2); color:#f39c12; }',
+      '.' + PFX + '-level-ERROR { background:rgba(231,76,60,.2); color:#e74c3c; }',
+      '.' + PFX + '-log-content { flex:1; min-width:0; }',
+      '.' + PFX + '-log-msg { color:var(--text-primary,#e0e0e0); word-break:break-all; }',
+      '.' + PFX + '-log-msg-trunc { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:100%; }',
+      '.' + PFX + '-log-source { color:var(--text-secondary,#888); font-size:10px; margin-top:1px; }',
+      '.' + PFX + '-log-time { flex-shrink:0; color:var(--text-secondary,#888); font-size:10px; white-space:nowrap; }',
+
+      /* Filter buttons */
+      '.' + PFX + '-filters { display:flex; gap:4px; padding:8px 12px; flex-shrink:0; flex-wrap:wrap; }',
+      '.' + PFX + '-filter-btn { padding:3px 10px; border:1px solid var(--border,#333); border-radius:12px; background:transparent; color:var(--text-secondary,#aaa); font-size:10px; cursor:pointer; transition:all .2s; }',
+      '.' + PFX + '-filter-btn:hover { border-color:var(--accent,#7c6ff7); color:var(--text-primary,#e0e0e0); }',
+      '.' + PFX + '-filter-btn.active { background:var(--accent,#7c6ff7); border-color:var(--accent,#7c6ff7); color:#fff; }',
+
+      /* Search */
+      '.' + PFX + '-search { padding:0 12px 8px; flex-shrink:0; }',
+      '.' + PFX + '-search-input { width:100%; padding:6px 10px; background:var(--input-bg,#1a1a2e); border:1px solid var(--border,#333); border-radius:6px; color:var(--text-primary,#e0e0e0); font-size:11px; outline:none; box-sizing:border-box; }',
+      '.' + PFX + '-search-input:focus { border-color:var(--accent,#7c6ff7); }',
+      '.' + PFX + '-search-input::placeholder { color:var(--text-secondary,#666); }',
+
+      /* Buttons */
+      '.' + PFX + '-btn { padding:5px 12px; border:none; border-radius:6px; font-size:11px; font-weight:500; cursor:pointer; transition:all .2s; }',
+      '.' + PFX + '-btn-danger { background:#e74c3c; color:#fff; }',
+      '.' + PFX + '-btn-danger:hover { filter:brightness(1.15); }',
+
+      /* Header actions */
+      '.' + PFX + '-header-actions { display:flex; gap:4px; }',
+
+      /* States */
+      '.' + PFX + '-loading, .' + PFX + '-error, .' + PFX + '-empty { display:flex; align-items:center; justify-content:center; flex:1; font-size:13px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-error { color:#e74c3c; }',
+      '.' + PFX + '-spinner { width:20px; height:20px; border:2px solid var(--border,#333); border-top-color:var(--accent,#7c6ff7); border-radius:50%; animation:' + PFX + '-spin .6s linear infinite; margin-right:8px; }',
+      '@keyframes ' + PFX + '-spin { to { transform:rotate(360deg); } }',
+
+      /* Auto-scroll indicator */
+      '.' + PFX + '-scroll-bottom { position:absolute; bottom:8px; right:8px; width:28px; height:28px; border-radius:50%; background:var(--accent,#7c6ff7); color:#fff; border:none; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:14px; box-shadow:0 2px 8px rgba(0,0,0,.3); opacity:0; transition:opacity .3s; pointer-events:none; }',
+      '.' + PFX + '-scroll-bottom.visible { opacity:1; pointer-events:auto; }'
+    ].join('\n');
+    document.head.appendChild(s);
+  }
+
+  /* ========== Helpers ========== */
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $$(sel, ctx) { return Array.prototype.slice.call((ctx || document).querySelectorAll(sel)); }
+  function el(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html !== undefined) e.innerHTML = html;
+    return e;
+  }
+  function formatTime(ts) {
+    if (!ts) return '';
+    var d = new Date(ts);
+    return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0') + ':' + String(d.getSeconds()).padStart(2,'0');
+  }
+  function formatTimeFull(ts) {
+    if (!ts) return '';
+    var d = new Date(ts);
+    return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0') + ' ' + String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0') + ':' + String(d.getSeconds()).padStart(2,'0');
+  }
+  function truncate(str, len) {
+    if (!str) return '';
+    return str.length > len ? str.substring(0, len) + '...' : str;
+  }
+
+  /* ========== Card Component ========== */
+  function LogsCard(container, opts) {
+    this.container = container;
+    this.opts = opts || {};
+    this.size = this.opts.size || 'medium';
+    this.logs = [];
+    this.stats = { DEBUG: 0, INFO: 0, WARNING: 0, ERROR: 0 };
+    this.levelFilter = 'ALL';
+    this.searchQuery = '';
+    this.loading = false;
+    this.error = null;
+    this.autoScroll = true;
+    this._subs = [];
+    this._bound = {};
+    injectCSS();
+    this.render();
+    this._bindEvents();
+    this.fetchLogs();
+    this.fetchStats();
+  }
+
+  LogsCard.prototype._bindEvents = function() {
+    var self = this;
+    this._bound._delegate = function(e) {
+      var t = e.target.closest('[data-action]');
+      if (!t) return;
+      var action = t.getAttribute('data-action');
+      var id = t.getAttribute('data-id') || '';
+      self._handleAction(action, id, e);
+    };
+    this.container.addEventListener('click', this._bound._delegate);
+  };
+
+  LogsCard.prototype._handleAction = function(action, id) {
+    switch (action) {
+      case 'open-overlay':
+        CardOverlay.open('logs-card', { w: 2, h: 2 });
+        break;
+      case 'filter-level':
+        this.levelFilter = id;
+        this.render();
+        break;
+      case 'clear-logs':
+        this.clearLogs();
+        break;
+      case 'scroll-bottom':
+        this._scrollToBottom();
+        break;
+    }
+  };
+
+  /* ========== Data ========== */
+  LogsCard.prototype.fetchLogs = function() {
+    var self = this;
+    this.loading = true;
+    this.error = null;
+    this.render();
+    var params = '?limit=100';
+    if (this.levelFilter !== 'ALL') params += '&level=' + this.levelFilter;
+    HermesClient.get('/api/logs' + params).then(function(data) {
+      self.logs = Array.isArray(data) ? data : (data.logs || []);
+      self.loading = false;
+      self.render();
+      if (self.autoScroll) self._scrollToBottom();
+    }).catch(function(err) {
+      self.error = err.message || '加载日志失败';
+      self.loading = false;
+      self.render();
+    });
+  };
+
+  LogsCard.prototype.fetchStats = function() {
+    var self = this;
+    HermesClient.get('/api/logs/stats').then(function(data) {
+      self.stats = data || { DEBUG: 0, INFO: 0, WARNING: 0, ERROR: 0 };
+      self.render();
+    }).catch(function() {
+      /* stats optional */
+    });
+  };
+
+  LogsCard.prototype.clearLogs = function() {
+    var self = this;
+    /* Assuming a DELETE /api/logs endpoint for clearing */
+    HermesClient.delete('/api/logs').then(function() {
+      self.logs = [];
+      self.stats = { DEBUG: 0, INFO: 0, WARNING: 0, ERROR: 0 };
+      Bus.emit('notification', { type: 'success', message: '日志已清空' });
+      self.render();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '清空失败: ' + (err.message || '') });
+    });
+  };
+
+  LogsCard.prototype._getFilteredLogs = function() {
+    var self = this;
+    var logs = this.logs;
+    if (this.levelFilter !== 'ALL') {
+      logs = logs.filter(function(l) { return l.level === self.levelFilter; });
+    }
+    if (this.searchQuery) {
+      var q = this.searchQuery.toLowerCase();
+      logs = logs.filter(function(l) {
+        return (l.message && l.message.toLowerCase().indexOf(q) !== -1) ||
+               (l.source && l.source.toLowerCase().indexOf(q) !== -1);
+      });
+    }
+    return logs;
+  };
+
+  LogsCard.prototype._scrollToBottom = function() {
+    var body = $('.' + PFX + '-body', this.container);
+    if (body) body.scrollTop = body.scrollHeight;
+  };
+
+  /* ========== Render ========== */
+  LogsCard.prototype.render = function() {
+    var c = this.container;
+    c.innerHTML = '';
+    var root = el('div', PFX + '-root');
+    root.appendChild(this._renderHeader());
+    if (this.loading) {
+      root.appendChild(el('div', PFX + '-loading', '<div class="' + PFX + '-spinner"></div>加载中...'));
+    } else if (this.error) {
+      root.appendChild(el('div', PFX + '-error', this.error));
+    } else {
+      var body = this._renderBody();
+      if (body) root.appendChild(body);
+    }
+    c.appendChild(root);
+  };
+
+  LogsCard.prototype._renderHeader = function() {
+    var h = el('div', PFX + '-header');
+    h.innerHTML = '<div class="' + PFX + '-header-title"><span class="icon">\uD83D\uDCDD</span>系统日志</div>';
+    return h;
+  };
+
+  LogsCard.prototype._renderBody = function() {
+    switch (this.size) {
+      case 'small': return this._renderSmall();
+      case 'medium': return this._renderMedium();
+      case 'large': return this._renderLarge();
+      case 'xlarge': return this._renderXLarge();
+      default: return this._renderMedium();
+    }
+  };
+
+  LogsCard.prototype._renderSmall = function() {
+    var body = el('div', PFX + '-body ' + PFX + '-small');
+    body.setAttribute('data-action', 'open-overlay');
+    body.style.position = 'relative';
+    var errCount = this.stats.ERROR || 0;
+    var badgeHtml = errCount > 0 ? '<div class="' + PFX + '-badge">' + errCount + '</div>' : '';
+    body.innerHTML = '<div class="' + PFX + '-small-icon">\uD83D\uDCDD</div><div class="' + PFX + '-small-label">日志</div>' + badgeHtml;
+    return body;
+  };
+
+  LogsCard.prototype._renderMedium = function() {
+    var body = el('div', PFX + '-body');
+    var logs = this.logs.slice(-5);
+    if (logs.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '暂无日志'));
+      return body;
+    }
+    logs.forEach(function(log) {
+      var item = el('div', PFX + '-log-item');
+      item.innerHTML =
+        '<span class="' + PFX + '-log-level ' + PFX + '-level-' + (log.level || 'INFO') + '">' + (log.level || 'INFO') + '</span>' +
+        '<div class="' + PFX + '-log-content"><div class="' + PFX + '-log-msg ' + PFX + '-log-msg-trunc">' + (log.message || '') + '</div></div>' +
+        '<span class="' + PFX + '-log-time">' + formatTime(log.timestamp) + '</span>';
+      body.appendChild(item);
+    });
+    return body;
+  };
+
+  LogsCard.prototype._renderLarge = function() {
+    var self = this;
+    var root = el('div', '');
+
+    /* Level filter buttons */
+    var filters = el('div', PFX + '-filters');
+    var levels = ['ALL', 'INFO', 'WARNING', 'ERROR'];
+    levels.forEach(function(lv) {
+      var btn = el('button', PFX + '-filter-btn' + (self.levelFilter === lv ? ' active' : ''));
+      btn.setAttribute('data-action', 'filter-level');
+      btn.setAttribute('data-id', lv);
+      btn.textContent = lv;
+      filters.appendChild(btn);
+    });
+    root.appendChild(filters);
+
+    /* Log list */
+    var body = el('div', PFX + '-body');
+    var logs = this._getFilteredLogs();
+    if (logs.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '暂无日志'));
+    } else {
+      logs.forEach(function(log) {
+        var item = el('div', PFX + '-log-item');
+        item.innerHTML =
+          '<span class="' + PFX + '-log-level ' + PFX + '-level-' + (log.level || 'INFO') + '">' + (log.level || 'INFO') + '</span>' +
+          '<div class="' + PFX + '-log-content">' +
+            '<div class="' + PFX + '-log-msg">' + (log.message || '') + '</div>' +
+            '<div class="' + PFX + '-log-source">' + (log.source || '') + '</div>' +
+          '</div>' +
+          '<span class="' + PFX + '-log-time">' + formatTime(log.timestamp) + '</span>';
+        body.appendChild(item);
+      });
+    }
+    root.appendChild(body);
+    return root;
+  };
+
+  LogsCard.prototype._renderXLarge = function() {
+    var self = this;
+    var root = el('div', '');
+
+    /* Header with clear button */
+    var header = el('div', PFX + '-header');
+    header.innerHTML = '<div class="' + PFX + '-header-title"><span class="icon">\uD83D\uDCDD</span>系统日志</div><div class="' + PFX + '-header-actions"><button class="' + PFX + '-btn ' + PFX + '-btn-danger" data-action="clear-logs">清空日志</button></div>';
+    root.appendChild(header);
+
+    /* Level filters */
+    var filters = el('div', PFX + '-filters');
+    var levels = ['ALL', 'DEBUG', 'INFO', 'WARNING', 'ERROR'];
+    levels.forEach(function(lv) {
+      var btn = el('button', PFX + '-filter-btn' + (self.levelFilter === lv ? ' active' : ''));
+      btn.setAttribute('data-action', 'filter-level');
+      btn.setAttribute('data-id', lv);
+      btn.textContent = lv;
+      filters.appendChild(btn);
+    });
+    root.appendChild(filters);
+
+    /* Search */
+    var search = el('div', PFX + '-search');
+    var searchInput = el('input', PFX + '-search-input');
+    searchInput.type = 'text';
+    searchInput.placeholder = '搜索日志...';
+    searchInput.value = this.searchQuery;
+    searchInput.addEventListener('input', function(e) {
+      self.searchQuery = e.target.value;
+      self.render();
+    });
+    search.appendChild(searchInput);
+    root.appendChild(search);
+
+    /* Log list */
+    var bodyWrap = el('div', '');
+    bodyWrap.style.position = 'relative';
+    bodyWrap.style.flex = '1';
+    bodyWrap.style.overflow = 'hidden';
+    var body = el('div', PFX + '-body');
+    var logs = this._getFilteredLogs();
+    if (logs.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '暂无日志'));
+    } else {
+      logs.forEach(function(log) {
+        var item = el('div', PFX + '-log-item');
+        item.innerHTML =
+          '<span class="' + PFX + '-log-level ' + PFX + '-level-' + (log.level || 'INFO') + '">' + (log.level || 'INFO') + '</span>' +
+          '<div class="' + PFX + '-log-content">' +
+            '<div class="' + PFX + '-log-msg">' + (log.message || '') + '</div>' +
+            (log.source ? '<div class="' + PFX + '-log-source">' + log.source + '</div>' : '') +
+          '</div>' +
+          '<span class="' + PFX + '-log-time">' + formatTimeFull(log.timestamp) + '</span>';
+        body.appendChild(item);
+      });
+    }
+    bodyWrap.appendChild(body);
+
+    /* Scroll to bottom button */
+    var scrollBtn = el('button', PFX + '-scroll-bottom');
+    scrollBtn.setAttribute('data-action', 'scroll-bottom');
+    scrollBtn.textContent = '\u2193';
+    scrollBtn.title = '滚动到底部';
+    bodyWrap.appendChild(scrollBtn);
+
+    root.appendChild(bodyWrap);
+    root.style.display = 'flex';
+    root.style.flexDirection = 'column';
+    root.style.flex = '1';
+
+    return root;
+  };
+
+  /* ========== SSE ========== */
+  LogsCard.prototype.subscribe = function() {
+    var self = this;
+    if (typeof DataService !== 'undefined' && DataService.subscribe) {
+      var sub = DataService.subscribe('logs:new', function(data) {
+        if (data && data.log) {
+          self.logs.push(data.log);
+          if (self.logs.length > 200) self.logs = self.logs.slice(-200);
+          if (data.log.level === 'ERROR') self.stats.ERROR = (self.stats.ERROR || 0) + 1;
+          self.render();
+          if (self.autoScroll && self.size === 'xlarge') self._scrollToBottom();
+        }
+      });
+      this._subs.push(sub);
+    }
+  };
+
+  /* ========== Destroy ========== */
+  LogsCard.prototype.destroy = function() {
+    this.container.removeEventListener('click', this._bound._delegate);
+    this._subs.forEach(function(s) { if (s && s.unsubscribe) s.unsubscribe(); });
+    this._subs = [];
+    this.container.innerHTML = '';
+  };
+
+  /* ========== Mount ========== */
+  function mount(container, opts) {
+    var card = new LogsCard(container, opts);
+    card.subscribe();
+    return card;
+  }
+
+  function mountEntry(container, opts) {
+    var card = new LogsCard(container, Object.assign({}, opts, { size: 'small' }));
+    card.subscribe();
+    return card;
+  }
+
+  /* ========== Register ========== */
+  if (typeof WidgetRegistry !== 'undefined') {
+    WidgetRegistry.register('logs-card', {
+      type: 'data',
+      label: '系统日志',
+      icon: '\uD83D\uDCDD',
+      defaultSize: { w: 2, h: 1 },
+      category: 'data',
+      mount: mount
+    });
+    WidgetRegistry.register('logs-entry', {
+      type: 'entry',
+      label: '日志入口',
+      icon: '\uD83D\uDCDD',
+      defaultSize: { w: 1, h: 1 },
+      category: 'entries',
+      mount: mountEntry
+    });
+  }
+
+})();

--- a/frontend/js/workspace/widgets/cards/MarketplaceCard.js
+++ b/frontend/js/workspace/widgets/cards/MarketplaceCard.js
@@ -1,0 +1,1321 @@
+/**
+ * MarketplaceCard.js - 功能商店卡片
+ *
+ * 支持 4 种尺寸: small(1x1) / medium(2x1) / large(2x2) / xlarge(全屏覆盖)
+ * 管理 MCP 服务、技能、工具、插件四大类功能模块
+ *
+ * 依赖全局: WidgetRegistry, HermesClient, DataService, CardOverlay, Components, Bus
+ */
+var MarketplaceCard = (() => {
+    'use strict';
+
+    // ========== 常量 ==========
+    var API_MCP_SERVERS = '/api/mcp/servers';
+    var API_SKILLS = '/api/skills';
+    var API_TOOLS = '/api/tools';
+    var API_PLUGINS_MARKET = '/api/plugins/market';
+    var API_PLUGINS_INSTALLED = '/api/plugins';
+    var API_PLUGINS_INSTALL = '/api/plugins/install';
+    var SEARCH_DEBOUNCE_MS = 300;
+    var MAX_ITEMS_LARGE = 8;
+
+    // 标签页定义
+    var TABS = [
+        { key: 'mcp', label: 'MCP服务', icon: '\u{1F517}' },
+        { key: 'skills', label: '技能', icon: '\u{1F9E0}' },
+        { key: 'tools', label: '工具', icon: '\u{1F6E0}\uFE0F' },
+        { key: 'plugins', label: '插件', icon: '\u{1F4E6}' }
+    ];
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (document.getElementById('mpc-styles')) return;
+        var style = document.createElement('style');
+        style.id = 'mpc-styles';
+        style.textContent = [
+            /* ===== 基础布局 ===== */
+            '.mpc-root { display:flex; flex-direction:column; height:100%; overflow:hidden; }',
+            '.mpc-header { display:flex; align-items:center; gap:8px; padding:12px 14px 8px; flex-shrink:0; }',
+            '.mpc-header__icon { font-size:18px; flex-shrink:0; }',
+            '.mpc-header__title { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; }',
+            '.mpc-header__count { font-size:var(--text-xs, 11px); color:var(--text-tertiary); flex-shrink:0; }',
+            '.mpc-body { flex:1; overflow-y:auto; overflow-x:hidden; padding:0 14px 12px; -webkit-overflow-scrolling:touch; }',
+            '.mpc-body::-webkit-scrollbar { width:4px; }',
+            '.mpc-body::-webkit-scrollbar-thumb { background:rgba(0,0,0,0.12); border-radius:2px; }',
+
+            /* ===== Small 尺寸 ===== */
+            '.mpc-small { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; cursor:pointer; padding:16px 8px; text-align:center; transition:opacity 0.15s; }',
+            '.mpc-small:hover { opacity:0.85; }',
+            '.mpc-small__emoji { font-size:32px; margin-bottom:6px; }',
+            '.mpc-small__label { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); }',
+            '.mpc-small__count { font-size:var(--text-2xl, 20px); font-weight:700; color:var(--accent); margin-top:4px; }',
+            '.mpc-small__unit { font-size:var(--text-xs, 11px); color:var(--text-tertiary); margin-top:2px; }',
+
+            /* ===== Medium 统计行 ===== */
+            '.mpc-stats { display:flex; gap:4px; padding:0 14px 12px; }',
+            '.mpc-stat { flex:1; display:flex; flex-direction:column; align-items:center; padding:8px 4px; border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s; gap:2px; }',
+            '.mpc-stat:hover { background:var(--bg-tertiary, rgba(0,0,0,0.04)); }',
+            '.mpc-stat__icon { font-size:16px; }',
+            '.mpc-stat__value { font-size:var(--text-sm, 13px); font-weight:700; color:var(--text-primary); }',
+            '.mpc-stat__label { font-size:10px; color:var(--text-tertiary); }',
+
+            /* ===== Large 标签按钮 ===== */
+            '.mpc-tabs { display:flex; gap:4px; padding:0 14px 8px; flex-shrink:0; overflow-x:auto; -webkit-overflow-scrolling:touch; }',
+            '.mpc-tabs::-webkit-scrollbar { display:none; }',
+            '.mpc-tab { padding:4px 10px; border:1px solid var(--border); border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs, 11px); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.mpc-tab:hover { border-color:var(--accent); color:var(--accent); }',
+            '.mpc-tab.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+
+            /* ===== Large 列表项 ===== */
+            '.mpc-list { display:flex; flex-direction:column; gap:4px; }',
+            '.mpc-item { display:flex; align-items:center; gap:8px; padding:6px 8px; border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s; }',
+            '.mpc-item:hover { background:var(--bg-tertiary, rgba(0,0,0,0.04)); }',
+            '.mpc-item__name { font-size:var(--text-xs, 11px); color:var(--text-primary); flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }',
+            '.mpc-item__badge { font-size:10px; padding:1px 6px; border-radius:var(--radius-xs, 4px); flex-shrink:0; }',
+            '.mpc-item__badge--connected { background:rgba(34,197,94,0.1); color:#22c55e; }',
+            '.mpc-item__badge--unknown { background:rgba(234,179,8,0.1); color:#eab308; }',
+            '.mpc-item__badge--active { background:rgba(34,197,94,0.1); color:#22c55e; }',
+            '.mpc-item__badge--disabled { background:rgba(156,163,175,0.1); color:#9ca3af; }',
+            '.mpc-item__badge--installed { background:rgba(99,102,241,0.1); color:#6366f1; }',
+            '.mpc-item__count { font-size:10px; color:var(--text-tertiary); flex-shrink:0; }',
+            '.mpc-item__toggle { width:32px; height:18px; border-radius:9px; border:none; cursor:pointer; position:relative; transition:background 0.2s; flex-shrink:0; }',
+            '.mpc-item__toggle.on { background:var(--accent); }',
+            '.mpc-item__toggle.off { background:var(--border); }',
+            '.mpc-item__toggle::after { content:""; position:absolute; top:2px; width:14px; height:14px; border-radius:50%; background:#fff; transition:left 0.2s; }',
+            '.mpc-item__toggle.on::after { left:16px; }',
+            '.mpc-item__toggle.off::after { left:2px; }',
+
+            /* ===== Xlarge 全屏覆盖 ===== */
+            '.mpc-xl { display:flex; flex-direction:column; height:100%; }',
+            '.mpc-xl__header { display:flex; align-items:center; gap:10px; padding:16px 20px 12px; flex-shrink:0; border-bottom:1px solid var(--border); }',
+            '.mpc-xl__title { font-size:var(--text-lg, 16px); font-weight:700; color:var(--text-primary); flex:1; }',
+            '.mpc-xl__body { flex:1; overflow-y:auto; padding:16px 20px; -webkit-overflow-scrolling:touch; }',
+            '.mpc-xl__body::-webkit-scrollbar { width:6px; }',
+            '.mpc-xl__body::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }',
+
+            /* ===== Xlarge 标签页 ===== */
+            '.mpc-xl__tabs { display:flex; gap:6px; padding:12px 20px 0; flex-shrink:0; overflow-x:auto; -webkit-overflow-scrolling:touch; }',
+            '.mpc-xl__tabs::-webkit-scrollbar { display:none; }',
+            '.mpc-xl__tab { padding:6px 16px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-sm); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.mpc-xl__tab:hover { border-color:var(--accent); color:var(--accent); }',
+            '.mpc-xl__tab.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+
+            /* ===== Xlarge 统计行 ===== */
+            '.mpc-xl__stats { display:flex; gap:16px; padding:12px 20px; flex-shrink:0; border-bottom:1px solid var(--border); }',
+            '.mpc-xl__stat { display:flex; align-items:center; gap:6px; font-size:var(--text-sm); color:var(--text-secondary); }',
+            '.mpc-xl__stat-value { font-weight:700; color:var(--text-primary); }',
+
+            /* ===== Xlarge 搜索栏 ===== */
+            '.mpc-xl__search { display:flex; align-items:center; gap:8px; padding:12px 20px; flex-shrink:0; }',
+            '.mpc-xl__search-input { flex:1; max-width:320px; padding:7px 12px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-sm); outline:none; transition:border-color 0.15s; }',
+            '.mpc-xl__search-input:focus { border-color:var(--accent); }',
+            '.mpc-xl__search-input::placeholder { color:var(--text-tertiary); }',
+            '.mpc-xl__filter { padding:5px 12px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.mpc-xl__filter:hover { border-color:var(--accent); color:var(--accent); }',
+            '.mpc-xl__filter.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+
+            /* ===== Xlarge 操作栏 ===== */
+            '.mpc-xl__actions { display:flex; gap:8px; padding:0 20px 12px; flex-shrink:0; }',
+            '.mpc-xl__btn { padding:6px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs); cursor:pointer; transition:all 0.15s; display:flex; align-items:center; gap:4px; }',
+            '.mpc-xl__btn:hover { border-color:var(--accent); color:var(--accent); }',
+            '.mpc-xl__btn--primary { background:var(--accent); color:#fff; border-color:var(--accent); }',
+            '.mpc-xl__btn--primary:hover { opacity:0.85; }',
+            '.mpc-xl__btn--danger:hover { border-color:var(--red, #ef4444); color:var(--red, #ef4444); }',
+
+            /* ===== Xlarge 服务器列表 ===== */
+            '.mpc-xl__list { display:flex; flex-direction:column; gap:8px; }',
+            '.mpc-xl__card { padding:12px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 8px); transition:background 0.15s, box-shadow 0.15s; }',
+            '.mpc-xl__card:hover { background:var(--bg-tertiary); box-shadow:var(--shadow, 0 1px 3px rgba(0,0,0,0.08)); }',
+            '.mpc-xl__card-top { display:flex; align-items:center; gap:10px; margin-bottom:4px; }',
+            '.mpc-xl__card-name { font-size:var(--text-sm); font-weight:600; color:var(--text-primary); flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }',
+            '.mpc-xl__card-actions { display:flex; gap:4px; flex-shrink:0; }',
+            '.mpc-xl__card-action { width:28px; height:28px; display:flex; align-items:center; justify-content:center; border:none; border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-tertiary); cursor:pointer; font-size:14px; transition:all 0.15s; }',
+            '.mpc-xl__card-action:hover { background:var(--bg-tertiary); color:var(--text-primary); }',
+            '.mpc-xl__card-action.danger:hover { background:rgba(239,68,68,0.1); color:var(--red, #ef4444); }',
+            '.mpc-xl__card-desc { font-size:var(--text-xs); color:var(--text-secondary); margin-bottom:6px; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; line-height:1.5; }',
+            '.mpc-xl__card-meta { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }',
+            '.mpc-xl__card-badge { font-size:10px; padding:2px 8px; border-radius:var(--radius-xs, 4px); background:rgba(99,102,241,0.1); color:#6366f1; }',
+            '.mpc-xl__card-url { font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono, monospace); }',
+            '.mpc-xl__card-status { width:8px; height:8px; border-radius:50%; flex-shrink:0; }',
+            '.mpc-xl__card-status.connected { background:#22c55e; }',
+            '.mpc-xl__card-status.unknown { background:#eab308; }',
+
+            /* ===== Xlarge 添加服务器表单 ===== */
+            '.mpc-xl__form { padding:12px 14px; border:1px dashed var(--border); border-radius:var(--radius-sm, 8px); margin-top:12px; display:flex; flex-direction:column; gap:8px; }',
+            '.mpc-xl__form-row { display:flex; gap:8px; align-items:center; }',
+            '.mpc-xl__form-input { flex:1; padding:6px 10px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-xs); outline:none; transition:border-color 0.15s; }',
+            '.mpc-xl__form-input:focus { border-color:var(--accent); }',
+            '.mpc-xl__form-input::placeholder { color:var(--text-tertiary); }',
+            '.mpc-xl__form-label { font-size:var(--text-xs); color:var(--text-secondary); font-weight:500; white-space:nowrap; }',
+
+            /* ===== Xlarge 插件子标签 ===== */
+            '.mpc-xl__sub-tabs { display:flex; gap:4px; margin-bottom:12px; }',
+            '.mpc-xl__sub-tab { padding:4px 12px; border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs); cursor:pointer; border:none; transition:all 0.15s; }',
+            '.mpc-xl__sub-tab:hover { background:var(--bg-secondary); }',
+            '.mpc-xl__sub-tab.active { background:var(--accent); color:#fff; }',
+
+            /* ===== Xlarge 工具网格 ===== */
+            '.mpc-xl__grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:8px; }',
+            '.mpc-xl__grid-card { padding:10px 12px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); display:flex; flex-direction:column; gap:4px; transition:background 0.15s; }',
+            '.mpc-xl__grid-card:hover { background:var(--bg-tertiary); }',
+            '.mpc-xl__grid-card-top { display:flex; align-items:center; justify-content:space-between; gap:8px; }',
+            '.mpc-xl__grid-card-name { font-size:var(--text-xs); font-weight:600; color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }',
+            '.mpc-xl__grid-card-desc { font-size:10px; color:var(--text-tertiary); display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; line-height:1.4; }',
+            '.mpc-xl__grid-card-toolset { font-size:10px; color:var(--text-tertiary); }',
+
+            /* ===== 状态提示 ===== */
+            '.mpc-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:40px 20px; color:var(--text-tertiary); text-align:center; }',
+            '.mpc-empty__icon { font-size:40px; margin-bottom:10px; opacity:0.5; }',
+            '.mpc-empty__text { font-size:var(--text-sm); }',
+            '.mpc-error { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:30px 20px; text-align:center; gap:10px; }',
+            '.mpc-error__icon { font-size:32px; }',
+            '.mpc-error__text { font-size:var(--text-sm); color:var(--red, #ef4444); }',
+            '.mpc-loading { display:flex; align-items:center; justify-content:center; padding:30px; }',
+            '.mpc-loading__spinner { width:24px; height:24px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:mpc-spin 0.6s linear infinite; }',
+            '@keyframes mpc-spin { to { transform:rotate(360deg); } }',
+
+            /* ===== 骨架屏 ===== */
+            '.mpc-skeleton { display:flex; flex-direction:column; gap:8px; padding:12px 14px; }',
+            '.mpc-skeleton__line { height:12px; border-radius:4px; background:linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-secondary) 50%, var(--bg-tertiary) 75%); background-size:200% 100%; animation:mpc-shimmer 1.5s infinite; }',
+            '.mpc-skeleton__line.short { width:60%; }',
+            '@keyframes mpc-shimmer { 0% { background-position:200% 0; } 100% { background-position:-200% 0; } }'
+        ].join('\n');
+        document.head.appendChild(style);
+    }
+
+    // ========== 工具函数 ==========
+
+    /** HTML 转义 */
+    function _esc(str) {
+        if (!str) return '';
+        if (typeof Components !== 'undefined' && Components.escapeHtml) {
+            return Components.escapeHtml(str);
+        }
+        return String(str).replace(/[&<>"']/g, function(c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
+    /** 截断文本 */
+    function _truncate(str, len) {
+        if (!str) return '';
+        return str.length > len ? str.slice(0, len) + '...' : str;
+    }
+
+    /** 显示 Toast */
+    function _toast(msg, type) {
+        if (typeof Components !== 'undefined' && Components.showToast) {
+            Components.showToast(msg, type);
+        } else {
+            console.log('[MarketplaceCard] ' + (type || 'info') + ': ' + msg);
+        }
+    }
+
+    /** 骨架屏 */
+    function _skeletonHtml(lines) {
+        var html = '<div class="mpc-skeleton">';
+        for (var i = 0; i < (lines || 4); i++) {
+            var cls = i === lines - 1 ? ' mpc-skeleton__line short' : '';
+            html += '<div class="mpc-skeleton__line' + cls + '"></div>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    /** 加载中 */
+    function _loadingHtml() {
+        return '<div class="mpc-loading"><div class="mpc-loading__spinner"></div></div>';
+    }
+
+    /** 空状态 */
+    function _emptyHtml(text) {
+        return '<div class="mpc-empty"><div class="mpc-empty__icon">\u{1F6D2}</div><div class="mpc-empty__text">' + (text || '暂无数据') + '</div></div>';
+    }
+
+    /** 错误状态 */
+    function _errorHtml(msg) {
+        return '<div class="mpc-error"><div class="mpc-error__icon">\u26A0\uFE0F</div><div class="mpc-error__text">' + _esc(msg || '加载失败') + '</div><button class="btn btn-sm btn-ghost" data-action="retry">重试</button></div>';
+    }
+
+    /** 判断尺寸 */
+    function _getSize(props) {
+        var config = props.config || {};
+        var w = config.w || 2;
+        var h = config.h || 1;
+        if (w <= 1 && h <= 1) return 'small';
+        if (w <= 2 && h <= 1) return 'medium';
+        if (w <= 2 && h <= 2) return 'large';
+        return 'xlarge';
+    }
+
+    /** 搜索过滤 */
+    function _filterByKeyword(items, keyword, fields) {
+        if (!Array.isArray(items)) return [];
+        if (!keyword || !keyword.trim()) return items;
+        var kw = keyword.toLowerCase().trim();
+        return items.filter(function(item) {
+            for (var i = 0; i < fields.length; i++) {
+                var val = item[fields[i]];
+                if (val && String(val).toLowerCase().indexOf(kw) !== -1) return true;
+            }
+            return false;
+        });
+    }
+
+    // ========== 数据获取 ==========
+
+    function _fetchMcpServers() {
+        return HermesClient.get(API_MCP_SERVERS).catch(function() { return []; });
+    }
+
+    function _fetchSkills() {
+        return HermesClient.get(API_SKILLS).catch(function() { return []; });
+    }
+
+    function _fetchTools() {
+        return HermesClient.get(API_TOOLS).catch(function() { return []; });
+    }
+
+    function _fetchPluginsMarket() {
+        return HermesClient.get(API_PLUGINS_MARKET).catch(function() { return []; });
+    }
+
+    function _fetchPluginsInstalled() {
+        return HermesClient.get(API_PLUGINS_INSTALLED).catch(function() { return []; });
+    }
+
+    function _addMcpServer(data) {
+        return HermesClient.post(API_MCP_SERVERS, data);
+    }
+
+    function _removeMcpServer(name) {
+        return HermesClient.del(API_MCP_SERVERS + '/' + encodeURIComponent(name));
+    }
+
+    function _refreshMcpServer(name) {
+        return HermesClient.post(API_MCP_SERVERS + '/' + encodeURIComponent(name) + '/refresh');
+    }
+
+    function _restartMcp() {
+        return HermesClient.post('/api/mcp/restart');
+    }
+
+    function _deleteSkill(name) {
+        return HermesClient.del(API_SKILLS + '/' + encodeURIComponent(name));
+    }
+
+    function _toggleTool(name, enabled) {
+        return HermesClient.post(API_TOOLS + '/' + encodeURIComponent(name) + '/toggle', { enabled: enabled });
+    }
+
+    function _installPlugin(name) {
+        return HermesClient.post(API_PLUGINS_INSTALL, { name: name });
+    }
+
+    function _uninstallPlugin(name) {
+        return HermesClient.del(API_PLUGINS + '/' + encodeURIComponent(name));
+    }
+
+    // ========== 主挂载函数 ==========
+
+    async function mount(container, props) {
+        var size = _getSize(props);
+
+        // 注入样式
+        _injectStyles();
+
+        // 内部状态
+        var mcpServers = [];
+        var skills = [];
+        var tools = [];
+        var pluginsMarket = [];
+        var pluginsInstalled = [];
+        var loading = true;
+        var error = null;
+        var activeTab = 'mcp';
+        var searchKeyword = '';
+        var pluginSubTab = 'market'; // 'market' | 'installed'
+        var toolsetFilter = '';
+        var typeFilter = '';
+        var debounceTimer = null;
+        var showAddServerForm = false;
+
+        // 事件处理函数引用
+        var _clickHandler = null;
+        var _inputHandler = null;
+        var _sseHandlers = [];
+
+        // ---------- 数据加载 ----------
+        async function loadData() {
+            loading = true;
+            error = null;
+            _render();
+
+            try {
+                var results = await Promise.all([
+                    _fetchMcpServers(),
+                    _fetchSkills(),
+                    _fetchTools(),
+                    _fetchPluginsMarket(),
+                    _fetchPluginsInstalled()
+                ]);
+                mcpServers = Array.isArray(results[0]) ? results[0] : [];
+                skills = Array.isArray(results[1]) ? results[1] : [];
+                tools = Array.isArray(results[2]) ? results[2] : [];
+                pluginsMarket = Array.isArray(results[3]) ? results[3] : [];
+                pluginsInstalled = Array.isArray(results[4]) ? results[4] : [];
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                loading = false;
+                error = e.message || '加载失败';
+                _render();
+            }
+        }
+
+        // ---------- 刷新（SSE 触发） ----------
+        async function refresh() {
+            try {
+                var results = await Promise.all([
+                    _fetchMcpServers(),
+                    _fetchSkills(),
+                    _fetchTools(),
+                    _fetchPluginsMarket(),
+                    _fetchPluginsInstalled()
+                ]);
+                mcpServers = Array.isArray(results[0]) ? results[0] : [];
+                skills = Array.isArray(results[1]) ? results[1] : [];
+                tools = Array.isArray(results[2]) ? results[2] : [];
+                pluginsMarket = Array.isArray(results[3]) ? results[3] : [];
+                pluginsInstalled = Array.isArray(results[4]) ? results[4] : [];
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                error = e.message || '刷新失败';
+                _render();
+            }
+        }
+
+        // ---------- 计算总数 ----------
+        function _totalCount() {
+            return mcpServers.length + skills.length + tools.length + pluginsInstalled.length;
+        }
+
+        // ---------- 提取唯一 toolset ----------
+        function _getToolsets() {
+            var set = {};
+            var result = [];
+            for (var i = 0; i < tools.length; i++) {
+                var ts = tools[i].toolset || 'default';
+                if (!set[ts]) {
+                    set[ts] = true;
+                    result.push(ts);
+                }
+            }
+            return result;
+        }
+
+        // ---------- 提取唯一插件类型 ----------
+        function _getPluginTypes() {
+            var set = {};
+            var result = [];
+            var all = pluginSubTab === 'market' ? pluginsMarket : pluginsInstalled;
+            for (var i = 0; i < all.length; i++) {
+                var t = all[i].type || 'other';
+                if (!set[t]) {
+                    set[t] = true;
+                    result.push(t);
+                }
+            }
+            return result;
+        }
+
+        // ---------- 渲染分发 ----------
+        function _render() {
+            switch (size) {
+                case 'small':  _renderSmall(); break;
+                case 'medium': _renderMedium(); break;
+                case 'large':  _renderLarge(); break;
+                case 'xlarge': _renderXlarge(); break;
+            }
+        }
+
+        // ========== Small 渲染 ==========
+        function _renderSmall() {
+            var count = _totalCount();
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="mpc-small" data-action="open-overlay">' +
+                        '<div class="mpc-small__emoji">\u{1F6D2}</div>' +
+                        '<div class="mpc-small__label">功能商店</div>' +
+                        (loading
+                            ? '<div class="mpc-loading" style="padding:8px 0;"><div class="mpc-loading__spinner" style="width:18px;height:18px;border-width:2px;"></div></div>'
+                            : '<div class="mpc-small__count">' + count + '</div>' +
+                              '<div class="mpc-small__unit">项功能</div>') +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== Medium 渲染 ==========
+        function _renderMedium() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="mpc-header"><span class="mpc-header__icon">\u{1F6D2}</span><span class="mpc-header__title">功能商店</span></div>' + _skeletonHtml(4) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="mpc-header"><span class="mpc-header__icon">\u{1F6D2}</span><span class="mpc-header__title">功能商店</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="mpc-header">' +
+                        '<span class="mpc-header__icon">\u{1F6D2}</span>' +
+                        '<span class="mpc-header__title">功能商店</span>' +
+                        '<span class="mpc-header__count">' + _totalCount() + '项</span>' +
+                    '</div>' +
+                    '<div class="mpc-stats">' +
+                        _renderStatItem('mcp', '\u{1F517}', mcpServers.length, 'MCP服务') +
+                        _renderStatItem('skills', '\u{1F9E0}', skills.length, '技能') +
+                        _renderStatItem('tools', '\u{1F6E0}\uFE0F', tools.length, '工具') +
+                        _renderStatItem('plugins', '\u{1F4E6}', pluginsInstalled.length, '插件') +
+                    '</div>' +
+                '</div>';
+        }
+
+        function _renderStatItem(tab, icon, value, label) {
+            return '<div class="mpc-stat" data-action="open-overlay-tab" data-tab="' + tab + '">' +
+                '<span class="mpc-stat__icon">' + icon + '</span>' +
+                '<span class="mpc-stat__value">' + value + '</span>' +
+                '<span class="mpc-stat__label">' + label + '</span>' +
+            '</div>';
+        }
+
+        // ========== Large 渲染 ==========
+        function _renderLarge() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="mpc-header"><span class="mpc-header__icon">\u{1F6D2}</span><span class="mpc-header__title">功能商店</span></div>' + _skeletonHtml(6) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="mpc-header"><span class="mpc-header__icon">\u{1F6D2}</span><span class="mpc-header__title">功能商店</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            // 标签按钮
+            var tabsHtml = '<div class="mpc-tabs">';
+            for (var i = 0; i < TABS.length; i++) {
+                var t = TABS[i];
+                tabsHtml += '<button class="mpc-tab' + (activeTab === t.key ? ' active' : '') + '" data-action="switch-tab" data-tab="' + t.key + '">' + t.icon + ' ' + t.label + '</button>';
+            }
+            tabsHtml += '</div>';
+
+            // 列表内容
+            var listHtml = '';
+            switch (activeTab) {
+                case 'mcp':
+                    listHtml = _renderLargeMcpList();
+                    break;
+                case 'skills':
+                    listHtml = _renderLargeSkillsList();
+                    break;
+                case 'tools':
+                    listHtml = _renderLargeToolsList();
+                    break;
+                case 'plugins':
+                    listHtml = _renderLargePluginsList();
+                    break;
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="mpc-header">' +
+                        '<span class="mpc-header__icon">\u{1F6D2}</span>' +
+                        '<span class="mpc-header__title">功能商店</span>' +
+                        '<span class="mpc-header__count">' + _totalCount() + '项</span>' +
+                    '</div>' +
+                    tabsHtml +
+                    '<div class="mpc-body">' + listHtml + '</div>' +
+                '</div>';
+        }
+
+        function _renderLargeMcpList() {
+            if (mcpServers.length === 0) return _emptyHtml('暂无 MCP 服务');
+            var html = '<div class="mpc-list">';
+            for (var i = 0; i < Math.min(mcpServers.length, MAX_ITEMS_LARGE); i++) {
+                var s = mcpServers[i];
+                var statusCls = s.status === 'connected' ? 'mpc-item__badge--connected' : 'mpc-item__badge--unknown';
+                html += '<div class="mpc-item" data-action="open-item" data-tab="mcp" data-item-id="' + _esc(s.name) + '">' +
+                    '<span class="mpc-xl__card-status ' + (s.status || 'unknown') + '"></span>' +
+                    '<span class="mpc-item__name">' + _esc(s.name) + '</span>' +
+                    '<span class="mpc-item__badge ' + statusCls + '">' + _esc(s.status || 'unknown') + '</span>' +
+                    '<span class="mpc-item__count">' + (s.tools_count || 0) + ' 工具</span>' +
+                '</div>';
+            }
+            html += '</div>';
+            return html;
+        }
+
+        function _renderLargeSkillsList() {
+            if (skills.length === 0) return _emptyHtml('暂无技能');
+            var html = '<div class="mpc-list">';
+            for (var i = 0; i < Math.min(skills.length, MAX_ITEMS_LARGE); i++) {
+                var s = skills[i];
+                var statusCls = s.status === 'active' ? 'mpc-item__badge--active' : 'mpc-item__badge--disabled';
+                html += '<div class="mpc-item" data-action="open-item" data-tab="skills" data-item-id="' + _esc(s.name) + '">' +
+                    '<span class="mpc-item__name">' + _esc(s.name) + '</span>' +
+                    '<span class="mpc-item__badge ' + statusCls + '">' + _esc(s.status || 'disabled') + '</span>' +
+                '</div>';
+            }
+            html += '</div>';
+            return html;
+        }
+
+        function _renderLargeToolsList() {
+            if (tools.length === 0) return _emptyHtml('暂无工具');
+            var html = '<div class="mpc-list">';
+            for (var i = 0; i < Math.min(tools.length, MAX_ITEMS_LARGE); i++) {
+                var t = tools[i];
+                var toggleCls = t.enabled ? 'on' : 'off';
+                html += '<div class="mpc-item">' +
+                    '<span class="mpc-item__name">' + _esc(t.name) + '</span>' +
+                    '<button class="mpc-item__toggle ' + toggleCls + '" data-action="toggle-tool" data-tool-name="' + _esc(t.name) + '"></button>' +
+                '</div>';
+            }
+            html += '</div>';
+            return html;
+        }
+
+        function _renderLargePluginsList() {
+            if (pluginsInstalled.length === 0) return _emptyHtml('暂无已安装插件');
+            var html = '<div class="mpc-list">';
+            for (var i = 0; i < Math.min(pluginsInstalled.length, MAX_ITEMS_LARGE); i++) {
+                var p = pluginsInstalled[i];
+                html += '<div class="mpc-item" data-action="open-item" data-tab="plugins" data-item-id="' + _esc(p.name) + '">' +
+                    '<span class="mpc-item__name">' + _esc(p.name) + '</span>' +
+                    '<span class="mpc-item__badge mpc-item__badge--installed">已安装</span>' +
+                '</div>';
+            }
+            html += '</div>';
+            return html;
+        }
+
+        // ========== Xlarge 渲染 ==========
+        function _renderXlarge() {
+            if (loading) {
+                container.innerHTML = '<div class="mpc-xl"><div class="mpc-xl__header"><span class="mpc-xl__title">功能商店</span></div>' + _loadingHtml() + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="mpc-xl"><div class="mpc-xl__header"><span class="mpc-xl__title">功能商店</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            // 标签页
+            var tabsHtml = '<div class="mpc-xl__tabs">';
+            for (var i = 0; i < TABS.length; i++) {
+                var t = TABS[i];
+                tabsHtml += '<button class="mpc-xl__tab' + (activeTab === t.key ? ' active' : '') + '" data-action="switch-tab" data-tab="' + t.key + '">' + t.icon + ' ' + t.label + '</button>';
+            }
+            tabsHtml += '</div>';
+
+            // 内容区
+            var contentHtml = '';
+            switch (activeTab) {
+                case 'mcp':     contentHtml = _renderXlMcp(); break;
+                case 'skills':  contentHtml = _renderXlSkills(); break;
+                case 'tools':   contentHtml = _renderXlTools(); break;
+                case 'plugins': contentHtml = _renderXlPlugins(); break;
+            }
+
+            container.innerHTML =
+                '<div class="mpc-xl">' +
+                    '<div class="mpc-xl__header">' +
+                        '<span style="font-size:20px;">\u{1F6D2}</span>' +
+                        '<span class="mpc-xl__title">功能商店</span>' +
+                    '</div>' +
+                    tabsHtml +
+                    contentHtml +
+                '</div>';
+        }
+
+        // ----- Xlarge: MCP Tab -----
+        function _renderXlMcp() {
+            var connected = 0;
+            for (var i = 0; i < mcpServers.length; i++) {
+                if (mcpServers[i].status === 'connected') connected++;
+            }
+
+            // 统计行
+            var statsHtml = '<div class="mpc-xl__stats">' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + connected + '</span> 已连接</div>' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + mcpServers.length + '</span> 总计</div>' +
+            '</div>';
+
+            // 搜索栏 + 操作按钮
+            var actionsHtml = '<div class="mpc-xl__search">' +
+                '<input class="mpc-xl__search-input" type="text" placeholder="搜索 MCP 服务..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+                '<button class="mpc-xl__btn mpc-xl__btn--primary" data-action="toggle-add-server">\u2795 添加服务</button>' +
+                '<button class="mpc-xl__btn" data-action="restart-mcp">\u{1F504} 重启 MCP</button>' +
+            '</div>';
+
+            // 服务器列表
+            var filtered = _filterByKeyword(mcpServers, searchKeyword, ['name', 'url', 'prefix']);
+            var listHtml = '';
+            if (filtered.length === 0) {
+                listHtml = _emptyHtml(searchKeyword ? '未找到匹配的 MCP 服务' : '暂无 MCP 服务，点击上方添加');
+            } else {
+                listHtml = '<div class="mpc-xl__list">';
+                for (var i = 0; i < filtered.length; i++) {
+                    var s = filtered[i];
+                    listHtml += '<div class="mpc-xl__card">' +
+                        '<div class="mpc-xl__card-top">' +
+                            '<span class="mpc-xl__card-status ' + (s.status || 'unknown') + '"></span>' +
+                            '<span class="mpc-xl__card-name">' + _esc(s.name) + '</span>' +
+                            '<span class="mpc-xl__card-badge">' + (s.tools_count || 0) + ' 工具</span>' +
+                            '<div class="mpc-xl__card-actions">' +
+                                '<button class="mpc-xl__card-action" data-action="refresh-server" data-name="' + _esc(s.name) + '" title="刷新">\u{1F504}</button>' +
+                                '<button class="mpc-xl__card-action danger" data-action="remove-server" data-name="' + _esc(s.name) + '" title="移除">\u{1F5D1}\uFE0F</button>' +
+                            '</div>' +
+                        '</div>' +
+                        (s.url ? '<div class="mpc-xl__card-url">' + _esc(s.url) + '</div>' : '') +
+                        (s.prefix ? '<div class="mpc-xl__card-meta"><span class="mpc-xl__card-badge">前缀: ' + _esc(s.prefix) + '</span></div>' : '') +
+                    '</div>';
+                }
+                listHtml += '</div>';
+            }
+
+            // 添加服务器表单
+            var formHtml = '';
+            if (showAddServerForm) {
+                formHtml = '<div class="mpc-xl__form">' +
+                    '<div style="font-size:var(--text-xs); font-weight:600; color:var(--text-secondary);">添加 MCP 服务</div>' +
+                    '<div class="mpc-xl__form-row"><span class="mpc-xl__form-label">名称</span><input class="mpc-xl__form-input" type="text" placeholder="服务名称" data-field="server-name" /></div>' +
+                    '<div class="mpc-xl__form-row"><span class="mpc-xl__form-label">URL</span><input class="mpc-xl__form-input" type="text" placeholder="http://localhost:8080" data-field="server-url" /></div>' +
+                    '<div class="mpc-xl__form-row"><span class="mpc-xl__form-label">前缀</span><input class="mpc-xl__form-input" type="text" placeholder="可选前缀" data-field="server-prefix" /></div>' +
+                    '<div class="mpc-xl__form-row" style="justify-content:flex-end;">' +
+                        '<button class="mpc-xl__btn" data-action="toggle-add-server">取消</button>' +
+                        '<button class="mpc-xl__btn mpc-xl__btn--primary" data-action="add-server">添加</button>' +
+                    '</div>' +
+                '</div>';
+            }
+
+            return statsHtml + actionsHtml + '<div class="mpc-xl__body">' + listHtml + formHtml + '</div>';
+        }
+
+        // ----- Xlarge: Skills Tab -----
+        function _renderXlSkills() {
+            var active = 0;
+            for (var i = 0; i < skills.length; i++) {
+                if (skills[i].status === 'active') active++;
+            }
+
+            // 统计行
+            var statsHtml = '<div class="mpc-xl__stats">' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + skills.length + '</span> 总计</div>' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + active + '</span> 已激活</div>' +
+            '</div>';
+
+            // 搜索栏
+            var searchHtml = '<div class="mpc-xl__search">' +
+                '<input class="mpc-xl__search-input" type="text" placeholder="搜索技能..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+            '</div>';
+
+            // 列表
+            var filtered = _filterByKeyword(skills, searchKeyword, ['name', 'description', 'category', 'tags']);
+            var listHtml = '';
+            if (filtered.length === 0) {
+                listHtml = _emptyHtml(searchKeyword ? '未找到匹配的技能' : '暂无技能');
+            } else {
+                listHtml = '<div class="mpc-xl__list">';
+                for (var i = 0; i < filtered.length; i++) {
+                    var s = filtered[i];
+                    var statusCls = s.status === 'active' ? 'mpc-item__badge--active' : 'mpc-item__badge--disabled';
+                    var tags = Array.isArray(s.tags) ? s.tags : [];
+                    var tagsHtml = '';
+                    for (var j = 0; j < Math.min(tags.length, 3); j++) {
+                        tagsHtml += '<span class="mpc-xl__card-badge">' + _esc(tags[j]) + '</span>';
+                    }
+                    listHtml += '<div class="mpc-xl__card">' +
+                        '<div class="mpc-xl__card-top">' +
+                            '<span class="mpc-xl__card-name">' + _esc(s.name) + '</span>' +
+                            '<span class="mpc-item__badge ' + statusCls + '">' + _esc(s.status || 'disabled') + '</span>' +
+                            '<div class="mpc-xl__card-actions">' +
+                                '<button class="mpc-xl__card-action danger" data-action="delete-skill" data-name="' + _esc(s.name) + '" title="删除">\u{1F5D1}\uFE0F</button>' +
+                            '</div>' +
+                        '</div>' +
+                        (s.description ? '<div class="mpc-xl__card-desc">' + _esc(s.description) + '</div>' : '') +
+                        '<div class="mpc-xl__card-meta">' +
+                            (s.category ? '<span class="mpc-xl__card-badge">' + _esc(s.category) + '</span>' : '') +
+                            tagsHtml +
+                        '</div>' +
+                    '</div>';
+                }
+                listHtml += '</div>';
+            }
+
+            return statsHtml + searchHtml + '<div class="mpc-xl__body">' + listHtml + '</div>';
+        }
+
+        // ----- Xlarge: Tools Tab -----
+        function _renderXlTools() {
+            var enabled = 0;
+            for (var i = 0; i < tools.length; i++) {
+                if (tools[i].enabled) enabled++;
+            }
+
+            // 统计行
+            var statsHtml = '<div class="mpc-xl__stats">' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + tools.length + '</span> 总计</div>' +
+                '<div class="mpc-xl__stat"><span class="mpc-xl__stat-value">' + enabled + '</span> 已启用</div>' +
+            '</div>';
+
+            // 搜索 + toolset 过滤
+            var toolsets = _getToolsets();
+            var filtersHtml = '<div class="mpc-xl__search">' +
+                '<input class="mpc-xl__search-input" type="text" placeholder="搜索工具..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+                (toolsets.length > 1
+                    ? toolsets.map(function(ts) {
+                        return '<button class="mpc-xl__filter' + (toolsetFilter === ts ? ' active' : '') + '" data-action="filter-toolset" data-toolset="' + _esc(ts) + '">' + _esc(ts) + '</button>';
+                    }).join('')
+                    : '') +
+            '</div>';
+
+            // 过滤工具
+            var filtered = _filterByKeyword(tools, searchKeyword, ['name', 'description']);
+            if (toolsetFilter) {
+                filtered = filtered.filter(function(t) { return (t.toolset || 'default') === toolsetFilter; });
+            }
+
+            // 网格
+            var gridHtml = '';
+            if (filtered.length === 0) {
+                gridHtml = _emptyHtml(searchKeyword || toolsetFilter ? '未找到匹配的工具' : '暂无工具');
+            } else {
+                gridHtml = '<div class="mpc-xl__grid">';
+                for (var i = 0; i < filtered.length; i++) {
+                    var t = filtered[i];
+                    var toggleCls = t.enabled ? 'on' : 'off';
+                    gridHtml += '<div class="mpc-xl__grid-card">' +
+                        '<div class="mpc-xl__grid-card-top">' +
+                            '<span class="mpc-xl__grid-card-name">' + _esc(t.name) + '</span>' +
+                            '<button class="mpc-item__toggle ' + toggleCls + '" data-action="toggle-tool" data-tool-name="' + _esc(t.name) + '"></button>' +
+                        '</div>' +
+                        (t.description ? '<div class="mpc-xl__grid-card-desc">' + _esc(_truncate(t.description, 60)) + '</div>' : '') +
+                        (t.toolset ? '<div class="mpc-xl__grid-card-toolset">' + _esc(t.toolset) + '</div>' : '') +
+                    '</div>';
+                }
+                gridHtml += '</div>';
+            }
+
+            return statsHtml + filtersHtml + '<div class="mpc-xl__body">' + gridHtml + '</div>';
+        }
+
+        // ----- Xlarge: Plugins Tab -----
+        function _renderXlPlugins() {
+            // 子标签
+            var subTabsHtml = '<div class="mpc-xl__search">' +
+                '<div class="mpc-xl__sub-tabs">' +
+                    '<button class="mpc-xl__sub-tab' + (pluginSubTab === 'market' ? ' active' : '') + '" data-action="switch-plugin-sub" data-sub="market">市场</button>' +
+                    '<button class="mpc-xl__sub-tab' + (pluginSubTab === 'installed' ? ' active' : '') + '" data-action="switch-plugin-sub" data-sub="installed">已安装</button>' +
+                '</div>' +
+                '<input class="mpc-xl__search-input" type="text" placeholder="搜索插件..." value="' + _esc(searchKeyword) + '" data-role="search-input" />' +
+            '</div>';
+
+            // 类型过滤
+            var types = _getPluginTypes();
+            var typeFilterHtml = '';
+            if (types.length > 1) {
+                typeFilterHtml = '<div class="mpc-xl__search" style="padding-top:0;">' +
+                    types.map(function(tp) {
+                        return '<button class="mpc-xl__filter' + (typeFilter === tp ? ' active' : '') + '" data-action="filter-plugin-type" data-type="' + _esc(tp) + '">' + _esc(tp) + '</button>';
+                    }).join('') +
+                '</div>';
+            }
+
+            // 数据源
+            var source = pluginSubTab === 'market' ? pluginsMarket : pluginsInstalled;
+            var filtered = _filterByKeyword(source, searchKeyword, ['name', 'description', 'author', 'category', 'tags']);
+            if (typeFilter) {
+                filtered = filtered.filter(function(p) { return (p.type || 'other') === typeFilter; });
+            }
+
+            // 列表
+            var listHtml = '';
+            if (filtered.length === 0) {
+                listHtml = _emptyHtml(searchKeyword ? '未找到匹配的插件' : (pluginSubTab === 'market' ? '插件市场为空' : '暂无已安装插件'));
+            } else {
+                listHtml = '<div class="mpc-xl__list">';
+                for (var i = 0; i < filtered.length; i++) {
+                    var p = filtered[i];
+                    var isInstalled = p.installed || pluginSubTab === 'installed';
+                    var btnHtml = '';
+                    if (isInstalled) {
+                        btnHtml = '<button class="mpc-xl__btn mpc-xl__btn--danger" data-action="uninstall-plugin" data-name="' + _esc(p.name) + '">卸载</button>';
+                    } else {
+                        btnHtml = '<button class="mpc-xl__btn mpc-xl__btn--primary" data-action="install-plugin" data-name="' + _esc(p.name) + '">安装</button>';
+                    }
+
+                    var tags = Array.isArray(p.tags) ? p.tags : [];
+                    var tagsHtml = '';
+                    for (var j = 0; j < Math.min(tags.length, 3); j++) {
+                        tagsHtml += '<span class="mpc-xl__card-badge">' + _esc(tags[j]) + '</span>';
+                    }
+
+                    listHtml += '<div class="mpc-xl__card">' +
+                        '<div class="mpc-xl__card-top">' +
+                            '<span class="mpc-xl__card-name">' + _esc(p.name) + '</span>' +
+                            (p.version ? '<span class="mpc-xl__card-badge">v' + _esc(p.version) + '</span>' : '') +
+                            (p.rating ? '<span class="mpc-xl__card-badge">\u2B50 ' + _esc(String(p.rating)) + '</span>' : '') +
+                            btnHtml +
+                        '</div>' +
+                        (p.description ? '<div class="mpc-xl__card-desc">' + _esc(p.description) + '</div>' : '') +
+                        '<div class="mpc-xl__card-meta">' +
+                            (p.author ? '<span style="font-size:10px;color:var(--text-tertiary);">' + _esc(p.author) + '</span>' : '') +
+                            (p.downloads ? '<span style="font-size:10px;color:var(--text-tertiary);">\u{1F4E5} ' + _esc(String(p.downloads)) + '</span>' : '') +
+                            (p.category ? '<span class="mpc-xl__card-badge">' + _esc(p.category) + '</span>' : '') +
+                            tagsHtml +
+                        '</div>' +
+                    '</div>';
+                }
+                listHtml += '</div>';
+            }
+
+            return subTabsHtml + typeFilterHtml + '<div class="mpc-xl__body">' + listHtml + '</div>';
+        }
+
+        // ========== 事件处理 ==========
+
+        function _handleClick(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+
+            var action = target.getAttribute('data-action');
+
+            switch (action) {
+                // ----- 通用: 打开覆盖层 -----
+                case 'open-overlay':
+                    e.preventDefault();
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('marketplace-card');
+                    }
+                    break;
+
+                // ----- Medium: 打开覆盖层并跳转标签 -----
+                case 'open-overlay-tab':
+                    e.preventDefault();
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('marketplace-card', { tab: target.getAttribute('data-tab') });
+                    }
+                    break;
+
+                // ----- Large/Xlarge: 切换标签 -----
+                case 'switch-tab':
+                    e.preventDefault();
+                    activeTab = target.getAttribute('data-tab') || 'mcp';
+                    searchKeyword = '';
+                    toolsetFilter = '';
+                    typeFilter = '';
+                    _render();
+                    break;
+
+                // ----- Large: 打开项目详情 -----
+                case 'open-item':
+                    e.preventDefault();
+                    var tab = target.getAttribute('data-tab');
+                    var itemId = target.getAttribute('data-item-id');
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('marketplace-card', { tab: tab, itemId: itemId });
+                    }
+                    break;
+
+                // ----- Xlarge MCP: 刷新服务器 -----
+                case 'refresh-server':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doRefreshServer(target.getAttribute('data-name'));
+                    break;
+
+                // ----- Xlarge MCP: 移除服务器 -----
+                case 'remove-server':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doRemoveServer(target.getAttribute('data-name'));
+                    break;
+
+                // ----- Xlarge MCP: 切换添加表单 -----
+                case 'toggle-add-server':
+                    e.preventDefault();
+                    showAddServerForm = !showAddServerForm;
+                    _render();
+                    break;
+
+                // ----- Xlarge MCP: 添加服务器 -----
+                case 'add-server':
+                    e.preventDefault();
+                    _doAddServer();
+                    break;
+
+                // ----- Xlarge MCP: 重启 MCP -----
+                case 'restart-mcp':
+                    e.preventDefault();
+                    _doRestartMcp();
+                    break;
+
+                // ----- Xlarge Skills: 删除技能 -----
+                case 'delete-skill':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doDeleteSkill(target.getAttribute('data-name'));
+                    break;
+
+                // ----- Large/Xlarge Tools: 切换工具 -----
+                case 'toggle-tool':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doToggleTool(target.getAttribute('data-tool-name'));
+                    break;
+
+                // ----- Xlarge Tools: 过滤 toolset -----
+                case 'filter-toolset':
+                    e.preventDefault();
+                    toolsetFilter = target.getAttribute('data-toolset') || '';
+                    _render();
+                    break;
+
+                // ----- Xlarge Plugins: 切换子标签 -----
+                case 'switch-plugin-sub':
+                    e.preventDefault();
+                    pluginSubTab = target.getAttribute('data-sub') || 'market';
+                    searchKeyword = '';
+                    typeFilter = '';
+                    _render();
+                    break;
+
+                // ----- Xlarge Plugins: 过滤类型 -----
+                case 'filter-plugin-type':
+                    e.preventDefault();
+                    typeFilter = target.getAttribute('data-type') || '';
+                    _render();
+                    break;
+
+                // ----- Xlarge Plugins: 安装插件 -----
+                case 'install-plugin':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doInstallPlugin(target.getAttribute('data-name'));
+                    break;
+
+                // ----- Xlarge Plugins: 卸载插件 -----
+                case 'uninstall-plugin':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    _doUninstallPlugin(target.getAttribute('data-name'));
+                    break;
+
+                // ----- 重试 -----
+                case 'retry':
+                    e.preventDefault();
+                    loadData();
+                    break;
+            }
+        }
+
+        // ---------- 搜索输入处理 ----------
+        function _handleInput(e) {
+            var input = e.target.closest('[data-role="search-input"]');
+            if (!input) return;
+
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(function() {
+                searchKeyword = input.value;
+                _render();
+            }, SEARCH_DEBOUNCE_MS);
+        }
+
+        // ---------- MCP 操作 ----------
+        async function _doRefreshServer(name) {
+            _toast('正在刷新 ' + name + '...', 'info');
+            try {
+                await _refreshMcpServer(name);
+                _toast(name + ' 刷新成功', 'success');
+                refresh();
+            } catch (e) {
+                _toast('刷新失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        async function _doRemoveServer(name) {
+            var msg = '确定要移除 MCP 服务「' + name + '」吗？';
+            if (typeof Components !== 'undefined' && Components.confirm) {
+                var confirmed = await Components.confirm(msg);
+                if (!confirmed) return;
+            } else if (typeof confirm === 'function') {
+                if (!confirm(msg)) return;
+            }
+
+            try {
+                await _removeMcpServer(name);
+                _toast(name + ' 已移除', 'success');
+                refresh();
+            } catch (e) {
+                _toast('移除失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        async function _doAddServer() {
+            var nameInput = container.querySelector('[data-field="server-name"]');
+            var urlInput = container.querySelector('[data-field="server-url"]');
+            var prefixInput = container.querySelector('[data-field="server-prefix"]');
+
+            var name = nameInput ? nameInput.value.trim() : '';
+            var url = urlInput ? urlInput.value.trim() : '';
+            var prefix = prefixInput ? prefixInput.value.trim() : '';
+
+            if (!name) { _toast('请输入服务名称', 'error'); return; }
+            if (!url) { _toast('请输入服务 URL', 'error'); return; }
+
+            try {
+                await _addMcpServer({ name: name, url: url, prefix: prefix });
+                _toast(name + ' 添加成功', 'success');
+                showAddServerForm = false;
+                refresh();
+            } catch (e) {
+                _toast('添加失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        async function _doRestartMcp() {
+            _toast('正在重启 MCP...', 'info');
+            try {
+                await _restartMcp();
+                _toast('MCP 重启成功', 'success');
+                refresh();
+            } catch (e) {
+                _toast('重启失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- Skills 操作 ----------
+        async function _doDeleteSkill(name) {
+            var msg = '确定要删除技能「' + name + '」吗？此操作不可撤销。';
+            if (typeof Components !== 'undefined' && Components.confirm) {
+                var confirmed = await Components.confirm(msg);
+                if (!confirmed) return;
+            } else if (typeof confirm === 'function') {
+                if (!confirm(msg)) return;
+            }
+
+            try {
+                await _deleteSkill(name);
+                _toast(name + ' 已删除', 'success');
+                refresh();
+            } catch (e) {
+                _toast('删除失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- Tools 操作 ----------
+        async function _doToggleTool(name) {
+            var tool = null;
+            for (var i = 0; i < tools.length; i++) {
+                if (tools[i].name === name) { tool = tools[i]; break; }
+            }
+            if (!tool) return;
+
+            var newState = !tool.enabled;
+            try {
+                await _toggleTool(name, newState);
+                tool.enabled = newState;
+                _toast(name + (newState ? ' 已启用' : ' 已禁用'), 'success');
+                _render();
+            } catch (e) {
+                _toast('操作失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- Plugins 操作 ----------
+        async function _doInstallPlugin(name) {
+            _toast('正在安装 ' + name + '...', 'info');
+            try {
+                await _installPlugin(name);
+                _toast(name + ' 安装成功', 'success');
+                refresh();
+            } catch (e) {
+                _toast('安装失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        async function _doUninstallPlugin(name) {
+            var msg = '确定要卸载插件「' + name + '」吗？';
+            if (typeof Components !== 'undefined' && Components.confirm) {
+                var confirmed = await Components.confirm(msg);
+                if (!confirmed) return;
+            } else if (typeof confirm === 'function') {
+                if (!confirm(msg)) return;
+            }
+
+            try {
+                await _uninstallPlugin(name);
+                _toast(name + ' 已卸载', 'success');
+                refresh();
+            } catch (e) {
+                _toast('卸载失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ========== 事件绑定 ==========
+        _clickHandler = _handleClick;
+        _inputHandler = _handleInput;
+        container.addEventListener('click', _clickHandler);
+        container.addEventListener('input', _inputHandler);
+
+        // SSE 事件订阅
+        if (typeof Bus !== 'undefined') {
+            var sseRefresh = refresh;
+            Bus.on('sse:mcp.*', sseRefresh);
+            Bus.on('sse:skill.*', sseRefresh);
+            Bus.on('sse:tool.*', sseRefresh);
+            _sseHandlers.push(
+                { event: 'sse:mcp.*', fn: sseRefresh },
+                { event: 'sse:skill.*', fn: sseRefresh },
+                { event: 'sse:tool.*', fn: sseRefresh }
+            );
+        }
+
+        // 初始加载数据
+        loadData();
+
+        // ========== 返回接口 ==========
+        return {
+            destroy: function() {
+                if (_clickHandler) container.removeEventListener('click', _clickHandler);
+                if (_inputHandler) container.removeEventListener('input', _inputHandler);
+                if (debounceTimer) clearTimeout(debounceTimer);
+
+                // 移除 SSE 订阅
+                if (typeof Bus !== 'undefined') {
+                    for (var i = 0; i < _sseHandlers.length; i++) {
+                        Bus.off(_sseHandlers[i].event, _sseHandlers[i].fn);
+                    }
+                }
+
+                container.innerHTML = '';
+            },
+            refresh: function() {
+                loadData();
+            }
+        };
+    }
+
+    // ========== 入口卡片（简化版 1x1） ==========
+    async function mountEntry(container, props) {
+        _injectStyles();
+
+        var totalCount = 0;
+        var loaded = false;
+
+        async function loadCount() {
+            try {
+                var results = await Promise.all([
+                    _fetchMcpServers(),
+                    _fetchSkills(),
+                    _fetchTools(),
+                    _fetchPluginsInstalled()
+                ]);
+                var mcp = Array.isArray(results[0]) ? results[0] : [];
+                var skl = Array.isArray(results[1]) ? results[1] : [];
+                var tls = Array.isArray(results[2]) ? results[2] : [];
+                var plg = Array.isArray(results[3]) ? results[3] : [];
+                totalCount = mcp.length + skl.length + tls.length + plg.length;
+                loaded = true;
+                _renderEntry();
+            } catch (e) {
+                loaded = true;
+                _renderEntry();
+            }
+        }
+
+        function _renderEntry() {
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="mpc-small" data-action="open-overlay">' +
+                        '<div class="mpc-small__emoji">\u{1F6D2}</div>' +
+                        '<div class="mpc-small__label">功能商店</div>' +
+                        (loaded
+                            ? '<div class="mpc-small__count">' + totalCount + '</div><div class="mpc-small__unit">项功能</div>'
+                            : '<div class="mpc-loading" style="padding:8px 0;"><div class="mpc-loading__spinner" style="width:18px;height:18px;border-width:2px;"></div></div>') +
+                    '</div>' +
+                '</div>';
+        }
+
+        var _clickHandler = function(e) {
+            var target = e.target.closest('[data-action="open-overlay"]');
+            if (target && typeof CardOverlay !== 'undefined') {
+                CardOverlay.open('marketplace-card');
+            }
+        };
+        container.addEventListener('click', _clickHandler);
+
+        _renderEntry();
+        loadCount();
+
+        // SSE 事件订阅
+        var _sseRefresh = function() { loadCount(); };
+        if (typeof Bus !== 'undefined') {
+            Bus.on('sse:mcp.*', _sseRefresh);
+            Bus.on('sse:skill.*', _sseRefresh);
+            Bus.on('sse:tool.*', _sseRefresh);
+
+            return {
+                destroy: function() {
+                    container.removeEventListener('click', _clickHandler);
+                    if (typeof Bus !== 'undefined') {
+                        Bus.off('sse:mcp.*', _sseRefresh);
+                        Bus.off('sse:skill.*', _sseRefresh);
+                        Bus.off('sse:tool.*', _sseRefresh);
+                    }
+                    container.innerHTML = '';
+                },
+                refresh: function() { loadCount(); }
+            };
+        }
+
+        return {
+            destroy: function() {
+                container.removeEventListener('click', _clickHandler);
+                container.innerHTML = '';
+            },
+            refresh: function() { loadCount(); }
+        };
+    }
+
+    // ========== 注册卡片 ==========
+    WidgetRegistry.register('marketplace-card', {
+        type: 'function',
+        label: '功能商店',
+        icon: '\u{1F6D2}',
+        description: 'MCP服务/技能/工具/插件管理',
+        defaultSize: { w: 2, h: 1 },
+        category: 'functions',
+        mount: mount
+    });
+
+    WidgetRegistry.register('marketplace-entry', {
+        type: 'entry',
+        label: '功能商店入口',
+        icon: '\u{1F6D2}',
+        description: '功能商店快速入口',
+        defaultSize: { w: 1, h: 1 },
+        category: 'entries',
+        mount: mountEntry
+    });
+
+    // ========== 公开接口（调试用） ==========
+    return {
+        mount: mount,
+        mountEntry: mountEntry
+    };
+})();

--- a/frontend/js/workspace/widgets/cards/MemoryCard.js
+++ b/frontend/js/workspace/widgets/cards/MemoryCard.js
@@ -1,0 +1,601 @@
+;(function() {
+  'use strict';
+
+  var CSS_ID = 'memory-card-css';
+  var PREFIX = 'mc';
+
+  // ── CSS ──────────────────────────────────────────────────────────
+  var css = [
+    '.' + PREFIX + '-wrap{font-family:var(--font-body,system-ui,sans-serif);color:var(--text-primary,#e0e0e0);height:100%;display:flex;flex-direction:column;overflow:hidden;background:var(--card-bg,#1a1a2e);border-radius:12px;padding:12px;box-sizing:border-box;position:relative}',
+    '.' + PREFIX + '-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;flex-shrink:0}',
+    '.' + PREFIX + '-header h3{margin:0;font-size:14px;font-weight:600;display:flex;align-items:center;gap:6px}',
+    '.' + PREFIX + '-header .count{font-size:11px;color:var(--text-secondary,#888);background:var(--bg-tertiary,#2a2a3e);padding:2px 8px;border-radius:10px}',
+    '.' + PREFIX + '-small{display:flex;flex-direction:column;align-items:center;justify-content:center;cursor:pointer;gap:4px;transition:transform .15s}',
+    '.' + PREFIX + '-small:hover{transform:scale(1.05)}',
+    '.' + PREFIX + '-small .icon{font-size:28px}',
+    '.' + PREFIX + '-small .label{font-size:12px;color:var(--text-secondary,#888)}',
+    '.' + PREFIX + '-small .num{font-size:20px;font-weight:700}',
+    '.' + PREFIX + '-list{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px}',
+    '.' + PREFIX + '-list::-webkit-scrollbar{width:4px}',
+    '.' + PREFIX + '-list::-webkit-scrollbar-thumb{background:var(--bg-tertiary,#2a2a3e);border-radius:2px}',
+    '.' + PREFIX + '-item{background:var(--bg-secondary,#22223a);border-radius:8px;padding:8px 10px;display:flex;flex-direction:column;gap:4px;transition:background .15s;cursor:pointer}',
+    '.' + PREFIX + '-item:hover{background:var(--bg-hover,#2e2e4a)}',
+    '.' + PREFIX + '-item .row{display:flex;align-items:center;justify-content:space-between;gap:6px}',
+    '.' + PREFIX + '-item .content{font-size:12px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+    '.' + PREFIX + '-item .meta{display:flex;align-items:center;gap:6px;font-size:10px;color:var(--text-secondary,#888)}',
+    '.' + PREFIX + '-badge{font-size:9px;padding:1px 6px;border-radius:8px;font-weight:600;text-transform:uppercase}',
+    '.' + PREFIX + '-badge-low{background:#2d4a2d;color:#6ecf6e}',
+    '.' + PREFIX + '-badge-medium{background:#4a4a2d;color:#cfcf6e}',
+    '.' + PREFIX + '-badge-high{background:#4a2d2d;color:#cf6e6e}',
+    '.' + PREFIX + '-tags{display:flex;gap:3px;flex-wrap:wrap}',
+    '.' + PREFIX + '-tag{font-size:9px;background:var(--bg-tertiary,#2a2a3e);padding:1px 5px;border-radius:4px;color:var(--text-secondary,#aaa)}',
+    '.' + PREFIX + '-toolbar{display:flex;gap:6px;margin-bottom:8px;flex-shrink:0;flex-wrap:wrap}',
+    '.' + PREFIX + '-search{flex:1;min-width:100px;background:var(--bg-secondary,#22223a);border:1px solid var(--border,#333);border-radius:6px;padding:5px 8px;font-size:12px;color:var(--text-primary,#e0e0e0);outline:none;box-sizing:border-box}',
+    '.' + PREFIX + '-search:focus{border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-filter{display:flex;gap:4px}',
+    '.' + PREFIX + '-filter-btn{font-size:10px;padding:3px 8px;border-radius:6px;border:1px solid var(--border,#333);background:transparent;color:var(--text-secondary,#888);cursor:pointer;transition:all .15s}',
+    '.' + PREFIX + '-filter-btn.active{background:var(--accent,#6c63ff);color:#fff;border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-actions{display:flex;gap:4px}',
+    '.' + PREFIX + '-btn{font-size:10px;padding:3px 8px;border-radius:6px;border:1px solid var(--border,#333);background:transparent;color:var(--text-secondary,#888);cursor:pointer;transition:all .15s}',
+    '.' + PREFIX + '-btn:hover{background:var(--bg-hover,#2e2e4a);color:var(--text-primary,#e0e0e0)}',
+    '.' + PREFIX + '-btn-primary{background:var(--accent,#6c63ff);color:#fff;border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-btn-primary:hover{opacity:.85}',
+    '.' + PREFIX + '-btn-danger{color:#cf6e6e;border-color:#4a2d2d}',
+    '.' + PREFIX + '-btn-danger:hover{background:#4a2d2d;color:#ff8888}',
+    '.' + PREFIX + '-detail{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:10px}',
+    '.' + PREFIX + '-detail-header{display:flex;align-items:center;gap:8px;margin-bottom:4px}',
+    '.' + PREFIX + '-detail-header .back{cursor:pointer;font-size:14px;padding:4px 8px;border-radius:6px;background:var(--bg-secondary,#22223a);border:none;color:var(--text-primary,#e0e0e0);transition:background .15s}',
+    '.' + PREFIX + '-detail-header .back:hover{background:var(--bg-hover,#2e2e4a)}',
+    '.' + PREFIX + '-detail-content{font-size:13px;line-height:1.6;padding:10px;background:var(--bg-secondary,#22223a);border-radius:8px}',
+    '.' + PREFIX + '-detail-meta{display:flex;flex-wrap:wrap;gap:8px;font-size:11px;color:var(--text-secondary,#888)}',
+    '.' + PREFIX + '-detail-meta span{display:flex;align-items:center;gap:4px}',
+    '.' + PREFIX + '-form{display:flex;flex-direction:column;gap:8px;padding:10px;background:var(--bg-secondary,#22223a);border-radius:8px}',
+    '.' + PREFIX + '-form label{font-size:11px;color:var(--text-secondary,#888);display:flex;flex-direction:column;gap:3px}',
+    '.' + PREFIX + '-form textarea,' + '.' + PREFIX + '-form input,' + '.' + PREFIX + '-form select{background:var(--bg-tertiary,#2a2a3e);border:1px solid var(--border,#333);border-radius:6px;padding:6px 8px;font-size:12px;color:var(--text-primary,#e0e0e0);outline:none;box-sizing:border-box;font-family:inherit;resize:vertical}',
+    '.' + PREFIX + '-form textarea{min-height:60px}',
+    '.' + PREFIX + '-form textarea:focus,' + '.' + PREFIX + '-form input:focus,' + '.' + PREFIX + '-form select:focus{border-color:var(--accent,#6c63ff)}',
+    '.' + PREFIX + '-form-actions{display:flex;gap:6px;justify-content:flex-end;margin-top:4px}',
+    '.' + PREFIX + '-confirm-bar{display:flex;align-items:center;gap:8px;padding:8px 10px;background:#4a2d2d;border-radius:8px;font-size:12px}',
+    '.' + PREFIX + '-confirm-bar span{flex:1}',
+    '.' + PREFIX + '-empty{flex:1;display:flex;align-items:center;justify-content:center;color:var(--text-secondary,#888);font-size:12px}',
+    '.' + PREFIX + '-loading{flex:1;display:flex;align-items:center;justify-content:center}',
+    '.' + PREFIX + '-loading .spinner{width:24px;height:24px;border:2px solid var(--border,#333);border-top-color:var(--accent,#6c63ff);border-radius:50%;animation:' + PREFIX + '-spin .6s linear infinite}',
+    '@keyframes ' + PREFIX + '-spin{to{transform:rotate(360deg)}}',
+    '.' + PREFIX + '-error{flex:1;display:flex;align-items:center;justify-content:center;color:#cf6e6e;font-size:12px}'
+  ].join('\n');
+
+  // ── Helpers ──────────────────────────────────────────────────────
+  function injectCSS() {
+    if (document.getElementById(CSS_ID)) return;
+    var el = document.createElement('style');
+    el.id = CSS_ID;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+
+  function truncate(str, len) {
+    if (!str) return '';
+    return str.length > len ? str.substring(0, len) + '...' : str;
+  }
+
+  function timeAgo(ts) {
+    if (!ts) return '';
+    var diff = Date.now() - new Date(ts).getTime();
+    var mins = Math.floor(diff / 60000);
+    if (mins < 1) return '刚刚';
+    if (mins < 60) return mins + '分钟前';
+    var hrs = Math.floor(mins / 60);
+    if (hrs < 24) return hrs + '小时前';
+    var days = Math.floor(hrs / 24);
+    if (days < 30) return days + '天前';
+    return new Date(ts).toLocaleDateString('zh-CN');
+  }
+
+  function escHtml(s) {
+    if (!s) return '';
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  // ── Card ─────────────────────────────────────────────────────────
+  function MemoryCard(container, options) {
+    this.container = container;
+    this.options = options || {};
+    this.size = this.options.size || 'medium';
+    this.memories = [];
+    this.stats = null;
+    this.loading = false;
+    this.error = null;
+    this.filter = 'all';
+    this.search = '';
+    this.selectedId = null;
+    this.editing = false;
+    this.confirmDelete = false;
+    this.showForm = false;
+    this.formData = { content: '', importance: 'medium', tags: '', source: '' };
+    this.sseSub = null;
+    this._bound = {};
+  }
+
+  MemoryCard.prototype.init = function() {
+    injectCSS();
+    this.container.innerHTML = '';
+    this.container.classList.add(PREFIX + '-wrap');
+    this.container.setAttribute('data-widget', 'memory-card');
+    this.bindEvents();
+    this.loadData();
+    this.subscribeSSE();
+  };
+
+  MemoryCard.prototype.bindEvents = function() {
+    var self = this;
+    this._bound.handleClick = function(e) {
+      var action = e.target.closest('[data-action]');
+      if (!action) return;
+      var act = action.getAttribute('data-action');
+      var id = action.getAttribute('data-id');
+      self.handleAction(act, id, e);
+    };
+    this.container.addEventListener('click', this._bound.handleClick);
+  };
+
+  MemoryCard.prototype.handleAction = function(action, id, e) {
+    switch (action) {
+      case 'open-overlay':
+        CardOverlay.open({ widget: 'memory-card', title: '记忆管理' });
+        break;
+      case 'select':
+        this.selectedId = id;
+        this.editing = false;
+        this.confirmDelete = false;
+        this.showForm = false;
+        this.render();
+        break;
+      case 'back':
+        this.selectedId = null;
+        this.editing = false;
+        this.confirmDelete = false;
+        this.showForm = false;
+        this.render();
+        break;
+      case 'edit':
+        var m = this.getById(id);
+        if (m) {
+          this.formData = { content: m.content, importance: m.importance, tags: (m.tags || []).join(', '), source: m.source || '' };
+          this.editing = true;
+          this.confirmDelete = false;
+          this.render();
+        }
+        break;
+      case 'delete':
+        this.confirmDelete = true;
+        this.editing = false;
+        this.render();
+        break;
+      case 'confirm-delete':
+        this.deleteMemory(id);
+        break;
+      case 'cancel-delete':
+        this.confirmDelete = false;
+        this.render();
+        break;
+      case 'new':
+        this.formData = { content: '', importance: 'medium', tags: '', source: '' };
+        this.showForm = true;
+        this.selectedId = null;
+        this.editing = false;
+        this.confirmDelete = false;
+        this.render();
+        break;
+      case 'save':
+        this.saveMemory();
+        break;
+      case 'cancel-form':
+        this.showForm = false;
+        this.editing = false;
+        this.render();
+        break;
+      case 'filter':
+        this.filter = id;
+        this.render();
+        break;
+    }
+  };
+
+  MemoryCard.prototype.getById = function(id) {
+    for (var i = 0; i < this.memories.length; i++) {
+      if (this.memories[i].id === id) return this.memories[i];
+    }
+    return null;
+  };
+
+  MemoryCard.prototype.getFiltered = function() {
+    var list = this.memories;
+    if (this.filter !== 'all') {
+      var f = this.filter;
+      list = list.filter(function(m) { return m.importance === f; });
+    }
+    if (this.search) {
+      var q = this.search.toLowerCase();
+      list = list.filter(function(m) {
+        return (m.content || '').toLowerCase().indexOf(q) !== -1 ||
+               (m.tags || []).some(function(t) { return t.toLowerCase().indexOf(q) !== -1; });
+      });
+    }
+    return list;
+  };
+
+  // ── Data ─────────────────────────────────────────────────────────
+  MemoryCard.prototype.loadData = function() {
+    var self = this;
+    this.loading = true;
+    this.error = null;
+    this.render();
+
+    var p1 = DataService.fetch('/api/memories').then(function(data) {
+      self.memories = data || [];
+    }).catch(function(err) {
+      self.error = '加载记忆失败: ' + (err.message || '未知错误');
+    });
+
+    var p2 = DataService.fetch('/api/memories/stats').then(function(data) {
+      self.stats = data;
+    }).catch(function() {
+      self.stats = null;
+    });
+
+    Promise.all([p1, p2]).then(function() {
+      self.loading = false;
+      self.render();
+    });
+  };
+
+  MemoryCard.prototype.saveMemory = function() {
+    var self = this;
+    var form = this.container.querySelector('.' + PREFIX + '-form');
+    if (!form) return;
+    var content = form.querySelector('[name="content"]').value.trim();
+    var importance = form.querySelector('[name="importance"]').value;
+    var tags = form.querySelector('[name="tags"]').value;
+    var source = form.querySelector('[name="source"]').value.trim();
+
+    if (!content) return;
+
+    var payload = {
+      content: content,
+      importance: importance,
+      tags: tags ? tags.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [],
+      source: source || undefined
+    };
+
+    var isEdit = this.editing && this.selectedId;
+    var url = isEdit ? '/api/memories/' + this.selectedId : '/api/memories';
+    var method = isEdit ? 'PUT' : 'POST';
+
+    DataService.fetch(url, { method: method, body: JSON.stringify(payload) }).then(function() {
+      self.showForm = false;
+      self.editing = false;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '保存失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  MemoryCard.prototype.deleteMemory = function(id) {
+    var self = this;
+    DataService.fetch('/api/memories/' + id, { method: 'DELETE' }).then(function() {
+      self.confirmDelete = false;
+      self.selectedId = null;
+      self.loadData();
+    }).catch(function(err) {
+      self.error = '删除失败: ' + (err.message || '未知错误');
+      self.render();
+    });
+  };
+
+  // ── SSE ──────────────────────────────────────────────────────────
+  MemoryCard.prototype.subscribeSSE = function() {
+    var self = this;
+    if (typeof Bus === 'undefined' || !Bus.subscribe) return;
+    this.sseSub = Bus.subscribe('memories', function(data) {
+      if (data && data.type === 'update') {
+        self.loadData();
+      }
+    });
+  };
+
+  // ── Render ───────────────────────────────────────────────────────
+  MemoryCard.prototype.render = function() {
+    if (this.loading) {
+      this.container.innerHTML = '<div class="' + PREFIX + '-loading"><div class="spinner"></div></div>';
+      return;
+    }
+    if (this.error) {
+      this.container.innerHTML = '<div class="' + PREFIX + '-error">' + escHtml(this.error) + '</div>';
+      return;
+    }
+    switch (this.size) {
+      case 'small': this.renderSmall(); break;
+      case 'medium': this.renderMedium(); break;
+      case 'large': this.renderLarge(); break;
+      case 'xlarge': this.renderXLarge(); break;
+      default: this.renderMedium();
+    }
+  };
+
+  MemoryCard.prototype.renderSmall = function() {
+    var count = this.memories.length;
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-small" data-action="open-overlay">' +
+        '<span class="icon">🧠</span>' +
+        '<span class="label">记忆</span>' +
+        '<span class="num">' + count + '</span>' +
+      '</div>';
+  };
+
+  MemoryCard.prototype.renderMedium = function() {
+    var recent = this.memories.slice(0, 4);
+    var items = '';
+    for (var i = 0; i < recent.length; i++) {
+      var m = recent[i];
+      items +=
+        '<div class="' + PREFIX + '-item" data-action="select" data-id="' + m.id + '">' +
+          '<div class="row">' +
+            '<span class="content">' + escHtml(truncate(m.content, 30)) + '</span>' +
+            '<span class="' + PREFIX + '-badge ' + PREFIX + '-badge-' + (m.importance || 'medium') + '">' + escHtml(m.importance || 'medium') + '</span>' +
+          '</div>' +
+          '<div class="meta"><span>' + timeAgo(m.created_at) + '</span></div>' +
+        '</div>';
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header">' +
+        '<h3>🧠 记忆 <span class="count">' + this.memories.length + '</span></h3>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无记忆</div>') + '</div>';
+  };
+
+  MemoryCard.prototype.renderLarge = function() {
+    var filtered = this.getFiltered();
+    var items = '';
+    for (var i = 0; i < filtered.length; i++) {
+      var m = filtered[i];
+      var tags = '';
+      if (m.tags && m.tags.length) {
+        for (var j = 0; j < m.tags.length; j++) {
+          tags += '<span class="' + PREFIX + '-tag">' + escHtml(m.tags[j]) + '</span>';
+        }
+      }
+      items +=
+        '<div class="' + PREFIX + '-item" data-action="select" data-id="' + m.id + '">' +
+          '<div class="row">' +
+            '<span class="content">' + escHtml(truncate(m.content, 50)) + '</span>' +
+            '<span class="' + PREFIX + '-badge ' + PREFIX + '-badge-' + (m.importance || 'medium') + '">' + escHtml(m.importance || 'medium') + '</span>' +
+          '</div>' +
+          '<div class="row meta">' +
+            '<div class="' + PREFIX + '-tags">' + tags + '</div>' +
+            '<span>' + timeAgo(m.created_at) + '</span>' +
+          '</div>' +
+        '</div>';
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header"><h3>🧠 记忆 <span class="count">' + this.memories.length + '</span></h3></div>' +
+      '<div class="' + PREFIX + '-toolbar">' +
+        '<input class="' + PREFIX + '-search" placeholder="搜索记忆..." value="' + escHtml(this.search) + '" data-field="search">' +
+        '<div class="' + PREFIX + '-filter">' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'all' ? ' active' : '') + '" data-action="filter" data-id="all">全部</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'high' ? ' active' : '') + '" data-action="filter" data-id="high">高</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'medium' ? ' active' : '') + '" data-action="filter" data-id="medium">中</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'low' ? ' active' : '') + '" data-action="filter" data-id="low">低</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无记忆</div>') + '</div>';
+    this.bindSearch();
+  };
+
+  MemoryCard.prototype.renderXLarge = function() {
+    if (this.showForm) {
+      this.renderForm();
+      return;
+    }
+    if (this.selectedId) {
+      this.renderDetail();
+      return;
+    }
+    this.renderXList();
+  };
+
+  MemoryCard.prototype.renderXList = function() {
+    var filtered = this.getFiltered();
+    var items = '';
+    for (var i = 0; i < filtered.length; i++) {
+      var m = filtered[i];
+      var tags = '';
+      if (m.tags && m.tags.length) {
+        for (var j = 0; j < m.tags.length; j++) {
+          tags += '<span class="' + PREFIX + '-tag">' + escHtml(m.tags[j]) + '</span>';
+        }
+      }
+      items +=
+        '<div class="' + PREFIX + '-item">' +
+          '<div class="row">' +
+            '<span class="content" data-action="select" data-id="' + m.id + '">' + escHtml(truncate(m.content, 60)) + '</span>' +
+            '<span class="' + PREFIX + '-badge ' + PREFIX + '-badge-' + (m.importance || 'medium') + '">' + escHtml(m.importance || 'medium') + '</span>' +
+          '</div>' +
+          '<div class="row meta">' +
+            '<div class="' + PREFIX + '-tags">' + tags + '</div>' +
+            '<span>' + timeAgo(m.created_at) + '</span>' +
+          '</div>' +
+          '<div class="actions">' +
+            '<button class="' + PREFIX + '-btn" data-action="edit" data-id="' + m.id + '">编辑</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="delete" data-id="' + m.id + '">删除</button>' +
+          '</div>' +
+        '</div>';
+    }
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-header">' +
+        '<h3>🧠 记忆管理 <span class="count">' + this.memories.length + '</span></h3>' +
+        '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-primary" data-action="new">新建</button>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-toolbar">' +
+        '<input class="' + PREFIX + '-search" placeholder="搜索记忆..." value="' + escHtml(this.search) + '" data-field="search">' +
+        '<div class="' + PREFIX + '-filter">' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'all' ? ' active' : '') + '" data-action="filter" data-id="all">全部</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'high' ? ' active' : '') + '" data-action="filter" data-id="high">高</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'medium' ? ' active' : '') + '" data-action="filter" data-id="medium">中</button>' +
+          '<button class="' + PREFIX + '-filter-btn' + (this.filter === 'low' ? ' active' : '') + '" data-action="filter" data-id="low">低</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="' + PREFIX + '-list">' + (items || '<div class="' + PREFIX + '-empty">暂无记忆</div>') + '</div>';
+    this.bindSearch();
+  };
+
+  MemoryCard.prototype.renderDetail = function() {
+    var m = this.getById(this.selectedId);
+    if (!m) {
+      this.selectedId = null;
+      this.render();
+      return;
+    }
+    var tags = '';
+    if (m.tags && m.tags.length) {
+      for (var j = 0; j < m.tags.length; j++) {
+        tags += '<span class="' + PREFIX + '-tag">' + escHtml(m.tags[j]) + '</span>';
+      }
+    }
+    var html =
+      '<div class="' + PREFIX + '-detail">' +
+        '<div class="' + PREFIX + '-detail-header">' +
+          '<button class="back" data-action="back">← 返回</button>' +
+          '<h3>记忆详情</h3>' +
+          '<div class="actions">' +
+            '<button class="' + PREFIX + '-btn" data-action="edit" data-id="' + m.id + '">编辑</button>' +
+            '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="delete" data-id="' + m.id + '">删除</button>' +
+          '</div>' +
+        '</div>';
+
+    if (this.confirmDelete) {
+      html +=
+        '<div class="' + PREFIX + '-confirm-bar">' +
+          '<span>确认删除这条记忆？</span>' +
+          '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-danger" data-action="confirm-delete" data-id="' + m.id + '">确认</button>' +
+          '<button class="' + PREFIX + '-btn" data-action="cancel-delete">取消</button>' +
+        '</div>';
+    }
+
+    if (this.editing) {
+      html += this.getFormHtml(m);
+    } else {
+      html +=
+        '<div class="' + PREFIX + '-detail-content">' + escHtml(m.content) + '</div>' +
+        '<div class="' + PREFIX + '-detail-meta">' +
+          '<span><span class="' + PREFIX + '-badge ' + PREFIX + '-badge-' + (m.importance || 'medium') + '">' + escHtml(m.importance || 'medium') + '</span></span>' +
+          '<span>创建: ' + timeAgo(m.created_at) + '</span>' +
+          (m.updated_at ? '<span>更新: ' + timeAgo(m.updated_at) + '</span>' : '') +
+          (m.source ? '<span>来源: ' + escHtml(m.source) + '</span>' : '') +
+        '</div>' +
+        (tags ? '<div class="' + PREFIX + '-tags" style="margin-top:6px">' + tags + '</div>' : '');
+    }
+
+    html += '</div>';
+    this.container.innerHTML = html;
+  };
+
+  MemoryCard.prototype.renderForm = function() {
+    var title = this.editing ? '编辑记忆' : '新建记忆';
+    this.container.innerHTML =
+      '<div class="' + PREFIX + '-detail">' +
+        '<div class="' + PREFIX + '-detail-header">' +
+          '<button class="back" data-action="cancel-form">← 返回</button>' +
+          '<h3>' + title + '</h3>' +
+        '</div>' +
+        this.getFormHtml(null) +
+      '</div>';
+  };
+
+  MemoryCard.prototype.getFormHtml = function(m) {
+    var fd = this.formData;
+    return '<div class="' + PREFIX + '-form">' +
+      '<label>内容<textarea name="content">' + escHtml(fd.content) + '</textarea></label>' +
+      '<label>重要性<select name="importance">' +
+        '<option value="low"' + (fd.importance === 'low' ? ' selected' : '') + '>低</option>' +
+        '<option value="medium"' + (fd.importance === 'medium' ? ' selected' : '') + '>中</option>' +
+        '<option value="high"' + (fd.importance === 'high' ? ' selected' : '') + '>高</option>' +
+      '</select></label>' +
+      '<label>标签 (逗号分隔)<input name="tags" value="' + escHtml(fd.tags) + '"></label>' +
+      '<label>来源<input name="source" value="' + escHtml(fd.source || '') + '" placeholder="可选"></label>' +
+      '<div class="' + PREFIX + '-form-actions">' +
+        '<button class="' + PREFIX + '-btn" data-action="cancel-form">取消</button>' +
+        '<button class="' + PREFIX + '-btn ' + PREFIX + '-btn-primary" data-action="save">保存</button>' +
+      '</div>' +
+    '</div>';
+  };
+
+  MemoryCard.prototype.bindSearch = function() {
+    var self = this;
+    var input = this.container.querySelector('[data-field="search"]');
+    if (!input) return;
+    var handler = function() {
+      self.search = input.value;
+      self.render();
+      self.bindSearch();
+    };
+    input.addEventListener('input', handler);
+  };
+
+  // ── Resize ───────────────────────────────────────────────────────
+  MemoryCard.prototype.setSize = function(size) {
+    this.size = size;
+    this.selectedId = null;
+    this.editing = false;
+    this.confirmDelete = false;
+    this.showForm = false;
+    this.render();
+  };
+
+  // ── Destroy ──────────────────────────────────────────────────────
+  MemoryCard.prototype.destroy = function() {
+    if (this._bound.handleClick) {
+      this.container.removeEventListener('click', this._bound.handleClick);
+    }
+    if (this.sseSub && typeof Bus !== 'undefined' && Bus.unsubscribe) {
+      Bus.unsubscribe('memories', this.sseSub);
+    }
+    this.container.innerHTML = '';
+    this.container.classList.remove(PREFIX + '-wrap');
+  };
+
+  // ── Mount ────────────────────────────────────────────────────────
+  function mount(container, options) {
+    var card = new MemoryCard(container, options);
+    card.init();
+    return card;
+  }
+
+  function mountEntry(container, options) {
+    var entry = new MemoryCard(container, Object.assign({}, options, { size: 'small' }));
+    entry.init();
+    return entry;
+  }
+
+  // ── Register ─────────────────────────────────────────────────────
+  WidgetRegistry.register('memory-card', {
+    type: 'data',
+    label: '记忆',
+    icon: '🧠',
+    defaultSize: { w: 2, h: 1 },
+    category: 'data',
+    mount: mount
+  });
+
+  WidgetRegistry.register('memory-entry', {
+    type: 'entry',
+    label: '记忆入口',
+    icon: '🧠',
+    defaultSize: { w: 1, h: 1 },
+    category: 'entries',
+    mount: mountEntry
+  });
+
+})();

--- a/frontend/js/workspace/widgets/cards/OpsCard.js
+++ b/frontend/js/workspace/widgets/cards/OpsCard.js
@@ -1,0 +1,1141 @@
+/**
+ * OpsCard.js - 运维监控卡片
+ *
+ * 支持 4 种尺寸: small(1x1) / medium(2x1) / large(2x2) / xlarge(全屏覆盖)
+ * xlarge 模式支持 3 个标签页: 系统概览 / MCP健康 / 告警
+ *
+ * 依赖全局: WidgetRegistry, HermesClient, DataService, CardOverlay, Components, Bus
+ */
+var OpsCard = (() => {
+    'use strict';
+
+    // ========== 常量 ==========
+    var API_STATUS = '/api/system/status';
+    var API_DASHBOARD = '/api/system/dashboard';
+    var API_MCP = '/api/mcp/servers';
+    var API_ALERTS = '/api/alerts';
+    var CACHE_DASHBOARD = 'ops:dashboard';
+    var CACHE_MCP = 'ops:mcp';
+    var CACHE_STATUS = 'ops:status';
+    var CACHE_ALERTS = 'ops:alerts';
+    var DASHBOARD_TTL = 10;          // 仪表盘缓存 10 秒
+    var AUTO_REFRESH_MS = 10000;     // xlarge 自动刷新 10 秒
+    var MAX_ALERTS_LARGE = 3;        // large 尺寸显示最近 3 条告警
+    var TRUNCATE_MSG_LARGE = 40;     // large 告警消息截断长度
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (document.getElementById('oc-styles')) return;
+        var style = document.createElement('style');
+        style.id = 'oc-styles';
+        style.textContent = [
+            /* ===== 基础布局 ===== */
+            '.oc-root { display:flex; flex-direction:column; height:100%; overflow:hidden; }',
+            '.oc-header { display:flex; align-items:center; gap:8px; padding:10px 12px; flex-shrink:0; }',
+            '.oc-header__icon { font-size:16px; flex-shrink:0; }',
+            '.oc-header__title { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }',
+            '.oc-header__status { width:8px; height:8px; border-radius:50%; flex-shrink:0; }',
+            '.oc-header__status--ok { background:var(--green, #22c55e); box-shadow:0 0 4px rgba(34,197,94,0.4); }',
+            '.oc-header__status--error { background:var(--red, #ef4444); box-shadow:0 0 4px rgba(239,68,68,0.4); }',
+            '.oc-header__status--unknown { background:var(--text-tertiary); }',
+            '.oc-body { flex:1; overflow-y:auto; overflow-x:hidden; padding:0 12px 12px; -webkit-overflow-scrolling:touch; }',
+            '.oc-body::-webkit-scrollbar { width:4px; }',
+            '.oc-body::-webkit-scrollbar-thumb { background:rgba(0,0,0,0.12); border-radius:2px; }',
+
+            /* ===== Small 尺寸 (1x1) ===== */
+            '.oc-small { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; cursor:pointer; padding:16px 8px; text-align:center; transition:opacity 0.15s; }',
+            '.oc-small:hover { opacity:0.85; }',
+            '.oc-small__emoji { font-size:32px; margin-bottom:6px; }',
+            '.oc-small__label { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); display:flex; align-items:center; gap:6px; }',
+            '.oc-small__dot { width:8px; height:8px; border-radius:50%; display:inline-block; }',
+
+            /* ===== Medium 迷你统计 ===== */
+            '.oc-mini-stats { display:flex; gap:8px; padding:0 12px 10px; }',
+            '.oc-mini-stat { flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; padding:8px 4px; border-radius:var(--radius-sm, 6px); background:var(--bg-secondary, rgba(0,0,0,0.03)); }',
+            '.oc-mini-stat__value { font-size:var(--text-lg, 16px); font-weight:700; color:var(--accent); }',
+            '.oc-mini-stat__label { font-size:10px; color:var(--text-tertiary); }',
+            '.oc-alert-badge { display:inline-flex; align-items:center; gap:3px; padding:2px 8px; border-radius:var(--radius-xs, 4px); background:rgba(239,68,68,0.1); color:var(--red, #ef4444); font-size:10px; font-weight:600; }',
+
+            /* ===== Large 统计网格 ===== */
+            '.oc-stats-grid { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-bottom:10px; }',
+            '.oc-stat-card { display:flex; align-items:center; gap:8px; padding:8px 10px; border-radius:var(--radius-sm, 6px); background:var(--bg-secondary, rgba(0,0,0,0.03)); }',
+            '.oc-stat-card__icon { font-size:16px; flex-shrink:0; }',
+            '.oc-stat-card__info { display:flex; flex-direction:column; gap:1px; min-width:0; }',
+            '.oc-stat-card__value { font-size:var(--text-sm, 13px); font-weight:700; color:var(--text-primary); }',
+            '.oc-stat-card__label { font-size:10px; color:var(--text-tertiary); }',
+
+            /* ===== Large MCP 健康 ===== */
+            '.oc-mcp-section { margin-bottom:10px; }',
+            '.oc-mcp-section__title { font-size:11px; font-weight:600; color:var(--text-secondary); margin-bottom:6px; display:flex; align-items:center; gap:6px; }',
+            '.oc-mcp-section__count { font-size:10px; color:var(--text-tertiary); font-weight:400; }',
+            '.oc-mcp-dots { display:flex; gap:4px; flex-wrap:wrap; }',
+            '.oc-mcp-dot { width:10px; height:10px; border-radius:50%; }',
+            '.oc-mcp-dot--connected { background:var(--green, #22c55e); }',
+            '.oc-mcp-dot--unknown { background:var(--text-tertiary); }',
+            '.oc-mcp-dot--error { background:var(--red, #ef4444); }',
+
+            /* ===== Large 最近告警 ===== */
+            '.oc-alerts-section__title { font-size:11px; font-weight:600; color:var(--text-secondary); margin-bottom:6px; }',
+            '.oc-alert-item { display:flex; align-items:flex-start; gap:6px; padding:6px 8px; border-radius:var(--radius-xs, 4px); cursor:pointer; transition:background 0.15s; margin-bottom:3px; }',
+            '.oc-alert-item:hover { background:var(--bg-tertiary, rgba(0,0,0,0.04)); }',
+            '.oc-alert-item__badge { font-size:9px; padding:1px 5px; border-radius:3px; font-weight:600; flex-shrink:0; margin-top:1px; }',
+            '.oc-alert-item__badge--info { background:rgba(59,130,246,0.1); color:var(--blue, #3b82f6); }',
+            '.oc-alert-item__badge--warning { background:rgba(234,179,8,0.1); color:var(--yellow, #eab308); }',
+            '.oc-alert-item__badge--error { background:rgba(239,68,68,0.1); color:var(--red, #ef4444); }',
+            '.oc-alert-item__msg { font-size:var(--text-xs, 11px); color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; }',
+
+            /* ===== Xlarge 全屏覆盖 ===== */
+            '.oc-xl { display:flex; flex-direction:column; height:100%; }',
+            '.oc-xl__header { display:flex; align-items:center; gap:10px; padding:14px 20px 10px; flex-shrink:0; border-bottom:1px solid var(--border); }',
+            '.oc-xl__title { font-size:var(--text-lg, 16px); font-weight:700; color:var(--text-primary); flex:1; }',
+            '.oc-xl__refresh { display:flex; align-items:center; gap:4px; padding:4px 10px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs, 11px); cursor:pointer; transition:all 0.15s; }',
+            '.oc-xl__refresh:hover { border-color:var(--accent); color:var(--accent); }',
+
+            /* ===== Xlarge 标签页 ===== */
+            '.oc-xl__tabs { display:flex; gap:6px; padding:10px 20px 0; flex-shrink:0; overflow-x:auto; -webkit-overflow-scrolling:touch; }',
+            '.oc-xl__tabs::-webkit-scrollbar { display:none; }',
+            '.oc-xl__tab { padding:5px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); background:transparent; color:var(--text-secondary); font-size:var(--text-sm, 13px); cursor:pointer; white-space:nowrap; transition:all 0.15s; }',
+            '.oc-xl__tab:hover { border-color:var(--accent); color:var(--accent); }',
+            '.oc-xl__tab.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+            '.oc-xl__body { flex:1; overflow-y:auto; padding:14px 20px; -webkit-overflow-scrolling:touch; }',
+            '.oc-xl__body::-webkit-scrollbar { width:6px; }',
+            '.oc-xl__body::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }',
+
+            /* ===== Xlarge 概览统计网格 ===== */
+            '.oc-xl-stats { display:grid; grid-template-columns:repeat(auto-fill, minmax(140px, 1fr)); gap:10px; margin-bottom:16px; }',
+            '.oc-xl-stat { padding:14px; border:1px solid var(--border); border-radius:var(--radius-sm, 8px); display:flex; flex-direction:column; gap:6px; transition:box-shadow 0.15s; }',
+            '.oc-xl-stat:hover { box-shadow:var(--shadow, 0 1px 3px rgba(0,0,0,0.08)); }',
+            '.oc-xl-stat__top { display:flex; align-items:center; gap:8px; }',
+            '.oc-xl-stat__icon { font-size:20px; }',
+            '.oc-xl-stat__label { font-size:10px; color:var(--text-tertiary); text-transform:uppercase; letter-spacing:0.5px; }',
+            '.oc-xl-stat__value { font-size:var(--text-lg, 18px); font-weight:700; color:var(--text-primary); }',
+            '.oc-xl-stat__sub { font-size:10px; color:var(--text-tertiary); }',
+
+            /* ===== Xlarge MCP 服务器列表 ===== */
+            '.oc-xl-mcp-summary { display:flex; gap:12px; margin-bottom:14px; }',
+            '.oc-xl-mcp-stat { display:flex; align-items:center; gap:6px; padding:8px 14px; border-radius:var(--radius-sm, 6px); background:var(--bg-secondary); }',
+            '.oc-xl-mcp-stat__dot { width:8px; height:8px; border-radius:50%; }',
+            '.oc-xl-mcp-stat__value { font-size:var(--text-sm, 13px); font-weight:600; color:var(--text-primary); }',
+            '.oc-xl-mcp-stat__label { font-size:10px; color:var(--text-tertiary); }',
+            '.oc-xl-mcp-list { display:flex; flex-direction:column; gap:6px; }',
+            '.oc-xl-mcp-server { padding:10px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s, box-shadow 0.15s; }',
+            '.oc-xl-mcp-server:hover { background:var(--bg-tertiary); box-shadow:var(--shadow); }',
+            '.oc-xl-mcp-server__top { display:flex; align-items:center; gap:8px; margin-bottom:4px; }',
+            '.oc-xl-mcp-server__name { font-size:var(--text-sm, 13px); font-weight:500; color:var(--text-primary); flex:1; }',
+            '.oc-xl-mcp-server__status { width:8px; height:8px; border-radius:50%; flex-shrink:0; }',
+            '.oc-xl-mcp-server__meta { display:flex; align-items:center; gap:10px; font-size:10px; color:var(--text-tertiary); }',
+            '.oc-xl-mcp-server__detail { display:none; padding-top:8px; margin-top:8px; border-top:1px solid var(--border); font-size:var(--text-xs, 11px); color:var(--text-secondary); }',
+            '.oc-xl-mcp-server.expanded .oc-xl-mcp-server__detail { display:block; }',
+            '.oc-xl-mcp-server__chevron { font-size:10px; color:var(--text-tertiary); transition:transform 0.2s; }',
+            '.oc-xl-mcp-server.expanded .oc-xl-mcp-server__chevron { transform:rotate(180deg); }',
+
+            /* ===== Xlarge 告警列表 ===== */
+            '.oc-xl-alert-filters { display:flex; gap:6px; margin-bottom:12px; }',
+            '.oc-xl-alert-filter { padding:4px 12px; border:1px solid var(--border); border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs, 11px); cursor:pointer; transition:all 0.15s; }',
+            '.oc-xl-alert-filter:hover { border-color:var(--accent); color:var(--accent); }',
+            '.oc-xl-alert-filter.active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+            '.oc-xl-alert-actions { display:flex; gap:8px; margin-bottom:12px; }',
+            '.oc-xl-alert-action { padding:4px 12px; border:1px solid var(--border); border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:var(--text-xs, 11px); cursor:pointer; transition:all 0.15s; }',
+            '.oc-xl-alert-action:hover { border-color:var(--accent); color:var(--accent); }',
+            '.oc-xl-alert-action.danger:hover { border-color:var(--red, #ef4444); color:var(--red, #ef4444); }',
+            '.oc-xl-alert-list { display:flex; flex-direction:column; gap:6px; }',
+            '.oc-xl-alert { padding:10px 14px; border:1px solid var(--border); border-radius:var(--radius-sm, 6px); cursor:pointer; transition:background 0.15s; }',
+            '.oc-xl-alert:hover { background:var(--bg-tertiary); }',
+            '.oc-xl-alert__top { display:flex; align-items:center; gap:8px; margin-bottom:4px; }',
+            '.oc-xl-alert__badge { font-size:10px; padding:2px 8px; border-radius:var(--radius-xs, 4px); font-weight:600; flex-shrink:0; }',
+            '.oc-xl-alert__badge--info { background:rgba(59,130,246,0.1); color:var(--blue, #3b82f6); }',
+            '.oc-xl-alert__badge--warning { background:rgba(234,179,8,0.1); color:var(--yellow, #eab308); }',
+            '.oc-xl-alert__badge--error { background:rgba(239,68,68,0.1); color:var(--red, #ef4444); }',
+            '.oc-xl-alert__source { font-size:10px; color:var(--text-tertiary); margin-left:auto; }',
+            '.oc-xl-alert__time { font-size:10px; color:var(--text-tertiary); flex-shrink:0; }',
+            '.oc-xl-alert__msg { font-size:var(--text-sm, 13px); color:var(--text-primary); line-height:1.4; margin-bottom:4px; }',
+            '.oc-xl-alert__unread { width:6px; height:6px; border-radius:50%; background:var(--accent); flex-shrink:0; }',
+            '.oc-xl-alert__detail { display:none; padding-top:8px; margin-top:8px; border-top:1px solid var(--border); }',
+            '.oc-xl-alert.expanded .oc-xl-alert__detail { display:block; }',
+            '.oc-xl-alert__detail-msg { font-size:var(--text-xs, 11px); color:var(--text-secondary); line-height:1.6; margin-bottom:8px; }',
+            '.oc-xl-alert__detail-actions { display:flex; gap:6px; }',
+            '.oc-xl-alert__detail-btn { padding:3px 10px; border:1px solid var(--border); border-radius:var(--radius-xs, 4px); background:transparent; color:var(--text-secondary); font-size:10px; cursor:pointer; transition:all 0.15s; }',
+            '.oc-xl-alert__detail-btn:hover { border-color:var(--accent); color:var(--accent); }',
+
+            /* ===== 状态提示 ===== */
+            '.oc-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:40px 20px; color:var(--text-tertiary); text-align:center; }',
+            '.oc-empty__icon { font-size:40px; margin-bottom:10px; opacity:0.5; }',
+            '.oc-empty__text { font-size:var(--text-sm, 13px); }',
+            '.oc-error { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:30px 20px; text-align:center; gap:10px; }',
+            '.oc-error__icon { font-size:32px; }',
+            '.oc-error__text { font-size:var(--text-sm, 13px); color:var(--red, #ef4444); }',
+            '.oc-loading { display:flex; align-items:center; justify-content:center; padding:30px; }',
+            '.oc-loading__spinner { width:24px; height:24px; border:2px solid var(--border); border-top-color:var(--accent); border-radius:50%; animation:oc-spin 0.6s linear infinite; }',
+            '@keyframes oc-spin { to { transform:rotate(360deg); } }',
+
+            /* ===== 骨架屏 ===== */
+            '.oc-skeleton { display:flex; flex-direction:column; gap:8px; padding:12px; }',
+            '.oc-skeleton__line { height:12px; border-radius:4px; background:linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-secondary) 50%, var(--bg-tertiary) 75%); background-size:200% 100%; animation:oc-shimmer 1.5s infinite; }',
+            '.oc-skeleton__line.short { width:60%; }',
+            '.oc-skeleton__line.medium { width:80%; }',
+            '@keyframes oc-shimmer { 0% { background-position:200% 0; } 100% { background-position:-200% 0; } }'
+        ].join('\n');
+        document.head.appendChild(style);
+    }
+
+    // ========== 工具函数 ==========
+
+    /** HTML 转义 */
+    function _esc(str) {
+        if (!str) return '';
+        if (typeof Components !== 'undefined' && Components.escapeHtml) {
+            return Components.escapeHtml(str);
+        }
+        return String(str).replace(/[&<>"']/g, function(c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
+    /** 截断文本 */
+    function _truncate(str, len) {
+        if (!str) return '';
+        return str.length > len ? str.slice(0, len) + '...' : str;
+    }
+
+    /** 格式化相对时间 */
+    function _formatTime(ts) {
+        if (!ts) return '';
+        if (typeof Components !== 'undefined' && Components.formatDateTime) {
+            return Components.formatDateTime(ts);
+        }
+        try {
+            var d = new Date(ts);
+            var now = new Date();
+            var diff = now - d;
+            if (diff < 60000) return '刚刚';
+            if (diff < 3600000) return Math.floor(diff / 60000) + '分钟前';
+            if (diff < 86400000) return Math.floor(diff / 3600000) + '小时前';
+            if (diff < 604800000) return Math.floor(diff / 86400000) + '天前';
+            return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+        } catch (e) {
+            return String(ts);
+        }
+    }
+
+    /** 格式化运行时间（秒 → 可读） */
+    function _formatUptime(seconds) {
+        if (!seconds && seconds !== 0) return '-';
+        var d = Math.floor(seconds / 86400);
+        var h = Math.floor((seconds % 86400) / 3600);
+        var m = Math.floor((seconds % 3600) / 60);
+        if (d > 0) return d + '天' + h + '小时';
+        if (h > 0) return h + '小时' + m + '分';
+        return m + '分钟';
+    }
+
+    /** 告警级别徽章 CSS 类 */
+    function _alertBadgeClass(level) {
+        var l = (level || 'info').toLowerCase();
+        if (l === 'warning') return 'oc-alert-item__badge--warning';
+        if (l === 'error') return 'oc-alert-item__badge--error';
+        return 'oc-alert-item__badge--info';
+    }
+
+    /** xlarge 告警级别徽章 CSS 类 */
+    function _xlAlertBadgeClass(level) {
+        var l = (level || 'info').toLowerCase();
+        if (l === 'warning') return 'oc-xl-alert__badge--warning';
+        if (l === 'error') return 'oc-xl-alert__badge--error';
+        return 'oc-xl-alert__badge--info';
+    }
+
+    /** 告警级别标签 */
+    function _alertLevelLabel(level) {
+        var l = (level || 'info').toLowerCase();
+        var map = { info: '信息', warning: '警告', error: '错误' };
+        return map[l] || level || '信息';
+    }
+
+    /** MCP 状态 CSS 类 */
+    function _mcpDotClass(status) {
+        var s = (status || '').toLowerCase();
+        if (s === 'connected') return 'oc-mcp-dot--connected';
+        if (s === 'error') return 'oc-mcp-dot--error';
+        return 'oc-mcp-dot--unknown';
+    }
+
+    /** 系统状态 CSS 类 */
+    function _statusDotClass(status) {
+        var s = (status || '').toLowerCase();
+        if (s === 'ok' || s === 'healthy') return 'oc-header__status--ok';
+        if (s === 'error' || s === 'unhealthy') return 'oc-header__status--error';
+        return 'oc-header__status--unknown';
+    }
+
+    /** 骨架屏 HTML */
+    function _skeletonHtml(lines) {
+        var html = '<div class="oc-skeleton">';
+        for (var i = 0; i < (lines || 4); i++) {
+            var cls = i === lines - 1 ? ' oc-skeleton__line short' : (i % 2 === 0 ? '' : ' oc-skeleton__line medium');
+            html += '<div class="oc-skeleton__line' + cls + '"></div>';
+        }
+        html += '</div>';
+        return html;
+    }
+
+    /** 加载中 HTML */
+    function _loadingHtml() {
+        return '<div class="oc-loading"><div class="oc-loading__spinner"></div></div>';
+    }
+
+    /** 空状态 HTML */
+    function _emptyHtml(text) {
+        return '<div class="oc-empty"><div class="oc-empty__icon">📭</div><div class="oc-empty__text">' + (text || '暂无数据') + '</div></div>';
+    }
+
+    /** 错误状态 HTML */
+    function _errorHtml(msg) {
+        return '<div class="oc-error"><div class="oc-error__icon">⚠️</div><div class="oc-error__text">' + _esc(msg || '加载失败') + '</div><button class="btn btn-sm btn-ghost" data-action="retry">重试</button></div>';
+    }
+
+    /** Toast 提示 */
+    function _showToast(msg, type) {
+        if (typeof Components !== 'undefined' && Components.showToast) {
+            Components.showToast(msg, type);
+        } else {
+            console.log('[OpsCard] ' + (type || 'info') + ': ' + msg);
+        }
+    }
+
+    // ========== 数据获取 ==========
+
+    /** 获取系统状态 */
+    function _fetchStatus() {
+        return HermesClient.cachedGet(CACHE_STATUS, function() {
+            return HermesClient.get(API_STATUS);
+        }, DASHBOARD_TTL);
+    }
+
+    /** 获取仪表盘统计 */
+    function _fetchDashboard() {
+        return HermesClient.cachedGet(CACHE_DASHBOARD, function() {
+            return HermesClient.get(API_DASHBOARD);
+        }, DASHBOARD_TTL);
+    }
+
+    /** 获取 MCP 服务器列表 */
+    function _fetchMcpServers() {
+        return HermesClient.cachedGet(CACHE_MCP, function() {
+            return HermesClient.get(API_MCP);
+        }, DASHBOARD_TTL);
+    }
+
+    /** 获取告警列表 */
+    function _fetchAlerts() {
+        return HermesClient.cachedGet(CACHE_ALERTS, function() {
+            return HermesClient.get(API_ALERTS);
+        }, DASHBOARD_TTL);
+    }
+
+    /** 标记告警已读 */
+    function _markAlertRead(id) {
+        return HermesClient.put(API_ALERTS + '/' + id + '/read');
+    }
+
+    /** 清除所有告警 */
+    function _clearAllAlerts() {
+        return HermesClient.del(API_ALERTS);
+    }
+
+    // ========== 判断尺寸 ==========
+
+    function _getSize(props) {
+        var config = props.config || {};
+        var w = config.w || 2;
+        var h = config.h || 1;
+        if (w <= 1 && h <= 1) return 'small';
+        if (w <= 2 && h <= 1) return 'medium';
+        if (w <= 2 && h <= 2) return 'large';
+        return 'xlarge';
+    }
+
+    // ========== 主挂载函数 ==========
+
+    async function mount(container, props) {
+        var cardId = props.cardId;
+        var desktopId = props.desktopId;
+        var size = _getSize(props);
+
+        // 注入样式
+        _injectStyles();
+
+        // 内部状态
+        var sysStatus = null;       // { status, version, uptime, memory_usage, cpu_usage }
+        var dashboard = null;       // { total_sessions, total_knowledge, total_agents, total_tools }
+        var mcpServers = [];        // [{ name, status, tools_count, ... }]
+        var alerts = [];            // [{ id, level, message, timestamp, source, read }]
+        var loading = true;
+        var error = null;
+
+        // xlarge 状态
+        var xlTab = 'overview';     // 'overview' | 'mcp' | 'alerts'
+        var xlAlertFilter = 'all';  // 'all' | 'info' | 'warning' | 'error'
+        var expandedAlertId = null;
+        var expandedMcpName = null;
+        var autoRefreshTimer = null;
+
+        // 事件处理函数引用（用于清理）
+        var _clickHandler = null;
+        var _sseHandlers = {};
+
+        // ---------- 数据加载 ----------
+        async function loadData() {
+            loading = true;
+            error = null;
+            _render();
+
+            try {
+                var results = await Promise.allSettled([
+                    _fetchStatus(),
+                    _fetchDashboard(),
+                    _fetchMcpServers(),
+                    _fetchAlerts()
+                ]);
+
+                if (results[0].status === 'fulfilled') sysStatus = results[0].value;
+                if (results[1].status === 'fulfilled') dashboard = results[1].value;
+                if (results[2].status === 'fulfilled') {
+                    mcpServers = Array.isArray(results[2].value) ? results[2].value : [];
+                }
+                if (results[3].status === 'fulfilled') {
+                    alerts = Array.isArray(results[3].value) ? results[3].value : [];
+                }
+
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                loading = false;
+                error = e.message || '加载失败';
+                _render();
+            }
+        }
+
+        // ---------- 刷新（SSE 触发） ----------
+        async function refresh() {
+            // 清除缓存后重新加载
+            try {
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_STATUS);
+                    HermesClient.clearCache(CACHE_DASHBOARD);
+                    HermesClient.clearCache(CACHE_MCP);
+                    HermesClient.clearCache(CACHE_ALERTS);
+                }
+            } catch (e) { /* ignore */ }
+
+            try {
+                var results = await Promise.allSettled([
+                    _fetchStatus(),
+                    _fetchDashboard(),
+                    _fetchMcpServers(),
+                    _fetchAlerts()
+                ]);
+
+                if (results[0].status === 'fulfilled') sysStatus = results[0].value;
+                if (results[1].status === 'fulfilled') dashboard = results[1].value;
+                if (results[2].status === 'fulfilled') {
+                    mcpServers = Array.isArray(results[2].value) ? results[2].value : [];
+                }
+                if (results[3].status === 'fulfilled') {
+                    alerts = Array.isArray(results[3].value) ? results[3].value : [];
+                }
+
+                loading = false;
+                error = null;
+                _render();
+            } catch (e) {
+                error = e.message || '刷新失败';
+                _render();
+            }
+        }
+
+        // ---------- xlarge 自动刷新 ----------
+        function _startAutoRefresh() {
+            if (autoRefreshTimer) clearInterval(autoRefreshTimer);
+            autoRefreshTimer = setInterval(function() {
+                refresh();
+            }, AUTO_REFRESH_MS);
+        }
+
+        function _stopAutoRefresh() {
+            if (autoRefreshTimer) {
+                clearInterval(autoRefreshTimer);
+                autoRefreshTimer = null;
+            }
+        }
+
+        // ---------- 渲染分发 ----------
+        function _render() {
+            switch (size) {
+                case 'small':  _renderSmall(); break;
+                case 'medium': _renderMedium(); break;
+                case 'large':  _renderLarge(); break;
+                case 'xlarge': _renderXlarge(); break;
+            }
+        }
+
+        // ========== Small 渲染 (1x1) ==========
+        function _renderSmall() {
+            var statusCls = 'oc-header__status--unknown';
+            if (sysStatus && sysStatus.status) {
+                statusCls = _statusDotClass(sysStatus.status);
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="oc-small" data-action="open-overlay">' +
+                        '<div class="oc-small__emoji">📊</div>' +
+                        '<div class="oc-small__label">运维中心 <span class="oc-small__dot ' + statusCls + '"></span></div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== Medium 渲染 (2x1) ==========
+        function _renderMedium() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="oc-header"><span class="oc-header__icon">📊</span><span class="oc-header__title">运维中心</span></div>' + _skeletonHtml(3) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="oc-header"><span class="oc-header__icon">📊</span><span class="oc-header__title">运维中心</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            var statusCls = 'oc-header__status--unknown';
+            if (sysStatus && sysStatus.status) {
+                statusCls = _statusDotClass(sysStatus.status);
+            }
+
+            var sessions = (dashboard && dashboard.total_sessions) || 0;
+            var knowledge = (dashboard && dashboard.total_knowledge) || 0;
+            var agents = (dashboard && dashboard.total_agents) || 0;
+            var unreadAlerts = 0;
+            for (var i = 0; i < alerts.length; i++) {
+                if (!alerts[i].read) unreadAlerts++;
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="oc-header">' +
+                        '<span class="oc-header__icon">📊</span>' +
+                        '<span class="oc-header__title">运维中心</span>' +
+                        '<span class="oc-header__status ' + statusCls + '"></span>' +
+                        (unreadAlerts > 0
+                            ? '<span class="oc-alert-badge">🔔 ' + unreadAlerts + '</span>'
+                            : '') +
+                    '</div>' +
+                    '<div class="oc-mini-stats">' +
+                        '<div class="oc-mini-stat" data-action="open-overlay">' +
+                            '<span class="oc-mini-stat__value">' + sessions + '</span>' +
+                            '<span class="oc-mini-stat__label">会话数</span>' +
+                        '</div>' +
+                        '<div class="oc-mini-stat" data-action="open-overlay">' +
+                            '<span class="oc-mini-stat__value">' + knowledge + '</span>' +
+                            '<span class="oc-mini-stat__label">知识数</span>' +
+                        '</div>' +
+                        '<div class="oc-mini-stat" data-action="open-overlay">' +
+                            '<span class="oc-mini-stat__value">' + agents + '</span>' +
+                            '<span class="oc-mini-stat__label">Agent数</span>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== Large 渲染 (2x2) ==========
+        function _renderLarge() {
+            if (loading) {
+                container.innerHTML = '<div class="ws-widget"><div class="oc-header"><span class="oc-header__icon">📊</span><span class="oc-header__title">运维中心</span></div>' + _skeletonHtml(6) + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="ws-widget"><div class="oc-header"><span class="oc-header__icon">📊</span><span class="oc-header__title">运维中心</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            var statusCls = 'oc-header__status--unknown';
+            if (sysStatus && sysStatus.status) {
+                statusCls = _statusDotClass(sysStatus.status);
+            }
+
+            var sessions = (dashboard && dashboard.total_sessions) || 0;
+            var knowledge = (dashboard && dashboard.total_knowledge) || 0;
+            var agents = (dashboard && dashboard.total_agents) || 0;
+            var tools = (dashboard && dashboard.total_tools) || 0;
+
+            // 统计网格
+            var statsHtml =
+                '<div class="oc-stats-grid">' +
+                    '<div class="oc-stat-card" data-action="open-overlay">' +
+                        '<span class="oc-stat-card__icon">💬</span>' +
+                        '<div class="oc-stat-card__info"><span class="oc-stat-card__value">' + sessions + '</span><span class="oc-stat-card__label">会话数</span></div>' +
+                    '</div>' +
+                    '<div class="oc-stat-card" data-action="open-overlay">' +
+                        '<span class="oc-stat-card__icon">📖</span>' +
+                        '<div class="oc-stat-card__info"><span class="oc-stat-card__value">' + knowledge + '</span><span class="oc-stat-card__label">知识数</span></div>' +
+                    '</div>' +
+                    '<div class="oc-stat-card" data-action="open-overlay">' +
+                        '<span class="oc-stat-card__icon">🤖</span>' +
+                        '<div class="oc-stat-card__info"><span class="oc-stat-card__value">' + agents + '</span><span class="oc-stat-card__label">Agent数</span></div>' +
+                    '</div>' +
+                    '<div class="oc-stat-card" data-action="open-overlay">' +
+                        '<span class="oc-stat-card__icon">🔧</span>' +
+                        '<div class="oc-stat-card__info"><span class="oc-stat-card__value">' + tools + '</span><span class="oc-stat-card__label">工具数</span></div>' +
+                    '</div>' +
+                '</div>';
+
+            // MCP 健康
+            var connectedCount = 0;
+            var mcpDotsHtml = '';
+            for (var i = 0; i < mcpServers.length; i++) {
+                var s = mcpServers[i];
+                var dotCls = _mcpDotClass(s.status);
+                mcpDotsHtml += '<span class="oc-mcp-dot ' + dotCls + '" title="' + _esc(s.name) + ': ' + _esc(s.status) + '"></span>';
+                if (s.status === 'connected') connectedCount++;
+            }
+
+            var mcpHtml =
+                '<div class="oc-mcp-section">' +
+                    '<div class="oc-mcp-section__title">MCP 健康 <span class="oc-mcp-section__count">' + connectedCount + '/' + mcpServers.length + '</span></div>' +
+                    (mcpServers.length > 0
+                        ? '<div class="oc-mcp-dots">' + mcpDotsHtml + '</div>'
+                        : '<div style="font-size:10px;color:var(--text-tertiary);">暂无 MCP 服务器</div>') +
+                '</div>';
+
+            // 最近告警
+            var recentAlerts = alerts.slice(0, MAX_ALERTS_LARGE);
+            var alertsHtml = '';
+            if (recentAlerts.length > 0) {
+                alertsHtml = '<div class="oc-alerts-section__title">最近告警</div>';
+                for (var j = 0; j < recentAlerts.length; j++) {
+                    var a = recentAlerts[j];
+                    var badgeCls = _alertBadgeClass(a.level);
+                    alertsHtml +=
+                        '<div class="oc-alert-item" data-action="open-alert-overlay" data-alert-id="' + _esc(a.id) + '">' +
+                            '<span class="oc-alert-item__badge ' + badgeCls + '">' + _alertLevelLabel(a.level) + '</span>' +
+                            '<span class="oc-alert-item__msg">' + _esc(_truncate(a.message, TRUNCATE_MSG_LARGE)) + '</span>' +
+                        '</div>';
+                }
+            } else {
+                alertsHtml = '<div class="oc-alerts-section__title">最近告警</div><div style="font-size:10px;color:var(--text-tertiary);padding:4px 0;">暂无告警</div>';
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="oc-header">' +
+                        '<span class="oc-header__icon">📊</span>' +
+                        '<span class="oc-header__title">运维中心</span>' +
+                        '<span class="oc-header__status ' + statusCls + '"></span>' +
+                    '</div>' +
+                    '<div class="oc-body">' +
+                        statsHtml +
+                        mcpHtml +
+                        alertsHtml +
+                    '</div>' +
+                '</div>';
+        }
+
+        // ========== Xlarge 渲染 ==========
+        function _renderXlarge() {
+            switch (xlTab) {
+                case 'overview': _renderXlOverview(); break;
+                case 'mcp':      _renderXlMcp(); break;
+                case 'alerts':   _renderXlAlerts(); break;
+            }
+        }
+
+        // ----- Xlarge 系统概览 -----
+        function _renderXlOverview() {
+            if (loading) {
+                container.innerHTML = '<div class="oc-xl"><div class="oc-xl__header"><span class="oc-xl__title">运维中心</span></div>' + _loadingHtml() + '</div>';
+                return;
+            }
+            if (error) {
+                container.innerHTML = '<div class="oc-xl"><div class="oc-xl__header"><span class="oc-xl__title">运维中心</span></div>' + _errorHtml(error) + '</div>';
+                return;
+            }
+
+            var version = (sysStatus && sysStatus.version) || '-';
+            var uptime = _formatUptime(sysStatus && sysStatus.uptime);
+            var memory = (sysStatus && sysStatus.memory_usage) || '-';
+            var cpu = (sysStatus && sysStatus.cpu_usage) || '-';
+            var sessions = (dashboard && dashboard.total_sessions) || 0;
+            var knowledge = (dashboard && dashboard.total_knowledge) || 0;
+            var agents = (dashboard && dashboard.total_agents) || 0;
+            var tools = (dashboard && dashboard.total_tools) || 0;
+
+            var statsHtml =
+                '<div class="oc-xl-stats">' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">🏷️</span><span class="oc-xl-stat__label">版本</span></div><span class="oc-xl-stat__value">' + _esc(version) + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">⏱️</span><span class="oc-xl-stat__label">运行时间</span></div><span class="oc-xl-stat__value">' + _esc(uptime) + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">💬</span><span class="oc-xl-stat__label">会话数</span></div><span class="oc-xl-stat__value">' + sessions + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">📖</span><span class="oc-xl-stat__label">知识数</span></div><span class="oc-xl-stat__value">' + knowledge + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">🤖</span><span class="oc-xl-stat__label">Agent数</span></div><span class="oc-xl-stat__value">' + agents + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">🔧</span><span class="oc-xl-stat__label">工具数</span></div><span class="oc-xl-stat__value">' + tools + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">💾</span><span class="oc-xl-stat__label">内存</span></div><span class="oc-xl-stat__value">' + _esc(memory) + '</span></div>' +
+                    '<div class="oc-xl-stat"><div class="oc-xl-stat__top"><span class="oc-xl-stat__icon">⚡</span><span class="oc-xl-stat__label">CPU</span></div><span class="oc-xl-stat__value">' + _esc(cpu) + '</span></div>' +
+                '</div>';
+
+            container.innerHTML =
+                '<div class="oc-xl">' +
+                    '<div class="oc-xl__header">' +
+                        '<span class="oc-xl__title">运维中心</span>' +
+                        '<button class="oc-xl__refresh" data-action="refresh">🔄 刷新</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__tabs">' +
+                        '<button class="oc-xl__tab active" data-action="switch-tab" data-tab="overview">系统概览</button>' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="mcp">MCP健康</button>' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="alerts">告警</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__body">' + statsHtml + '</div>' +
+                '</div>';
+        }
+
+        // ----- Xlarge MCP 健康 -----
+        function _renderXlMcp() {
+            if (loading) {
+                container.innerHTML = '<div class="oc-xl"><div class="oc-xl__header"><span class="oc-xl__title">运维中心</span></div>' + _loadingHtml() + '</div>';
+                return;
+            }
+
+            var connectedCount = 0;
+            for (var i = 0; i < mcpServers.length; i++) {
+                if (mcpServers[i].status === 'connected') connectedCount++;
+            }
+
+            // 汇总统计
+            var summaryHtml =
+                '<div class="oc-xl-mcp-summary">' +
+                    '<div class="oc-xl-mcp-stat"><span class="oc-xl-mcp-stat__dot" style="background:var(--green, #22c55e);"></span><span class="oc-xl-mcp-stat__value">' + connectedCount + '</span><span class="oc-xl-mcp-stat__label">已连接</span></div>' +
+                    '<div class="oc-xl-mcp-stat"><span class="oc-xl-mcp-stat__dot" style="background:var(--text-tertiary);"></span><span class="oc-xl-mcp-stat__value">' + mcpServers.length + '</span><span class="oc-xl-mcp-stat__label">总计</span></div>' +
+                '</div>';
+
+            // 服务器列表
+            var listHtml = '';
+            if (mcpServers.length === 0) {
+                listHtml = _emptyHtml('暂无 MCP 服务器');
+            } else {
+                listHtml = '<div class="oc-xl-mcp-list">';
+                for (var j = 0; j < mcpServers.length; j++) {
+                    var srv = mcpServers[j];
+                    var dotColor = srv.status === 'connected' ? 'var(--green, #22c55e)' : (srv.status === 'error' ? 'var(--red, #ef4444)' : 'var(--text-tertiary)');
+                    var isExpanded = expandedMcpName === srv.name;
+                    var toolsCount = srv.tools_count || 0;
+                    var lastCheck = _formatTime(srv.last_check || srv.updated_at);
+
+                    listHtml +=
+                        '<div class="oc-xl-mcp-server' + (isExpanded ? ' expanded' : '') + '" data-action="toggle-mcp" data-name="' + _esc(srv.name) + '">' +
+                            '<div class="oc-xl-mcp-server__top">' +
+                                '<span class="oc-xl-mcp-server__status" style="background:' + dotColor + ';"></span>' +
+                                '<span class="oc-xl-mcp-server__name">' + _esc(srv.name) + '</span>' +
+                                '<span class="oc-xl-mcp-server__chevron">▼</span>' +
+                            '</div>' +
+                            '<div class="oc-xl-mcp-server__meta">' +
+                                '<span>🔧 ' + toolsCount + ' 个工具</span>' +
+                                '<span>🕐 ' + lastCheck + '</span>' +
+                            '</div>' +
+                            '<div class="oc-xl-mcp-server__detail">' +
+                                '<div style="display:grid;grid-template-columns:auto 1fr;gap:4px 12px;">' +
+                                    '<span style="color:var(--text-tertiary);">状态:</span><span>' + _esc(srv.status || 'unknown') + '</span>' +
+                                    '<span style="color:var(--text-tertiary);">工具数:</span><span>' + toolsCount + '</span>' +
+                                    (srv.description ? '<span style="color:var(--text-tertiary);">描述:</span><span>' + _esc(srv.description) + '</span>' : '') +
+                                    (srv.endpoint ? '<span style="color:var(--text-tertiary);">端点:</span><span>' + _esc(srv.endpoint) + '</span>' : '') +
+                                '</div>' +
+                            '</div>' +
+                        '</div>';
+                }
+                listHtml += '</div>';
+            }
+
+            container.innerHTML =
+                '<div class="oc-xl">' +
+                    '<div class="oc-xl__header">' +
+                        '<span class="oc-xl__title">运维中心</span>' +
+                        '<button class="oc-xl__refresh" data-action="refresh">🔄 刷新</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__tabs">' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="overview">系统概览</button>' +
+                        '<button class="oc-xl__tab active" data-action="switch-tab" data-tab="mcp">MCP健康</button>' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="alerts">告警</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__body">' + summaryHtml + listHtml + '</div>' +
+                '</div>';
+        }
+
+        // ----- Xlarge 告警 -----
+        function _renderXlAlerts() {
+            if (loading) {
+                container.innerHTML = '<div class="oc-xl"><div class="oc-xl__header"><span class="oc-xl__title">运维中心</span></div>' + _loadingHtml() + '</div>';
+                return;
+            }
+
+            // 过滤告警
+            var filtered = alerts;
+            if (xlAlertFilter !== 'all') {
+                filtered = [];
+                for (var i = 0; i < alerts.length; i++) {
+                    if (alerts[i].level === xlAlertFilter) filtered.push(alerts[i]);
+                }
+            }
+
+            // 筛选按钮
+            var filtersHtml =
+                '<div class="oc-xl-alert-filters">' +
+                    '<button class="oc-xl-alert-filter' + (xlAlertFilter === 'all' ? ' active' : '') + '" data-action="alert-filter" data-filter="all">全部</button>' +
+                    '<button class="oc-xl-alert-filter' + (xlAlertFilter === 'info' ? ' active' : '') + '" data-action="alert-filter" data-filter="info">信息</button>' +
+                    '<button class="oc-xl-alert-filter' + (xlAlertFilter === 'warning' ? ' active' : '') + '" data-action="alert-filter" data-filter="warning">警告</button>' +
+                    '<button class="oc-xl-alert-filter' + (xlAlertFilter === 'error' ? ' active' : '') + '" data-action="alert-filter" data-filter="error">错误</button>' +
+                '</div>';
+
+            // 操作按钮
+            var actionsHtml =
+                '<div class="oc-xl-alert-actions">' +
+                    '<button class="oc-xl-alert-action" data-action="mark-all-read">全部已读</button>' +
+                    '<button class="oc-xl-alert-action danger" data-action="clear-all-alerts">清除全部</button>' +
+                '</div>';
+
+            // 告警列表
+            var listHtml = '';
+            if (filtered.length === 0) {
+                listHtml = _emptyHtml('暂无告警');
+            } else {
+                listHtml = '<div class="oc-xl-alert-list">';
+                for (var j = 0; j < filtered.length; j++) {
+                    var a = filtered[j];
+                    var badgeCls = _xlAlertBadgeClass(a.level);
+                    var isExpanded = expandedAlertId === a.id;
+
+                    listHtml +=
+                        '<div class="oc-xl-alert' + (isExpanded ? ' expanded' : '') + '" data-action="toggle-alert" data-alert-id="' + _esc(a.id) + '">' +
+                            '<div class="oc-xl-alert__top">' +
+                                (!a.read ? '<span class="oc-xl-alert__unread"></span>' : '') +
+                                '<span class="oc-xl-alert__badge ' + badgeCls + '">' + _alertLevelLabel(a.level) + '</span>' +
+                                '<span class="oc-xl-alert__source">' + _esc(a.source || '') + '</span>' +
+                                '<span class="oc-xl-alert__time">' + _formatTime(a.timestamp) + '</span>' +
+                            '</div>' +
+                            '<div class="oc-xl-alert__msg">' + _esc(a.message) + '</div>' +
+                            '<div class="oc-xl-alert__detail">' +
+                                '<div class="oc-xl-alert__detail-msg">' + _esc(a.message) + '</div>' +
+                                '<div class="oc-xl-alert__detail-actions">' +
+                                    (!a.read ? '<button class="oc-xl-alert__detail-btn" data-action="mark-read" data-alert-id="' + _esc(a.id) + '">标为已读</button>' : '') +
+                                '</div>' +
+                            '</div>' +
+                        '</div>';
+                }
+                listHtml += '</div>';
+            }
+
+            container.innerHTML =
+                '<div class="oc-xl">' +
+                    '<div class="oc-xl__header">' +
+                        '<span class="oc-xl__title">运维中心</span>' +
+                        '<button class="oc-xl__refresh" data-action="refresh">🔄 刷新</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__tabs">' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="overview">系统概览</button>' +
+                        '<button class="oc-xl__tab" data-action="switch-tab" data-tab="mcp">MCP健康</button>' +
+                        '<button class="oc-xl__tab active" data-action="switch-tab" data-tab="alerts">告警</button>' +
+                    '</div>' +
+                    '<div class="oc-xl__body">' + filtersHtml + actionsHtml + listHtml + '</div>' +
+                '</div>';
+        }
+
+        // ========== 事件处理 ==========
+
+        function _handleClick(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+
+            var action = target.getAttribute('data-action');
+
+            switch (action) {
+                // ----- 通用: 打开覆盖层 -----
+                case 'open-overlay':
+                    e.preventDefault();
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('ops-card');
+                    }
+                    break;
+
+                // ----- Large: 点击告警打开覆盖层 -----
+                case 'open-alert-overlay':
+                    e.preventDefault();
+                    var alertId = target.getAttribute('data-alert-id');
+                    if (typeof CardOverlay !== 'undefined') {
+                        CardOverlay.open('ops-card', { tab: 'alerts', alertId: alertId });
+                    }
+                    break;
+
+                // ----- Xlarge: 切换标签页 -----
+                case 'switch-tab':
+                    e.preventDefault();
+                    var tab = target.getAttribute('data-tab');
+                    if (tab) {
+                        xlTab = tab;
+                        expandedAlertId = null;
+                        expandedMcpName = null;
+                        _renderXlarge();
+                    }
+                    break;
+
+                // ----- Xlarge: 刷新 -----
+                case 'refresh':
+                    e.preventDefault();
+                    refresh();
+                    break;
+
+                // ----- Xlarge: 告警筛选 -----
+                case 'alert-filter':
+                    e.preventDefault();
+                    var filter = target.getAttribute('data-filter');
+                    if (filter) {
+                        xlAlertFilter = filter;
+                        expandedAlertId = null;
+                        _renderXlAlerts();
+                    }
+                    break;
+
+                // ----- Xlarge: 展开/折叠告警 -----
+                case 'toggle-alert':
+                    e.preventDefault();
+                    var tid = target.getAttribute('data-alert-id');
+                    expandedAlertId = (expandedAlertId === tid) ? null : tid;
+                    _renderXlAlerts();
+                    break;
+
+                // ----- Xlarge: 展开/折叠 MCP 服务器 -----
+                case 'toggle-mcp':
+                    e.preventDefault();
+                    var name = target.getAttribute('data-name');
+                    expandedMcpName = (expandedMcpName === name) ? null : name;
+                    _renderXlMcp();
+                    break;
+
+                // ----- Xlarge: 标记单条已读 -----
+                case 'mark-read':
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var readId = target.getAttribute('data-alert-id');
+                    _doMarkRead(readId);
+                    break;
+
+                // ----- Xlarge: 全部已读 -----
+                case 'mark-all-read':
+                    e.preventDefault();
+                    _doMarkAllRead();
+                    break;
+
+                // ----- Xlarge: 清除全部告警 -----
+                case 'clear-all-alerts':
+                    e.preventDefault();
+                    _doClearAll();
+                    break;
+
+                // ----- 重试 -----
+                case 'retry':
+                    e.preventDefault();
+                    loadData();
+                    break;
+            }
+        }
+
+        // ---------- 标记单条已读 ----------
+        async function _doMarkRead(id) {
+            try {
+                await _markAlertRead(id);
+                // 更新本地状态
+                for (var i = 0; i < alerts.length; i++) {
+                    if (alerts[i].id === id) {
+                        alerts[i].read = true;
+                        break;
+                    }
+                }
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_ALERTS);
+                }
+                _showToast('已标为已读', 'success');
+                _renderXlAlerts();
+            } catch (e) {
+                _showToast('操作失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- 全部已读 ----------
+        async function _doMarkAllRead() {
+            try {
+                for (var i = 0; i < alerts.length; i++) {
+                    if (!alerts[i].read) {
+                        await _markAlertRead(alerts[i].id);
+                        alerts[i].read = true;
+                    }
+                }
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_ALERTS);
+                }
+                _showToast('已全部标为已读', 'success');
+                _renderXlAlerts();
+            } catch (e) {
+                _showToast('操作失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ---------- 清除全部 ----------
+        async function _doClearAll() {
+            try {
+                await _clearAllAlerts();
+                alerts = [];
+                if (typeof HermesClient !== 'undefined' && HermesClient.clearCache) {
+                    HermesClient.clearCache(CACHE_ALERTS);
+                }
+                _showToast('已清除全部告警', 'success');
+                _renderXlAlerts();
+            } catch (e) {
+                _showToast('清除失败: ' + (e.message || '未知错误'), 'error');
+            }
+        }
+
+        // ========== 事件绑定 ==========
+        _clickHandler = _handleClick;
+        container.addEventListener('click', _clickHandler);
+
+        // SSE 事件订阅
+        if (typeof Bus !== 'undefined') {
+            _sseHandlers['sse:alert.*'] = refresh;
+            _sseHandlers['sse:system.*'] = refresh;
+            Bus.on('sse:alert.*', refresh);
+            Bus.on('sse:system.*', refresh);
+        }
+
+        // 初始加载数据
+        loadData();
+
+        // xlarge 模式启动自动刷新
+        if (size === 'xlarge') {
+            _startAutoRefresh();
+        }
+
+        // ========== 返回接口 ==========
+        return {
+            destroy: function() {
+                // 移除 DOM 事件
+                if (_clickHandler) container.removeEventListener('click', _clickHandler);
+
+                // 停止自动刷新
+                _stopAutoRefresh();
+
+                // 取消 SSE 订阅
+                if (typeof Bus !== 'undefined') {
+                    Bus.off('sse:alert.*', refresh);
+                    Bus.off('sse:system.*', refresh);
+                }
+
+                // 清空内容
+                container.innerHTML = '';
+            },
+            refresh: function() {
+                loadData();
+            }
+        };
+    }
+
+    // ========== 入口卡片（简化版 1x1） ==========
+    async function mountEntry(container, props) {
+        _injectStyles();
+
+        var sysStatus = null;
+        var loaded = false;
+
+        async function loadStatus() {
+            try {
+                sysStatus = await _fetchStatus();
+                loaded = true;
+                _renderEntry();
+            } catch (e) {
+                loaded = true;
+                _renderEntry();
+            }
+        }
+
+        function _renderEntry() {
+            var statusCls = 'oc-header__status--unknown';
+            if (sysStatus && sysStatus.status) {
+                statusCls = _statusDotClass(sysStatus.status);
+            }
+
+            container.innerHTML =
+                '<div class="ws-widget">' +
+                    '<div class="oc-small" data-action="open-overlay">' +
+                        '<div class="oc-small__emoji">📊</div>' +
+                        '<div class="oc-small__label">运维中心 <span class="oc-small__dot ' + statusCls + '"></span></div>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        var _clickHandler = function(e) {
+            var target = e.target.closest('[data-action="open-overlay"]');
+            if (target && typeof CardOverlay !== 'undefined') {
+                CardOverlay.open('ops-card');
+            }
+        };
+        container.addEventListener('click', _clickHandler);
+
+        _renderEntry();
+        loadStatus();
+
+        // SSE 事件订阅
+        if (typeof Bus !== 'undefined') {
+            var _sseRefresh = function() { loadStatus(); };
+            Bus.on('sse:system.*', _sseRefresh);
+
+            return {
+                destroy: function() {
+                    container.removeEventListener('click', _clickHandler);
+                    if (typeof Bus !== 'undefined') {
+                        Bus.off('sse:system.*', _sseRefresh);
+                    }
+                    container.innerHTML = '';
+                },
+                refresh: function() { loadStatus(); }
+            };
+        }
+
+        return {
+            destroy: function() {
+                container.removeEventListener('click', _clickHandler);
+                container.innerHTML = '';
+            },
+            refresh: function() { loadStatus(); }
+        };
+    }
+
+    // ========== 注册卡片 ==========
+    WidgetRegistry.register('ops-card', {
+        type: 'stat',
+        label: '运维中心',
+        icon: '📊',
+        description: '系统监控、MCP健康状态、告警管理',
+        defaultSize: { w: 2, h: 1 },
+        category: 'stats',
+        mount: mount
+    });
+
+    WidgetRegistry.register('ops-entry', {
+        type: 'entry',
+        label: '运维中心入口',
+        icon: '📊',
+        description: '运维中心快速入口',
+        defaultSize: { w: 1, h: 1 },
+        category: 'entries',
+        mount: mountEntry
+    });
+
+    // ========== 公开接口（调试用） ==========
+    return {
+        mount: mount,
+        mountEntry: mountEntry
+    };
+})();

--- a/frontend/js/workspace/widgets/cards/RulesCard.js
+++ b/frontend/js/workspace/widgets/cards/RulesCard.js
@@ -1,0 +1,598 @@
+;(function() {
+  'use strict';
+
+  var CSS_ID = 'rules-card-css';
+  var PREFIX = 'rc';
+  var API = '/api/rules';
+  var instanceCount = 0;
+
+  /* ── CSS ─────────────────────────────────────────────── */
+  var css = [
+    '.rc-wrap{font-family:system-ui,-apple-system,sans-serif;height:100%;display:flex;flex-direction:column;overflow:hidden;color:#e0e0e0;background:#1a1a2e;border-radius:8px;box-sizing:border-box}',
+    '.rc-header{display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-bottom:1px solid rgba(255,255,255,.08);flex-shrink:0}',
+    '.rc-header h3{margin:0;font-size:13px;font-weight:600;display:flex;align-items:center;gap:6px}',
+    '.rc-header .rc-count{font-size:11px;color:#888;background:rgba(255,255,255,.06);padding:1px 7px;border-radius:10px}',
+    '.rc-body{flex:1;overflow-y:auto;padding:6px 8px}',
+    '.rc-body::-webkit-scrollbar{width:4px}',
+    '.rc-body::-webkit-scrollbar-thumb{background:rgba(255,255,255,.12);border-radius:2px}',
+    '.rc-search{display:flex;gap:6px;padding:6px 8px;flex-shrink:0}',
+    '.rc-search input{flex:1;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:5px 10px;color:#e0e0e0;font-size:12px;outline:none}',
+    '.rc-search input:focus{border-color:#6c8cff}',
+    '.rc-filters{display:flex;gap:4px;padding:0 8px 6px;flex-shrink:0;flex-wrap:wrap}',
+    '.rc-filter-btn{font-size:11px;padding:2px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.12);background:transparent;color:#aaa;cursor:pointer;transition:.2s}',
+    '.rc-filter-btn:hover,.rc-filter-btn.active{background:#6c8cff;color:#fff;border-color:#6c8cff}',
+    '.rc-item{display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:6px;cursor:pointer;transition:.15s;border:1px solid transparent}',
+    '.rc-item:hover{background:rgba(255,255,255,.05);border-color:rgba(255,255,255,.08)}',
+    '.rc-item .rc-name{flex:1;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}',
+    '.rc-priority{font-size:10px;padding:1px 6px;border-radius:8px;font-weight:600;flex-shrink:0}',
+    '.rc-priority-high{background:rgba(255,77,77,.15);color:#ff6b6b}',
+    '.rc-priority-medium{background:rgba(255,193,7,.15);color:#ffc107}',
+    '.rc-priority-low{background:rgba(76,175,80,.15);color:#66bb6a}',
+    '.rc-enabled{width:7px;height:7px;border-radius:50%;flex-shrink:0}',
+    '.rc-enabled.on{background:#66bb6a}',
+    '.rc-enabled.off{background:#555}',
+    '.rc-scope{font-size:10px;color:#888;max-width:80px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+    '.rc-toggle{width:32px;height:18px;border-radius:9px;border:none;cursor:pointer;position:relative;transition:.2s;flex-shrink:0}',
+    '.rc-toggle.on{background:#6c8cff}',
+    '.rc-toggle.off{background:#444}',
+    '.rc-toggle::after{content:"";position:absolute;top:2px;width:14px;height:14px;border-radius:50%;background:#fff;transition:.2s}',
+    '.rc-toggle.on::after{left:16px}',
+    '.rc-toggle.off::after{left:2px}',
+    '.rc-actions{display:flex;gap:4px;flex-shrink:0}',
+    '.rc-actions button{background:none;border:none;color:#888;cursor:pointer;font-size:13px;padding:2px 4px;border-radius:4px;transition:.15s}',
+    '.rc-actions button:hover{color:#e0e0e0;background:rgba(255,255,255,.1)}',
+    '.rc-actions button.danger:hover{color:#ff6b6b}',
+    '.rc-btn{font-size:11px;padding:4px 12px;border-radius:6px;border:1px solid rgba(255,255,255,.15);background:rgba(255,255,255,.06);color:#ccc;cursor:pointer;transition:.2s}',
+    '.rc-btn:hover{background:#6c8cff;color:#fff;border-color:#6c8cff}',
+    '.rc-btn.primary{background:#6c8cff;color:#fff;border-color:#6c8cff}',
+    '.rc-btn.primary:hover{background:#5a7ae6}',
+    '.rc-btn.danger{color:#ff6b6b;border-color:rgba(255,77,77,.3)}',
+    '.rc-btn.danger:hover{background:rgba(255,77,77,.15)}',
+    '.rc-detail{padding:12px;flex:1;overflow-y:auto}',
+    '.rc-detail .rc-back{display:flex;align-items:center;gap:4px;background:none;border:none;color:#6c8cff;cursor:pointer;font-size:12px;margin-bottom:10px;padding:4px 8px;border-radius:6px;transition:.15s}',
+    '.rc-detail .rc-back:hover{background:rgba(108,140,255,.1)}',
+    '.rc-detail .rc-meta{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:10px 0;font-size:12px}',
+    '.rc-detail .rc-meta dt{color:#888}',
+    '.rc-detail .rc-meta dd{color:#ccc;margin:0}',
+    '.rc-detail .rc-content{font-size:12px;line-height:1.7;color:#bbb;padding:10px;background:rgba(255,255,255,.03);border-radius:6px;margin:10px 0;white-space:pre-wrap}',
+    '.rc-form{display:flex;flex-direction:column;gap:8px;margin-top:10px}',
+    '.rc-form label{font-size:11px;color:#888}',
+    '.rc-form input,.rc-form textarea,.rc-form select{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.1);border-radius:6px;padding:6px 10px;color:#e0e0e0;font-size:12px;outline:none;font-family:inherit}',
+    '.rc-form input:focus,.rc-form textarea:focus,.rc-form select:focus{border-color:#6c8cff}',
+    '.rc-form textarea{resize:vertical;min-height:80px}',
+    '.rc-form select option{background:#1a1a2e;color:#e0e0e0}',
+    '.rc-confirm{display:flex;align-items:center;gap:8px;padding:8px 12px;background:rgba(255,77,77,.08);border-radius:6px;margin-top:8px;font-size:12px}',
+    '.rc-confirm .rc-confirm-text{flex:1;color:#ff6b6b}',
+    '.rc-tags{display:flex;gap:4px;flex-wrap:wrap}',
+    '.rc-tag{font-size:10px;padding:1px 7px;border-radius:8px;background:rgba(108,140,255,.12);color:#8ea8ff}',
+    '.rc-empty,.rc-loading,.rc-error{text-align:center;padding:20px;font-size:12px;color:#888}',
+    '.rc-loading::after{content:"";display:inline-block;width:16px;height:16px;border:2px solid rgba(255,255,255,.1);border-top-color:#6c8cff;border-radius:50%;animation:rc-spin .6s linear infinite;margin-left:6px;vertical-align:middle}',
+    '@keyframes rc-spin{to{transform:rotate(360deg)}}',
+    '.rc-small{display:flex;align-items:center;justify-content:center;height:100%;cursor:pointer;gap:8px;font-size:14px;font-weight:600;transition:.15s}',
+    '.rc-small:hover{background:rgba(108,140,255,.08)}',
+    '.rc-small .rc-badge{font-size:11px;background:#6c8cff;color:#fff;padding:1px 8px;border-radius:10px}'
+  ].join('\n');
+
+  function injectCSS() {
+    if (document.getElementById(CSS_ID)) return;
+    var s = document.createElement('style');
+    s.id = CSS_ID;
+    s.textContent = css;
+    document.head.appendChild(s);
+  }
+
+  /* ── Helpers ─────────────────────────────────────────── */
+  function escapeHTML(str) {
+    var d = document.createElement('div');
+    d.textContent = str || '';
+    return d.innerHTML;
+  }
+
+  function timeAgo(ts) {
+    if (!ts) return '';
+    var diff = Date.now() - new Date(ts).getTime();
+    var m = Math.floor(diff / 60000);
+    if (m < 1) return '刚刚';
+    if (m < 60) return m + '分钟前';
+    var h = Math.floor(m / 60);
+    if (h < 24) return h + '小时前';
+    var d = Math.floor(h / 24);
+    if (d < 30) return d + '天前';
+    return new Date(ts).toLocaleDateString('zh-CN');
+  }
+
+  /* ── Card ────────────────────────────────────────────── */
+  function createCard(container, opts) {
+    injectCSS();
+    var uid = ++instanceCount;
+    var size = (opts && opts.size) || 'medium';
+    var el = document.createElement('div');
+    el.className = 'rc-wrap';
+    el.setAttribute('data-uid', uid);
+    container.appendChild(el);
+
+    var state = {
+      data: [],
+      stats: null,
+      loading: true,
+      error: null,
+      search: '',
+      filter: 'all',
+      view: 'list',
+      current: null,
+      editing: false,
+      creating: false,
+      deleting: false,
+      sseId: null
+    };
+
+    /* ── API ── */
+    function fetchList() {
+      state.loading = true;
+      state.error = null;
+      DataService.get(API).then(function(res) {
+        state.data = (res && res.data) ? res.data : (Array.isArray(res) ? res : []);
+        state.loading = false;
+        render();
+      }).catch(function(err) {
+        state.loading = false;
+        state.error = err.message || '加载失败';
+        render();
+      });
+    }
+
+    function fetchStats() {
+      DataService.get(API + '/stats').then(function(res) {
+        state.stats = res;
+        if (size === 'small') render();
+      }).catch(function() {});
+    }
+
+    function createRule(data) {
+      return DataService.post(API, data).then(function(res) {
+        fetchList();
+        fetchStats();
+        return res;
+      });
+    }
+
+    function updateRule(id, data) {
+      return DataService.put(API + '/' + id, data).then(function(res) {
+        fetchList();
+        fetchStats();
+        return res;
+      });
+    }
+
+    function deleteRule(id) {
+      return DataService.delete(API + '/' + id).then(function() {
+        fetchList();
+        fetchStats();
+        state.view = 'list';
+        state.current = null;
+        state.deleting = false;
+      });
+    }
+
+    function toggleRule(id, enabled) {
+      return DataService.put(API + '/' + id, { enabled: enabled }).then(function() {
+        fetchList();
+        fetchStats();
+      });
+    }
+
+    /* ── SSE ── */
+    function subscribeSSE() {
+      if (typeof HermesClient === 'undefined' || !HermesClient.sse) return;
+      state.sseId = HermesClient.sse.subscribe('rules', function(event) {
+        if (event.type === 'update' || event.type === 'create' || event.type === 'delete') {
+          fetchList();
+          fetchStats();
+        }
+      });
+    }
+
+    function unsubscribeSSE() {
+      if (state.sseId && typeof HermesClient !== 'undefined' && HermesClient.sse) {
+        HermesClient.sse.unsubscribe(state.sseId);
+        state.sseId = null;
+      }
+    }
+
+    /* ── Filter ── */
+    function filtered() {
+      var list = state.data;
+      if (state.search) {
+        var q = state.search.toLowerCase();
+        list = list.filter(function(r) {
+          return (r.name || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.content || '').toLowerCase().indexOf(q) !== -1 ||
+                 (r.scope || '').toLowerCase().indexOf(q) !== -1;
+        });
+      }
+      if (state.filter !== 'all') {
+        list = list.filter(function(r) { return r.priority === state.filter; });
+      }
+      return list;
+    }
+
+    /* ── Render ── */
+    function render() {
+      if (size === 'small') { renderSmall(); return; }
+      if (size === 'xlarge') {
+        if (state.view === 'detail') renderXlDetail();
+        else renderXlList();
+        return;
+      }
+      if (size === 'large') { renderLarge(); return; }
+      renderMedium();
+    }
+
+    function renderSmall() {
+      var active = state.data.filter(function(r) { return r.enabled; }).length;
+      el.innerHTML =
+        '<div class="rc-small" data-action="open-overlay">' +
+          '<span>\u{1F4CB}</span>' +
+          '<span>\u89C4\u5219</span>' +
+          '<span class="rc-badge">' + active + '</span>' +
+        '</div>';
+    }
+
+    function renderMedium() {
+      var list = filtered().slice(0, 8);
+      var h = '<div class="rc-header"><h3>\u{1F4CB} \u89C4\u5219 <span class="rc-count">' + state.data.length + '</span></h3></div>';
+      h += '<div class="rc-body">';
+      if (state.loading) { h += '<div class="rc-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="rc-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="rc-empty">\u6682\u65E0\u89C4\u5219</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="rc-item" data-action="open-detail" data-id="' + r.id + '">' +
+            '<span class="rc-enabled ' + (r.enabled ? 'on' : 'off') + '"></span>' +
+            '<span class="rc-name">' + escapeHTML(r.name) + '</span>' +
+            '<span class="rc-priority rc-priority-' + (r.priority || 'medium') + '">' + escapeHTML(r.priority || 'medium') + '</span>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderLarge() {
+      var list = filtered().slice(0, 20);
+      var h = '<div class="rc-header"><h3>\u{1F4CB} \u89C4\u5219 <span class="rc-count">' + state.data.length + '</span></h3></div>';
+      h += '<div class="rc-search"><input placeholder="\u641C\u7D22\u89C4\u5219..." data-action="search" value="' + escapeHTML(state.search) + '"></div>';
+      h += '<div class="rc-filters">' +
+        '<button class="rc-filter-btn ' + (state.filter === 'all' ? 'active' : '') + '" data-action="filter" data-val="all">\u5168\u90E8</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'high' ? 'active' : '') + '" data-action="filter" data-val="high">\u9AD8</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'medium' ? 'active' : '') + '" data-action="filter" data-val="medium">\u4E2D</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'low' ? 'active' : '') + '" data-action="filter" data-val="low">\u4F4E</button>' +
+      '</div>';
+      h += '<div class="rc-body">';
+      if (state.loading) { h += '<div class="rc-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="rc-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="rc-empty">\u6682\u65E0\u89C4\u5219</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="rc-item">' +
+            '<span class="rc-enabled ' + (r.enabled ? 'on' : 'off') + '"></span>' +
+            '<span class="rc-name">' + escapeHTML(r.name) + '</span>' +
+            '<span class="rc-priority rc-priority-' + (r.priority || 'medium') + '">' + escapeHTML(r.priority || 'medium') + '</span>' +
+            '<span class="rc-scope">' + escapeHTML(r.scope || '') + '</span>' +
+            '<button class="rc-toggle ' + (r.enabled ? 'on' : 'off') + '" data-action="toggle" data-id="' + r.id + '" data-val="' + (!r.enabled) + '"></button>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderXlList() {
+      var list = filtered();
+      var h = '<div class="rc-header"><h3>\u{1F4CB} \u89C4\u5219\u7BA1\u7406 <span class="rc-count">' + state.data.length + '</span></h3>' +
+        '<button class="rc-btn primary" data-action="create">\u65B0\u5EFA</button></div>';
+      h += '<div class="rc-search"><input placeholder="\u641C\u7D22\u89C4\u5219..." data-action="search" value="' + escapeHTML(state.search) + '"></div>';
+      h += '<div class="rc-filters">' +
+        '<button class="rc-filter-btn ' + (state.filter === 'all' ? 'active' : '') + '" data-action="filter" data-val="all">\u5168\u90E8</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'high' ? 'active' : '') + '" data-action="filter" data-val="high">\u9AD8</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'medium' ? 'active' : '') + '" data-action="filter" data-val="medium">\u4E2D</button>' +
+        '<button class="rc-filter-btn ' + (state.filter === 'low' ? 'active' : '') + '" data-action="filter" data-val="low">\u4F4E</button>' +
+      '</div>';
+      h += '<div class="rc-body">';
+      if (state.loading) { h += '<div class="rc-loading">\u52A0\u8F7D\u4E2D</div>'; }
+      else if (state.error) { h += '<div class="rc-error">' + escapeHTML(state.error) + '</div>'; }
+      else if (list.length === 0) { h += '<div class="rc-empty">\u6682\u65E0\u89C4\u5219</div>'; }
+      else {
+        list.forEach(function(r) {
+          h += '<div class="rc-item">' +
+            '<span class="rc-enabled ' + (r.enabled ? 'on' : 'off') + '"></span>' +
+            '<span class="rc-name" data-action="open-detail" data-id="' + r.id + '">' + escapeHTML(r.name) + '</span>' +
+            '<span class="rc-priority rc-priority-' + (r.priority || 'medium') + '">' + escapeHTML(r.priority || 'medium') + '</span>' +
+            '<span class="rc-scope">' + escapeHTML(r.scope || '') + '</span>' +
+            '<button class="rc-toggle ' + (r.enabled ? 'on' : 'off') + '" data-action="toggle" data-id="' + r.id + '" data-val="' + (!r.enabled) + '"></button>' +
+            '<div class="rc-actions">' +
+              '<button data-action="edit" data-id="' + r.id + '" title="\u7F16\u8F91">\u270F\uFE0F</button>' +
+              '<button class="danger" data-action="delete" data-id="' + r.id + '" title="\u5220\u9664">\u{1F5D1}</button>' +
+            '</div>' +
+          '</div>';
+        });
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    function renderXlDetail() {
+      var r = state.current;
+      if (!r) { state.view = 'list'; renderXlList(); return; }
+      var h = '<div class="rc-detail">';
+      h += '<button class="rc-back" data-action="back">\u2190 \u8FD4\u56DE</button>';
+      h += '<div class="rc-header"><h3>' + escapeHTML(r.name) + '</h3></div>';
+      h += '<div class="rc-meta">' +
+        '<div><dt>\u4F18\u5148\u7EA7</dt><dd><span class="rc-priority rc-priority-' + (r.priority || 'medium') + '">' + escapeHTML(r.priority || 'medium') + '</span></dd></div>' +
+        '<div><dt>\u72B6\u6001</dt><dd><span class="rc-enabled ' + (r.enabled ? 'on' : 'off') + '"></span> ' + (r.enabled ? '\u5DF2\u542F\u7528' : '\u5DF2\u7981\u7528') + '</dd></div>' +
+        '<div><dt>\u4F5C\u7528\u57DF</dt><dd>' + escapeHTML(r.scope || '-') + '</dd></div>' +
+        '<div><dt>\u66F4\u65B0</dt><dd>' + timeAgo(r.updated_at) + '</dd></div>' +
+      '</div>';
+      if (r.tags && r.tags.length) {
+        h += '<div class="rc-tags">';
+        r.tags.forEach(function(t) { h += '<span class="rc-tag">' + escapeHTML(t) + '</span>'; });
+        h += '</div>';
+      }
+      h += '<div class="rc-content">' + escapeHTML(r.content || '') + '</div>';
+
+      if (state.editing) {
+        h += '<div class="rc-form">' +
+          '<label>\u540D\u79F0</label><input id="rc-edit-name" value="' + escapeHTML(r.name) + '">' +
+          '<label>\u4F18\u5148\u7EA7</label><select id="rc-edit-priority">' +
+            '<option value="low"' + (r.priority === 'low' ? ' selected' : '') + '>\u4F4E</option>' +
+            '<option value="medium"' + (r.priority === 'medium' ? ' selected' : '') + '>\u4E2D</option>' +
+            '<option value="high"' + (r.priority === 'high' ? ' selected' : '') + '>\u9AD8</option>' +
+          '</select>' +
+          '<label>\u4F5C\u7528\u57DF</label><input id="rc-edit-scope" value="' + escapeHTML(r.scope || '') + '">' +
+          '<label>\u5185\u5BB9</label><textarea id="rc-edit-content">' + escapeHTML(r.content || '') + '</textarea>' +
+          '<div style="display:flex;gap:6px;justify-content:flex-end">' +
+            '<button class="rc-btn" data-action="cancel-edit">\u53D6\u6D88</button>' +
+            '<button class="rc-btn primary" data-action="save-edit">\u4FDD\u5B58</button>' +
+          '</div>' +
+        '</div>';
+      } else if (state.creating) {
+        h += '<div class="rc-form">' +
+          '<label>\u540D\u79F0</label><input id="rc-edit-name" placeholder="\u89C4\u5219\u540D\u79F0">' +
+          '<label>\u4F18\u5148\u7EA7</label><select id="rc-edit-priority">' +
+            '<option value="low">\u4F4E</option><option value="medium" selected>\u4E2D</option><option value="high">\u9AD8</option>' +
+          '</select>' +
+          '<label>\u4F5C\u7528\u57DF</label><input id="rc-edit-scope" placeholder="\u4F5C\u7528\u57DF">' +
+          '<label>\u5185\u5BB9</label><textarea id="rc-edit-content" placeholder="\u89C4\u5219\u5185\u5BB9..."></textarea>' +
+          '<div style="display:flex;gap:6px;justify-content:flex-end">' +
+            '<button class="rc-btn" data-action="cancel-create">\u53D6\u6D88</button>' +
+            '<button class="rc-btn primary" data-action="save-create">\u521B\u5EFA</button>' +
+          '</div>' +
+        '</div>';
+      } else {
+        h += '<div style="display:flex;gap:6px;flex-wrap:wrap;padding-top:8px">' +
+          '<button class="rc-btn" data-action="toggle-detail" data-id="' + r.id + '" data-val="' + (!r.enabled) + '">' + (r.enabled ? '\u7981\u7528' : '\u542F\u7528') + '</button>' +
+          '<button class="rc-btn" data-action="start-edit">\u7F16\u8F91</button>' +
+          '<button class="rc-btn danger" data-action="confirm-delete">\u5220\u9664</button>' +
+        '</div>';
+        if (state.deleting) {
+          h += '<div class="rc-confirm">' +
+            '<span class="rc-confirm-text">\u786E\u5B9A\u5220\u9664\u8FD9\u6761\u89C4\u5219\uFF1F</span>' +
+            '<button class="rc-btn danger" data-action="do-delete">\u5220\u9664</button>' +
+            '<button class="rc-btn" data-action="cancel-delete">\u53D6\u6D88</button>' +
+          '</div>';
+        }
+      }
+      h += '</div>';
+      el.innerHTML = h;
+    }
+
+    /* ── Events ── */
+    el.addEventListener('click', function(e) {
+      var target = e.target.closest('[data-action]');
+      if (!target) return;
+      var action = target.getAttribute('data-action');
+      var id = target.getAttribute('data-id');
+      var val = target.getAttribute('data-val');
+
+      switch (action) {
+        case 'open-overlay':
+          if (typeof CardOverlay !== 'undefined') {
+            CardOverlay.open('rules-card', { size: 'xlarge' });
+          }
+          break;
+        case 'open-detail':
+          var item = state.data.find(function(r) { return r.id == id; });
+          if (item) {
+            state.current = item;
+            state.view = 'detail';
+            state.editing = false;
+            state.creating = false;
+            state.deleting = false;
+            render();
+          }
+          break;
+        case 'toggle':
+          toggleRule(id, val === 'true');
+          break;
+        case 'toggle-detail':
+          toggleRule(id, val === 'true').then(function() {
+            if (state.current && state.current.id == id) {
+              state.current.enabled = val === 'true';
+              render();
+            }
+          });
+          break;
+        case 'back':
+          state.view = 'list';
+          state.current = null;
+          state.editing = false;
+          state.creating = false;
+          state.deleting = false;
+          render();
+          break;
+        case 'create':
+          state.view = 'detail';
+          state.current = { id: null, name: '', content: '', priority: 'medium', scope: '', enabled: true, tags: [] };
+          state.creating = true;
+          state.editing = false;
+          state.deleting = false;
+          render();
+          break;
+        case 'save-create':
+          var nameEl = el.querySelector('#rc-edit-name');
+          var prioEl = el.querySelector('#rc-edit-priority');
+          var scopeEl = el.querySelector('#rc-edit-scope');
+          var contentEl = el.querySelector('#rc-edit-content');
+          if (nameEl && nameEl.value.trim()) {
+            createRule({
+              name: nameEl.value.trim(),
+              priority: prioEl ? prioEl.value : 'medium',
+              scope: scopeEl ? scopeEl.value.trim() : '',
+              content: contentEl ? contentEl.value.trim() : '',
+              enabled: true
+            }).then(function() {
+              state.view = 'list';
+              state.creating = false;
+              render();
+            });
+          }
+          break;
+        case 'edit':
+          var editItem = state.data.find(function(r) { return r.id == id; });
+          if (editItem) {
+            state.current = editItem;
+            state.view = 'detail';
+            state.editing = true;
+            state.creating = false;
+            state.deleting = false;
+            render();
+          }
+          break;
+        case 'start-edit':
+          state.editing = true;
+          render();
+          break;
+        case 'save-edit':
+          var enEl = el.querySelector('#rc-edit-name');
+          var epEl = el.querySelector('#rc-edit-priority');
+          var esEl = el.querySelector('#rc-edit-scope');
+          var ecEl = el.querySelector('#rc-edit-content');
+          if (enEl && enEl.value.trim() && state.current) {
+            updateRule(state.current.id, {
+              name: enEl.value.trim(),
+              priority: epEl ? epEl.value : state.current.priority,
+              scope: esEl ? esEl.value.trim() : state.current.scope,
+              content: ecEl ? ecEl.value.trim() : state.current.content
+            }).then(function() {
+              state.editing = false;
+              render();
+            });
+          }
+          break;
+        case 'cancel-edit':
+          state.editing = false;
+          render();
+          break;
+        case 'cancel-create':
+          state.creating = false;
+          state.view = 'list';
+          state.current = null;
+          render();
+          break;
+        case 'confirm-delete':
+          state.deleting = true;
+          render();
+          break;
+        case 'do-delete':
+          if (state.current) {
+            deleteRule(state.current.id).then(function() { render(); });
+          }
+          break;
+        case 'cancel-delete':
+          state.deleting = false;
+          render();
+          break;
+      }
+    });
+
+    el.addEventListener('input', function(e) {
+      if (e.target.getAttribute('data-action') === 'search') {
+        state.search = e.target.value;
+        render();
+        var input = el.querySelector('[data-action="search"]');
+        if (input) { input.focus(); input.selectionStart = input.selectionEnd = input.value.length; }
+      }
+    });
+
+    el.addEventListener('click', function(e) {
+      var target = e.target.closest('[data-action="filter"]');
+      if (target) {
+        state.filter = target.getAttribute('data-val');
+        render();
+      }
+    });
+
+    /* ── Bus ── */
+    if (typeof Bus !== 'undefined') {
+      Bus.on('rules:refresh', fetchList);
+    }
+
+    /* ── Init ── */
+    fetchList();
+    fetchStats();
+    subscribeSSE();
+
+    /* ── Destroy ── */
+    return {
+      destroy: function() {
+        unsubscribeSSE();
+        if (typeof Bus !== 'undefined') {
+          Bus.off('rules:refresh', fetchList);
+        }
+        if (el.parentNode) el.parentNode.removeChild(el);
+        el.innerHTML = '';
+      },
+      resize: function(newSize) {
+        size = newSize;
+        state.view = 'list';
+        state.current = null;
+        state.editing = false;
+        state.creating = false;
+        state.deleting = false;
+        render();
+      }
+    };
+  }
+
+  /* ── Entry (small) ── */
+  function mountEntry(container, opts) {
+    return createCard(container, { size: 'small' });
+  }
+
+  /* ── Mount ── */
+  function mount(container, opts) {
+    var size = (opts && opts.size) || 'medium';
+    return createCard(container, { size: size });
+  }
+
+  /* ── Register ── */
+  if (typeof WidgetRegistry !== 'undefined') {
+    WidgetRegistry.register('rules-card', {
+      type: 'data',
+      label: '\u89C4\u5219\u5F15\u64CE',
+      icon: '\u{1F4CB}',
+      defaultSize: { w: 2, h: 1 },
+      category: 'data',
+      mount: mount
+    });
+    WidgetRegistry.register('rules-entry', {
+      type: 'entry',
+      label: '\u89C4\u5219\u5165\u53E3',
+      icon: '\u{1F4CB}',
+      defaultSize: { w: 1, h: 1 },
+      category: 'entries',
+      mount: mountEntry
+    });
+  }
+
+})();

--- a/frontend/js/workspace/widgets/cards/SessionCard.js
+++ b/frontend/js/workspace/widgets/cards/SessionCard.js
@@ -1,0 +1,1284 @@
+/**
+ * SessionCard.js
+ * 统一会话卡片 — 支持 4 种尺寸 (small/medium/large/xlarge)
+ * xlarge 模式下包含卡片内导航：会话列表 ↔ 聊天界面
+ *
+ * 依赖: WidgetRegistry, HermesClient, DataService, CardOverlay, Components, Bus
+ */
+var SessionCard = (() => {
+    'use strict';
+
+    // ========== 常量 ==========
+    var CACHE_KEY = 'sessions:list';
+    var API_SESSIONS = '/api/sessions';
+    var API_MESSAGES = '/api/sessions/{id}/messages';
+    var API_SEARCH = '/api/sessions/search';
+    var API_SEND_MSG = '/api/sessions/{id}/messages';
+    var DEBOUNCE_MS = 300;
+    var MAX_ITEMS = {
+        small: 0,
+        medium: 4,
+        large: 6,
+        xlarge: 50
+    };
+
+    // ========== 工具函数 ==========
+
+    /**
+     * 相对时间格式化
+     */
+    function formatRelativeTime(ts) {
+        if (!ts) return '';
+        var d = new Date(ts);
+        if (isNaN(d.getTime())) return '';
+        var now = new Date();
+        var diffMs = now - d;
+        var diffMin = Math.floor(diffMs / 60000);
+        if (diffMin < 1) return '刚刚';
+        if (diffMin < 60) return diffMin + '分钟前';
+        var diffHr = Math.floor(diffMin / 60);
+        if (diffHr < 24) return diffHr + '小时前';
+        var diffDay = Math.floor(diffHr / 24);
+        if (diffDay < 30) return diffDay + '天前';
+        return (d.getMonth() + 1) + '/' + d.getDate();
+    }
+
+    /**
+     * 截断字符串
+     */
+    function truncate(str, maxLen) {
+        if (!str) return '';
+        if (str.length <= maxLen) return str;
+        return str.substring(0, maxLen) + '...';
+    }
+
+    /**
+     * 判断卡片尺寸
+     */
+    function getSize(props) {
+        if (!props || !props.config) return 'medium';
+        var w = props.config.w || 2;
+        var h = props.config.h || 1;
+        if (w === 1 && h === 1) return 'small';
+        if (w === 2 && h === 1) return 'medium';
+        if (w === 2 && h === 2) return 'large';
+        return 'xlarge';
+    }
+
+    /**
+     * 获取消息数量
+     */
+    function getMsgCount(session) {
+        return session.message_count || session.messages || 0;
+    }
+
+    /**
+     * 获取会话 ID
+     */
+    function getSessionId(session) {
+        return session.id || session.session_id || '';
+    }
+
+    /**
+     * 获取会话标题
+     */
+    function getSessionTitle(session) {
+        return session.title || '未命名会话';
+    }
+
+    /**
+     * 状态文本映射
+     */
+    function statusText(status) {
+        var map = { active: '活跃', completed: '完成' };
+        return map[status] || status || '未知';
+    }
+
+    /**
+     * 状态颜色映射
+     */
+    function statusColor(status) {
+        var map = { active: 'var(--green)', completed: 'var(--text-tertiary)' };
+        return map[status] || 'var(--text-tertiary)';
+    }
+
+    /**
+     * 安全 HTML 转义
+     */
+    function esc(str) {
+        if (typeof Components !== 'undefined' && Components.escapeHtml) {
+            return Components.escapeHtml(str);
+        }
+        if (!str) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    /**
+     * 安全渲染 Markdown
+     */
+    function renderMd(text) {
+        if (typeof Components !== 'undefined' && Components.renderMarkdown) {
+            return Components.renderMarkdown(text);
+        }
+        return esc(text || '');
+    }
+
+    /**
+     * 安全格式化日期时间
+     */
+    function formatDT(ts) {
+        if (typeof Components !== 'undefined' && Components.formatDateTime) {
+            return Components.formatDateTime(ts);
+        }
+        if (!ts) return '';
+        return new Date(ts).toLocaleString('zh-CN');
+    }
+
+    /**
+     * 渲染标签徽章
+     */
+    function renderBadge(text, color) {
+        if (typeof Components !== 'undefined' && Components.renderBadge) {
+            return Components.renderBadge(text, color);
+        }
+        return '<span style="display:inline-block;padding:1px 6px;border-radius:4px;font-size:10px;background:' +
+            (color || 'var(--bg-tertiary)') + ';color:var(--text-secondary);">' + esc(text) + '</span>';
+    }
+
+    /**
+     * 创建加载占位
+     */
+    function createLoading() {
+        if (typeof Components !== 'undefined' && Components.createLoading) {
+            return Components.createLoading();
+        }
+        return '<div style="display:flex;align-items:center;justify-content:center;padding:20px;color:var(--text-tertiary);">加载中...</div>';
+    }
+
+    /**
+     * 显示 Toast 提示
+     */
+    function showToast(msg, type) {
+        if (typeof Components !== 'undefined' && Components.showToast) {
+            Components.showToast(msg, type);
+        } else {
+            console.log('[SessionCard] ' + (type || 'info') + ': ' + msg);
+        }
+    }
+
+    // ========== 样式注入 ==========
+    function _injectStyles() {
+        if (document.getElementById('sc-styles')) return;
+        var style = document.createElement('style');
+        style.id = 'sc-styles';
+        style.textContent = [
+            /* ===== 会话卡片基础 ===== */
+            '.sc-card { display:flex; flex-direction:column; height:100%; overflow:hidden; }',
+            '.sc-card__header { display:flex; align-items:center; gap:8px; padding:10px 12px; flex-shrink:0; }',
+            '.sc-card__title { font-size:var(--text-sm); font-weight:600; color:var(--text-primary); flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+            '.sc-card__count { font-size:var(--text-xs); color:var(--text-tertiary); flex-shrink:0; }',
+            '.sc-card__body { flex:1; overflow-y:auto; overflow-x:hidden; padding:0 12px 12px; }',
+            '.sc-card__body::-webkit-scrollbar { width:4px; }',
+            '.sc-card__body::-webkit-scrollbar-thumb { background:var(--border); border-radius:2px; }',
+
+            /* ===== 小尺寸 (1x1) ===== */
+            '.sc-small { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; cursor:pointer; padding:16px; text-align:center; transition:opacity .2s; }',
+            '.sc-small:hover { opacity:0.85; }',
+            '.sc-small__icon { font-size:32px; margin-bottom:6px; }',
+            '.sc-small__label { font-size:var(--text-sm); font-weight:600; color:var(--text-primary); }',
+            '.sc-small__count { font-size:var(--text-2xl); font-weight:700; color:var(--accent); margin-top:4px; }',
+            '.sc-small__unit { font-size:var(--text-xs); color:var(--text-tertiary); margin-top:2px; }',
+
+            /* ===== 会话列表项 ===== */
+            '.sc-item { display:flex; align-items:center; gap:8px; padding:8px; border-radius:var(--radius-sm); cursor:pointer; transition:background .15s; }',
+            '.sc-item:hover { background:var(--bg-secondary); }',
+            '.sc-item__info { flex:1; min-width:0; display:flex; flex-direction:column; gap:2px; }',
+            '.sc-item__title { font-size:var(--text-xs); color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+            '.sc-item__meta { display:flex; align-items:center; gap:6px; font-size:10px; color:var(--text-tertiary); }',
+            '.sc-item__badge { flex-shrink:0; }',
+            '.sc-item__tags { display:flex; gap:3px; flex-wrap:wrap; margin-top:2px; }',
+            '.sc-item__tag { font-size:9px; padding:0 4px; border-radius:3px; background:var(--bg-tertiary); color:var(--text-tertiary); }',
+            '.sc-item__status { width:6px; height:6px; border-radius:50%; flex-shrink:0; }',
+
+            /* ===== 搜索框 ===== */
+            '.sc-search { display:flex; align-items:center; gap:6px; padding:0 12px; flex-shrink:0; }',
+            '.sc-search__input { flex:1; padding:5px 10px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-xs); outline:none; transition:border-color .2s; }',
+            '.sc-search__input:focus { border-color:var(--accent); }',
+            '.sc-search__input::placeholder { color:var(--text-tertiary); }',
+
+            /* ===== 状态过滤标签 ===== */
+            '.sc-filters { display:flex; gap:4px; padding:4px 12px; flex-shrink:0; }',
+            '.sc-filter { padding:3px 10px; border-radius:var(--radius-xs); font-size:var(--text-xs); color:var(--text-secondary); background:transparent; border:none; cursor:pointer; transition:all .15s; }',
+            '.sc-filter:hover { background:var(--bg-secondary); }',
+            '.sc-filter--active { background:var(--accent); color:#fff; }',
+
+            /* ===== xlarge 列表视图 ===== */
+            '.sc-xlarge { display:flex; flex-direction:column; height:100%; }',
+            '.sc-xlarge__header { display:flex; align-items:center; gap:10px; padding:14px 16px; border-bottom:1px solid var(--border); flex-shrink:0; }',
+            '.sc-xlarge__title { font-size:var(--text-lg); font-weight:600; color:var(--text-primary); }',
+            '.sc-xlarge__search { flex:1; max-width:280px; }',
+            '.sc-xlarge__search-input { width:100%; padding:7px 12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-sm); outline:none; transition:border-color .2s; }',
+            '.sc-xlarge__search-input:focus { border-color:var(--accent); }',
+            '.sc-xlarge__search-input::placeholder { color:var(--text-tertiary); }',
+            '.sc-xlarge__filters { display:flex; gap:6px; padding:8px 16px; border-bottom:1px solid var(--border); flex-shrink:0; }',
+            '.sc-xlarge__filter { padding:5px 14px; border-radius:var(--radius-sm); font-size:var(--text-sm); color:var(--text-secondary); background:transparent; border:1px solid transparent; cursor:pointer; transition:all .15s; }',
+            '.sc-xlarge__filter:hover { background:var(--bg-secondary); }',
+            '.sc-xlarge__filter--active { background:var(--accent); color:#fff; border-color:var(--accent); }',
+            '.sc-xlarge__list { flex:1; overflow-y:auto; padding:8px 12px; }',
+            '.sc-xlarge__list::-webkit-scrollbar { width:6px; }',
+            '.sc-xlarge__list::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }',
+            '.sc-xlarge__item { display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius:var(--radius-sm); cursor:pointer; transition:background .15s; margin-bottom:2px; }',
+            '.sc-xlarge__item:hover { background:var(--bg-secondary); }',
+            '.sc-xlarge__item-info { flex:1; min-width:0; display:flex; flex-direction:column; gap:3px; }',
+            '.sc-xlarge__item-title { font-size:var(--text-sm); font-weight:500; color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+            '.sc-xlarge__item-meta { display:flex; align-items:center; gap:8px; font-size:var(--text-xs); color:var(--text-tertiary); }',
+            '.sc-xlarge__item-tags { display:flex; gap:4px; flex-wrap:wrap; }',
+            '.sc-xlarge__item-tag { font-size:10px; padding:1px 6px; border-radius:4px; background:var(--bg-tertiary); color:var(--text-tertiary); }',
+
+            /* ===== xlarge 聊天视图 ===== */
+            '.sc-chat { display:flex; flex-direction:column; height:100%; }',
+            '.sc-chat__header { display:flex; align-items:center; gap:10px; padding:12px 16px; border-bottom:1px solid var(--border); flex-shrink:0; }',
+            '.sc-chat__back { display:flex; align-items:center; justify-content:center; width:32px; height:32px; border:none; border-radius:var(--radius-sm); background:var(--bg-secondary); color:var(--text-secondary); font-size:16px; cursor:pointer; transition:background .15s; flex-shrink:0; }',
+            '.sc-chat__back:hover { background:var(--bg-tertiary); }',
+            '.sc-chat__session-info { flex:1; min-width:0; display:flex; align-items:center; gap:8px; }',
+            '.sc-chat__session-title { font-size:var(--text-sm); font-weight:600; color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+            '.sc-chat__msg-count { font-size:var(--text-xs); color:var(--text-tertiary); flex-shrink:0; }',
+
+            /* ===== 聊天消息列表 ===== */
+            '.sc-chat__messages { flex:1; overflow-y:auto; padding:16px; display:flex; flex-direction:column; gap:12px; }',
+            '.sc-chat__messages::-webkit-scrollbar { width:6px; }',
+            '.sc-chat__messages::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }',
+
+            /* ===== 消息气泡 ===== */
+            '.sc-msg { display:flex; flex-direction:column; max-width:80%; animation:scMsgFadeIn .3s ease; }',
+            '.sc-msg--user { align-self:flex-end; align-items:flex-end; }',
+            '.sc-msg--assistant { align-self:flex-start; align-items:flex-start; }',
+            '.sc-msg--system { align-self:center; align-items:center; max-width:90%; }',
+            '.sc-msg__header { display:flex; align-items:center; gap:6px; margin-bottom:4px; }',
+            '.sc-msg__role { font-size:10px; font-weight:600; color:var(--text-secondary); text-transform:uppercase; }',
+            '.sc-msg__time { font-size:10px; color:var(--text-tertiary); }',
+            '.sc-msg__bubble { padding:10px 14px; border-radius:var(--radius-sm); font-size:var(--text-sm); line-height:1.6; word-break:break-word; }',
+            '.sc-msg--user .sc-msg__bubble { background:var(--accent); color:#fff; border-bottom-right-radius:4px; }',
+            '.sc-msg--assistant .sc-msg__bubble { background:var(--bg-secondary); color:var(--text-primary); border-bottom-left-radius:4px; }',
+            '.sc-msg--system .sc-msg__bubble { background:var(--bg-tertiary); color:var(--text-tertiary); font-size:var(--text-xs); }',
+            '.sc-msg__bubble p { margin:0 0 6px; }',
+            '.sc-msg__bubble p:last-child { margin-bottom:0; }',
+            '.sc-msg__bubble code { font-family:var(--font-mono); font-size:12px; background:rgba(0,0,0,0.08); padding:1px 4px; border-radius:3px; }',
+            '.sc-msg__bubble pre { background:rgba(0,0,0,0.06); padding:8px 10px; border-radius:var(--radius-xs); overflow-x:auto; margin:6px 0; }',
+            '.sc-msg__bubble pre code { background:none; padding:0; }',
+
+            /* ===== 工具调用卡片 ===== */
+            '.sc-tool { margin:4px 0; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-secondary); overflow:hidden; }',
+            '.sc-tool__header { display:flex; align-items:center; gap:8px; padding:8px 10px; cursor:pointer; user-select:none; transition:background .15s; }',
+            '.sc-tool__header:hover { background:var(--bg-tertiary); }',
+            '.sc-tool__name { font-size:var(--text-xs); font-weight:500; color:var(--accent); }',
+            '.sc-tool__status { font-size:10px; display:flex; align-items:center; gap:3px; }',
+            '.sc-tool__status--success { color:var(--green); }',
+            '.sc-tool__status--error { color:var(--red); }',
+            '.sc-tool__duration { font-size:10px; color:var(--text-tertiary); }',
+            '.sc-tool__chevron { margin-left:auto; color:var(--text-tertiary); transition:transform .2s; font-size:12px; }',
+            '.sc-tool__chevron--open { transform:rotate(180deg); }',
+            '.sc-tool__result { display:none; padding:8px 10px; border-top:1px solid var(--border); font-size:11px; font-family:var(--font-mono); color:var(--text-secondary); max-height:200px; overflow:auto; white-space:pre-wrap; background:var(--bg); }',
+            '.sc-tool__result--open { display:block; }',
+
+            /* ===== 输入栏 ===== */
+            '.sc-chat__input-bar { display:flex; align-items:center; gap:8px; padding:12px 16px; border-top:1px solid var(--border); background:var(--bg); flex-shrink:0; }',
+            '.sc-chat__input { flex:1; padding:8px 12px; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-secondary); color:var(--text-primary); font-size:var(--text-sm); outline:none; resize:none; transition:border-color .2s; font-family:inherit; }',
+            '.sc-chat__input:focus { border-color:var(--accent); }',
+            '.sc-chat__input::placeholder { color:var(--text-tertiary); }',
+            '.sc-chat__send { padding:8px 16px; border:none; border-radius:var(--radius-sm); background:var(--accent); color:#fff; font-size:var(--text-sm); font-weight:500; cursor:pointer; transition:opacity .15s; flex-shrink:0; }',
+            '.sc-chat__send:hover { opacity:0.85; }',
+            '.sc-chat__send:disabled { opacity:0.4; cursor:not-allowed; }',
+
+            /* ===== 打字指示器 ===== */
+            '.sc-typing { display:flex; gap:4px; padding:10px 14px; align-self:flex-start; }',
+            '.sc-typing__dot { width:6px; height:6px; border-radius:50%; background:var(--text-tertiary); animation:scTypingBounce .6s infinite alternate; }',
+            '.sc-typing__dot:nth-child(2) { animation-delay:.2s; }',
+            '.sc-typing__dot:nth-child(3) { animation-delay:.4s; }',
+
+            /* ===== 空状态 ===== */
+            '.sc-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:30px 20px; color:var(--text-tertiary); text-align:center; }',
+            '.sc-empty__icon { font-size:28px; margin-bottom:8px; opacity:0.6; }',
+            '.sc-empty__text { font-size:var(--text-xs); }',
+
+            /* ===== 错误状态 ===== */
+            '.sc-error { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:20px; color:var(--red); text-align:center; gap:6px; }',
+            '.sc-error__icon { font-size:24px; }',
+            '.sc-error__text { font-size:var(--text-xs); }',
+            '.sc-error__retry { padding:4px 12px; border:1px solid var(--red); border-radius:var(--radius-xs); background:transparent; color:var(--red); font-size:var(--text-xs); cursor:pointer; margin-top:4px; }',
+
+            /* ===== 动画 ===== */
+            '@keyframes scMsgFadeIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }',
+            '@keyframes scTypingBounce { from { transform:translateY(0); } to { transform:translateY(-4px); } }'
+        ].join('\n');
+        document.head.appendChild(style);
+    }
+
+    // ========== 数据获取 ==========
+
+    /**
+     * 获取会话列表（带缓存）
+     */
+    function fetchSessions() {
+        if (typeof HermesClient !== 'undefined' && HermesClient.cachedGet) {
+            return HermesClient.cachedGet(CACHE_KEY, function () {
+                return HermesClient.get(API_SESSIONS);
+            });
+        }
+        if (typeof DataService !== 'undefined') {
+            return DataService.fetch('sessions');
+        }
+        if (typeof HermesClient !== 'undefined') {
+            return HermesClient.get(API_SESSIONS);
+        }
+        return Promise.resolve([]);
+    }
+
+    /**
+     * 搜索会话
+     */
+    function searchSessions(term) {
+        if (!term || !term.trim()) return fetchSessions();
+        if (typeof HermesClient !== 'undefined') {
+            return HermesClient.get(API_SEARCH + '?q=' + encodeURIComponent(term.trim()));
+        }
+        return Promise.resolve([]);
+    }
+
+    /**
+     * 获取会话消息
+     */
+    function fetchMessages(sessionId) {
+        if (!sessionId) return Promise.resolve([]);
+        var url = API_MESSAGES.replace('{id}', sessionId);
+        if (typeof HermesClient !== 'undefined') {
+            return HermesClient.get(url);
+        }
+        return Promise.resolve([]);
+    }
+
+    /**
+     * 发送消息
+     */
+    function sendMessage(sessionId, content) {
+        if (!sessionId || !content) return Promise.reject(new Error('缺少参数'));
+        var url = API_SEND_MSG.replace('{id}', sessionId);
+        if (typeof HermesClient !== 'undefined') {
+            return HermesClient.post(url, { content: content });
+        }
+        return Promise.reject(new Error('HermesClient 不可用'));
+    }
+
+    // ========== 渲染函数：Small (1x1) ==========
+
+    function renderSmall(container, sessions) {
+        var count = Array.isArray(sessions) ? sessions.length : 0;
+        container.innerHTML =
+            '<div class="sc-small" data-action="openOverlay">' +
+                '<div class="sc-small__icon">\u{1F4AC}</div>' +
+                '<div class="sc-small__label">会话</div>' +
+                '<div class="sc-small__count">' + count + '</div>' +
+                '<div class="sc-small__unit">个会话</div>' +
+            '</div>';
+    }
+
+    // ========== 渲染函数：Medium (2x1) ==========
+
+    function renderMedium(container, sessions) {
+        var count = Array.isArray(sessions) ? sessions.length : 0;
+        var items = (Array.isArray(sessions) ? sessions : []).slice(0, MAX_ITEMS.medium);
+        var itemsHtml = '';
+
+        if (items.length === 0) {
+            itemsHtml = '<div class="sc-empty"><div class="sc-empty__icon">\u{1F4ED}</div><div class="sc-empty__text">暂无会话</div></div>';
+        } else {
+            for (var i = 0; i < items.length; i++) {
+                var s = items[i];
+                var sid = getSessionId(s);
+                var title = truncate(getSessionTitle(s), 20);
+                var msgCount = getMsgCount(s);
+                var time = formatRelativeTime(s.updated_at || s.createdAt);
+                itemsHtml +=
+                    '<div class="sc-item" data-action="openSession" data-session-id="' + esc(sid) + '">' +
+                        '<div class="sc-item__info">' +
+                            '<div class="sc-item__title">' + esc(title) + '</div>' +
+                            '<div class="sc-item__meta">' +
+                                '<span>' + msgCount + ' 条消息</span>' +
+                                '<span>' + time + '</span>' +
+                            '</div>' +
+                        '</div>' +
+                    '</div>';
+            }
+        }
+
+        container.innerHTML =
+            '<div class="sc-card">' +
+                '<div class="sc-card__header">' +
+                    '<span>\u{1F4AC}</span>' +
+                    '<span class="sc-card__title">会话</span>' +
+                    '<span class="sc-card__count">' + count + '</span>' +
+                '</div>' +
+                '<div class="sc-card__body">' + itemsHtml + '</div>' +
+            '</div>';
+    }
+
+    // ========== 渲染函数：Large (2x2) ==========
+
+    function renderLarge(container, sessions, filter, searchTerm) {
+        var filtered = _filterSessions(sessions, filter, searchTerm);
+        var count = Array.isArray(sessions) ? sessions.length : 0;
+        var items = filtered.slice(0, MAX_ITEMS.large);
+        var itemsHtml = '';
+
+        if (items.length === 0) {
+            itemsHtml = '<div class="sc-empty"><div class="sc-empty__icon">\u{1F50D}</div><div class="sc-empty__text">' +
+                (searchTerm ? '未找到匹配的会话' : '暂无会话') + '</div></div>';
+        } else {
+            for (var i = 0; i < items.length; i++) {
+                itemsHtml += _renderListItem(items[i], false);
+            }
+        }
+
+        container.innerHTML =
+            '<div class="sc-card">' +
+                '<div class="sc-card__header">' +
+                    '<span>\u{1F4AC}</span>' +
+                    '<span class="sc-card__title">会话</span>' +
+                    '<span class="sc-card__count">' + count + '</span>' +
+                '</div>' +
+                '<div class="sc-search">' +
+                    '<input class="sc-search__input" type="text" placeholder="搜索会话..." data-action="search" value="' + esc(searchTerm || '') + '">' +
+                '</div>' +
+                '<div class="sc-filters">' +
+                    '<button class="sc-filter' + (filter === 'all' ? ' sc-filter--active' : '') + '" data-action="setFilter" data-filter="all">全部</button>' +
+                    '<button class="sc-filter' + (filter === 'active' ? ' sc-filter--active' : '') + '" data-action="setFilter" data-filter="active">活跃</button>' +
+                    '<button class="sc-filter' + (filter === 'completed' ? ' sc-filter--active' : '') + '" data-action="setFilter" data-filter="completed">完成</button>' +
+                '</div>' +
+                '<div class="sc-card__body">' + itemsHtml + '</div>' +
+            '</div>';
+    }
+
+    // ========== 渲染函数：XLarge (全屏 Overlay) ==========
+
+    /**
+     * 渲染 xlarge 列表视图
+     */
+    function renderXlargeList(container, sessions, filter, searchTerm) {
+        var filtered = _filterSessions(sessions, filter, searchTerm);
+        var items = filtered.slice(0, MAX_ITEMS.xlarge);
+        var itemsHtml = '';
+
+        if (items.length === 0) {
+            itemsHtml = '<div class="sc-empty" style="padding:60px 20px;"><div class="sc-empty__icon">\u{1F50D}</div><div class="sc-empty__text">' +
+                (searchTerm ? '未找到匹配的会话' : '暂无会话') + '</div></div>';
+        } else {
+            for (var i = 0; i < items.length; i++) {
+                itemsHtml += _renderListItem(items[i], true);
+            }
+        }
+
+        container.innerHTML =
+            '<div class="sc-xlarge">' +
+                '<div class="sc-xlarge__header">' +
+                    '<span style="font-size:20px;">\u{1F4AC}</span>' +
+                    '<span class="sc-xlarge__title">会话</span>' +
+                    '<div class="sc-xlarge__search">' +
+                        '<input class="sc-xlarge__search-input" type="text" placeholder="搜索会话..." data-action="search" value="' + esc(searchTerm || '') + '">' +
+                    '</div>' +
+                '</div>' +
+                '<div class="sc-xlarge__filters">' +
+                    '<button class="sc-xlarge__filter' + (filter === 'all' ? ' sc-xlarge__filter--active' : '') + '" data-action="setFilter" data-filter="all">全部</button>' +
+                    '<button class="sc-xlarge__filter' + (filter === 'active' ? ' sc-xlarge__filter--active' : '') + '" data-action="setFilter" data-filter="active">活跃</button>' +
+                    '<button class="sc-xlarge__filter' + (filter === 'completed' ? ' sc-xlarge__filter--active' : '') + '" data-action="setFilter" data-filter="completed">完成</button>' +
+                '</div>' +
+                '<div class="sc-xlarge__list">' + itemsHtml + '</div>' +
+            '</div>';
+    }
+
+    /**
+     * 渲染 xlarge 聊天视图
+     */
+    function renderXlargeChat(container, session, messages, isTyping) {
+        var sessionTitle = getSessionTitle(session);
+        var model = session.model || '';
+        var msgCount = messages ? messages.length : 0;
+        var messagesHtml = '';
+
+        if (!messages || messages.length === 0) {
+            messagesHtml = '<div class="sc-empty"><div class="sc-empty__icon">\u{1F4AC}</div><div class="sc-empty__text">暂无消息</div></div>';
+        } else {
+            for (var i = 0; i < messages.length; i++) {
+                messagesHtml += _renderMessage(messages[i]);
+            }
+        }
+
+        // 打字指示器
+        if (isTyping) {
+            messagesHtml +=
+                '<div class="sc-msg sc-msg--assistant">' +
+                    '<div class="sc-msg__header"><span class="sc-msg__role">助手</span></div>' +
+                    '<div class="sc-typing">' +
+                        '<span class="sc-typing__dot"></span>' +
+                        '<span class="sc-typing__dot"></span>' +
+                        '<span class="sc-typing__dot"></span>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        container.innerHTML =
+            '<div class="sc-chat">' +
+                '<div class="sc-chat__header">' +
+                    '<button class="sc-chat__back" data-action="backToList" title="返回">\u2190</button>' +
+                    '<div class="sc-chat__session-info">' +
+                        '<span class="sc-chat__session-title">' + esc(sessionTitle) + '</span>' +
+                        (model ? renderBadge(model, 'blue') : '') +
+                    '</div>' +
+                    '<span class="sc-chat__msg-count">' + msgCount + ' 条消息</span>' +
+                '</div>' +
+                '<div class="sc-chat__messages" data-action="messageList">' + messagesHtml + '</div>' +
+                '<div class="sc-chat__input-bar">' +
+                    '<input class="sc-chat__input" type="text" placeholder="输入消息... (Enter 发送, Shift+Enter 换行)" data-action="chatInput">' +
+                    '<button class="sc-chat__send" data-action="sendMessage">发送</button>' +
+                '</div>' +
+            '</div>';
+
+        // 自动滚动到底部
+        _scrollToBottom(container);
+    }
+
+    // ========== 列表项渲染 ==========
+
+    function _renderListItem(session, isXlarge) {
+        var sid = getSessionId(session);
+        var title = getSessionTitle(session);
+        var msgCount = getMsgCount(session);
+        var time = formatRelativeTime(session.updated_at || session.createdAt);
+        var model = session.model || '';
+        var status = session.status || '';
+        var tags = session.tags || [];
+        var prefix = isXlarge ? 'sc-xlarge__item' : 'sc-item';
+        var subPrefix = isXlarge ? 'sc-xlarge__item' : 'sc-item';
+
+        // 标签 HTML
+        var tagsHtml = '';
+        if (tags.length > 0 && isXlarge) {
+            tagsHtml = '<div class="' + subPrefix + '-tags">';
+            for (var t = 0; t < Math.min(tags.length, 3); t++) {
+                tagsHtml += '<span class="' + subPrefix + '-tag">' + esc(tags[t]) + '</span>';
+            }
+            if (tags.length > 3) {
+                tagsHtml += '<span class="' + subPrefix + '-tag">+' + (tags.length - 3) + '</span>';
+            }
+            tagsHtml += '</div>';
+        }
+
+        // 状态指示点
+        var statusDot = '';
+        if (status) {
+            statusDot = '<span class="' + subPrefix + '__status" style="background:' + statusColor(status) + ';" title="' + statusText(status) + '"></span>';
+        }
+
+        return '<div class="' + prefix + '" data-action="openSession" data-session-id="' + esc(sid) + '">' +
+            statusDot +
+            '<div class="' + subPrefix + '-info">' +
+                '<div class="' + subPrefix + '-title">' + esc(title) + '</div>' +
+                '<div class="' + subPrefix + '-meta">' +
+                    (model ? '<span class="' + subPrefix + '__badge">' + renderBadge(model, 'blue') + '</span>' : '') +
+                    '<span>' + msgCount + ' 条消息</span>' +
+                    '<span>' + time + '</span>' +
+                '</div>' +
+                tagsHtml +
+            '</div>' +
+        '</div>';
+    }
+
+    // ========== 消息渲染 ==========
+
+    function _renderMessage(msg) {
+        if (!msg) return '';
+        var role = msg.role || 'user';
+        var content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content || '');
+        var ts = msg.timestamp || '';
+        var roleMap = { user: '用户', assistant: '助手', system: '系统' };
+        var roleLabel = roleMap[role] || role;
+
+        var html = '<div class="sc-msg sc-msg--' + role + '">' +
+            '<div class="sc-msg__header">' +
+                '<span class="sc-msg__role">' + roleLabel + '</span>' +
+                (ts ? '<span class="sc-msg__time">' + formatDT(ts) + '</span>' : '') +
+            '</div>' +
+            '<div class="sc-msg__bubble">' + renderMd(content) + '</div>';
+
+        // 工具调用卡片
+        if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+            for (var i = 0; i < msg.tool_calls.length; i++) {
+                html += _renderToolCall(msg.tool_calls[i], i);
+            }
+        }
+
+        html += '</div>';
+        return html;
+    }
+
+    /**
+     * 渲染工具调用卡片
+     */
+    function _renderToolCall(tool, index) {
+        if (!tool) return '';
+        var name = tool.name || '工具调用';
+        var status = tool.status || 'unknown';
+        var duration = tool.duration || 0;
+        var result = tool.result || '';
+        var isSuccess = status === 'success' || status === 'completed';
+        var statusClass = isSuccess ? 'sc-tool__status--success' : 'sc-tool__status--error';
+        var statusLabel = isSuccess ? '成功' : '失败';
+        var durationText = duration > 0 ? duration + 'ms' : '';
+        var resultStr = typeof result === 'string' ? result : JSON.stringify(result || {}, null, 2);
+
+        return '<div class="sc-tool" data-action="toggleTool" data-tool-index="' + index + '">' +
+            '<div class="sc-tool__header">' +
+                '<span style="color:var(--accent);">\u26A1</span>' +
+                '<span class="sc-tool__name">' + esc(name) + '</span>' +
+                '<span class="sc-tool__status ' + statusClass + '">\u2713 ' + statusLabel + '</span>' +
+                (durationText ? '<span class="sc-tool__duration">' + durationText + '</span>' : '') +
+                '<span class="sc-tool__chevron">\u25BC</span>' +
+            '</div>' +
+            '<div class="sc-tool__result">' + esc(resultStr) + '</div>' +
+        '</div>';
+    }
+
+    // ========== 过滤逻辑 ==========
+
+    function _filterSessions(sessions, filter, searchTerm) {
+        var list = Array.isArray(sessions) ? sessions : [];
+
+        // 状态过滤
+        if (filter && filter !== 'all') {
+            list = list.filter(function (s) { return s.status === filter; });
+        }
+
+        // 搜索过滤
+        if (searchTerm && searchTerm.trim()) {
+            var term = searchTerm.trim().toLowerCase();
+            list = list.filter(function (s) {
+                var title = (s.title || '').toLowerCase();
+                var model = (s.model || '').toLowerCase();
+                var tags = (s.tags || []).join(' ').toLowerCase();
+                return title.indexOf(term) !== -1 || model.indexOf(term) !== -1 || tags.indexOf(term) !== -1;
+            });
+        }
+
+        return list;
+    }
+
+    // ========== 滚动控制 ==========
+
+    function _scrollToBottom(container) {
+        requestAnimationFrame(function () {
+            var msgList = container.querySelector('[data-action="messageList"]');
+            if (msgList) {
+                msgList.scrollTop = msgList.scrollHeight;
+            }
+        });
+    }
+
+    function _isScrolledUp(container) {
+        var msgList = container.querySelector('[data-action="messageList"]');
+        if (!msgList) return false;
+        var threshold = 60;
+        return (msgList.scrollHeight - msgList.scrollTop - msgList.clientHeight) > threshold;
+    }
+
+    // ========== 主挂载函数 ==========
+
+    async function mount(container, props) {
+        var cardId = props.cardId;
+        var desktopId = props.desktopId;
+        var config = props.config || {};
+        var size = getSize(props);
+
+        // 注入样式
+        _injectStyles();
+
+        // 内部状态
+        var state = {
+            sessions: [],
+            filter: 'all',
+            searchTerm: '',
+            // xlarge 聊天状态
+            currentSession: null,
+            messages: [],
+            isTyping: false,
+            viewState: 'list', // 'list' | 'chat'
+            userScrolledUp: false,
+            // 事件处理
+            handlers: [],
+            searchTimer: null
+        };
+
+        // 显示加载
+        container.innerHTML = createLoading();
+
+        // 获取数据
+        try {
+            state.sessions = await fetchSessions();
+        } catch (err) {
+            console.error('[SessionCard] 获取会话列表失败:', err);
+            container.innerHTML =
+                '<div class="sc-error">' +
+                    '<div class="sc-error__icon">\u26A0\uFE0F</div>' +
+                    '<div class="sc-error__text">加载失败</div>' +
+                    '<button class="sc-error__retry" data-action="retry">重试</button>' +
+                '</div>';
+            _bindEvents(container, state, size);
+            return _buildLifecycle(state, container, size);
+        }
+
+        // 渲染
+        _render(container, state, size);
+
+        // 绑定事件
+        _bindEvents(container, state, size);
+
+        // SSE 事件订阅
+        _subscribeSSE(state, container, size);
+
+        return _buildLifecycle(state, container, size);
+    }
+
+    // ========== 渲染分发 ==========
+
+    function _render(container, state, size) {
+        switch (size) {
+            case 'small':
+                renderSmall(container, state.sessions);
+                break;
+            case 'medium':
+                renderMedium(container, state.sessions);
+                break;
+            case 'large':
+                renderLarge(container, state.sessions, state.filter, state.searchTerm);
+                break;
+            case 'xlarge':
+                if (state.viewState === 'chat' && state.currentSession) {
+                    renderXlargeChat(container, state.currentSession, state.messages, state.isTyping);
+                } else {
+                    renderXlargeList(container, state.sessions, state.filter, state.searchTerm);
+                }
+                break;
+        }
+    }
+
+    // ========== 事件绑定 ==========
+
+    function _bindEvents(container, state, size) {
+        // 事件委托
+        function handleClick(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+
+            var action = target.getAttribute('data-action');
+
+            switch (action) {
+                case 'openOverlay':
+                    _handleOpenOverlay();
+                    break;
+                case 'openSession':
+                    _handleOpenSession(target, state, size);
+                    break;
+                case 'setFilter':
+                    _handleSetFilter(target, state, container, size);
+                    break;
+                case 'search':
+                    // 搜索框获取焦点，由 input 事件处理
+                    break;
+                case 'backToList':
+                    _handleBackToList(state, container, size);
+                    break;
+                case 'sendMessage':
+                    _handleSendMessage(state, container, size);
+                    break;
+                case 'toggleTool':
+                    _handleToggleTool(target);
+                    break;
+                case 'retry':
+                    _handleRetry(container, state, size);
+                    break;
+            }
+        }
+
+        function handleInput(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+            var action = target.getAttribute('data-action');
+
+            if (action === 'search') {
+                _handleSearch(target, state, container, size);
+            }
+        }
+
+        function handleKeyDown(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+            var action = target.getAttribute('data-action');
+
+            if (action === 'chatInput') {
+                // Enter 发送，Shift+Enter 换行
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    _handleSendMessage(state, container, size);
+                }
+            }
+        }
+
+        // 聊天消息列表滚动检测
+        function handleScroll(e) {
+            var msgList = container.querySelector('[data-action="messageList"]');
+            if (e.target === msgList) {
+                state.userScrolledUp = _isScrolledUp(container);
+            }
+        }
+
+        container.addEventListener('click', handleClick);
+        container.addEventListener('input', handleInput);
+        container.addEventListener('keydown', handleKeyDown);
+        container.addEventListener('scroll', handleScroll, true);
+
+        // 保存引用以便清理
+        state.handlers.push(
+            { el: container, type: 'click', fn: handleClick },
+            { el: container, type: 'input', fn: handleInput },
+            { el: container, type: 'keydown', fn: handleKeyDown },
+            { el: container, type: 'scroll', fn: handleScroll, capture: true }
+        );
+    }
+
+    // ========== SSE 订阅 ==========
+
+    function _subscribeSSE(state, container, size) {
+        if (typeof Bus === 'undefined') return;
+
+        // 新消息事件
+        function onNewMessage(data) {
+            // 如果当前正在查看该会话的聊天
+            if (state.viewState === 'chat' && state.currentSession) {
+                var msgSessionId = data.session_id || data.sessionId || '';
+                if (msgSessionId === getSessionId(state.currentSession)) {
+                    // 追加新消息
+                    if (data.message) {
+                        state.messages.push(data.message);
+                        if (!state.userScrolledUp) {
+                            _render(container, state, size);
+                        }
+                    }
+                }
+            }
+            // 刷新列表数据
+            fetchSessions().then(function (sessions) {
+                state.sessions = sessions;
+                if (state.viewState === 'list') {
+                    _render(container, state, size);
+                }
+            }).catch(function () {});
+        }
+
+        // 会话创建事件
+        function onSessionCreated() {
+            fetchSessions().then(function (sessions) {
+                state.sessions = sessions;
+                _render(container, state, size);
+            }).catch(function () {});
+        }
+
+        // 会话更新事件
+        function onSessionUpdated(data) {
+            // 如果正在查看该会话，更新标题等信息
+            if (state.viewState === 'chat' && state.currentSession) {
+                var updatedId = data.session_id || data.sessionId || data.id || '';
+                if (updatedId === getSessionId(state.currentSession)) {
+                    if (data.title) state.currentSession.title = data.title;
+                    if (data.status) state.currentSession.status = data.status;
+                }
+            }
+            fetchSessions().then(function (sessions) {
+                state.sessions = sessions;
+                if (state.viewState === 'list') {
+                    _render(container, state, size);
+                }
+            }).catch(function () {});
+        }
+
+        Bus.on('sse:session.message', onNewMessage);
+        Bus.on('sse:session.created', onSessionCreated);
+        Bus.on('sse:session.updated', onSessionUpdated);
+
+        // 保存引用以便清理
+        state._sseHandlers = {
+            'sse:session.message': onNewMessage,
+            'sse:session.created': onSessionCreated,
+            'sse:session.updated': onSessionUpdated
+        };
+    }
+
+    // ========== 事件处理函数 ==========
+
+    /**
+     * 打开 Overlay（small 尺寸点击）
+     */
+    function _handleOpenOverlay() {
+        if (typeof CardOverlay !== 'undefined') {
+            CardOverlay.open('session-card');
+        }
+    }
+
+    /**
+     * 打开会话详情
+     */
+    function _handleOpenSession(target, state, size) {
+        var sessionId = target.getAttribute('data-session-id');
+        if (!sessionId) return;
+
+        if (size === 'xlarge') {
+            // xlarge 模式：卡片内导航到聊天视图
+            _openChatView(state, sessionId);
+        } else {
+            // 其他尺寸：打开 Overlay
+            if (typeof CardOverlay !== 'undefined') {
+                CardOverlay.open('session-card', { sessionId: sessionId });
+            }
+        }
+    }
+
+    /**
+     * 在 xlarge 模式下打开聊天视图
+     */
+    async function _openChatView(state, sessionId) {
+        // 查找会话
+        var session = null;
+        for (var i = 0; i < state.sessions.length; i++) {
+            if (getSessionId(state.sessions[i]) === sessionId) {
+                session = state.sessions[i];
+                break;
+            }
+        }
+        if (!session) return;
+
+        state.currentSession = session;
+        state.messages = [];
+        state.isTyping = false;
+        state.viewState = 'chat';
+        state.userScrolledUp = false;
+
+        // 获取消息
+        try {
+            state.messages = await fetchMessages(sessionId);
+        } catch (err) {
+            console.error('[SessionCard] 获取消息失败:', err);
+            state.messages = [];
+        }
+
+        // 重新渲染（由外部调用 _render）
+        // 这里通过刷新回调来触发
+        if (state._refreshFn) {
+            state._refreshFn();
+        }
+    }
+
+    /**
+     * 返回列表视图
+     */
+    function _handleBackToList(state, container, size) {
+        state.currentSession = null;
+        state.messages = [];
+        state.isTyping = false;
+        state.viewState = 'list';
+        _render(container, state, size);
+    }
+
+    /**
+     * 设置过滤条件
+     */
+    function _handleSetFilter(target, state, container, size) {
+        var filter = target.getAttribute('data-filter');
+        if (!filter) return;
+        state.filter = filter;
+        _render(container, state, size);
+    }
+
+    /**
+     * 搜索处理（带防抖）
+     */
+    function _handleSearch(target, state, container, size) {
+        var term = target.value || '';
+
+        // 清除之前的定时器
+        if (state.searchTimer) {
+            clearTimeout(state.searchTimer);
+        }
+
+        // 防抖
+        state.searchTimer = setTimeout(function () {
+            state.searchTerm = term;
+            _render(container, state, size);
+
+            // 如果有搜索词，调用搜索 API
+            if (term.trim()) {
+                searchSessions(term).then(function (results) {
+                    if (Array.isArray(results)) {
+                        state.sessions = results;
+                        _render(container, state, size);
+                    }
+                }).catch(function () {});
+            } else {
+                // 清空搜索时恢复完整列表
+                fetchSessions().then(function (sessions) {
+                    state.sessions = sessions;
+                    _render(container, state, size);
+                }).catch(function () {});
+            }
+        }, DEBOUNCE_MS);
+    }
+
+    /**
+     * 发送消息
+     */
+    function _handleSendMessage(state, container, size) {
+        var input = container.querySelector('[data-action="chatInput"]');
+        if (!input) return;
+
+        var content = (input.value || '').trim();
+        if (!content || !state.currentSession) return;
+
+        var sessionId = getSessionId(state.currentSession);
+
+        // 立即清空输入框并追加用户消息到界面
+        input.value = '';
+
+        var userMsg = {
+            id: 'temp-' + Date.now(),
+            role: 'user',
+            content: content,
+            timestamp: new Date().toISOString()
+        };
+        state.messages.push(userMsg);
+        state.isTyping = true;
+        state.userScrolledUp = false;
+        _render(container, state, size);
+
+        // 发送请求
+        sendMessage(sessionId, content).then(function () {
+            state.isTyping = false;
+            // 重新获取消息列表以确保同步
+            return fetchMessages(sessionId);
+        }).then(function (msgs) {
+            if (Array.isArray(msgs)) {
+                state.messages = msgs;
+            }
+            _render(container, state, size);
+        }).catch(function (err) {
+            console.error('[SessionCard] 发送消息失败:', err);
+            state.isTyping = false;
+            _render(container, state, size);
+            showToast('发送失败: ' + (err.message || '未知错误'), 'error');
+        });
+    }
+
+    /**
+     * 切换工具调用卡片展开/折叠
+     */
+    function _handleToggleTool(target) {
+        var toolEl = target.closest('.sc-tool');
+        if (!toolEl) return;
+
+        var result = toolEl.querySelector('.sc-tool__result');
+        var chevron = toolEl.querySelector('.sc-tool__chevron');
+        if (!result) return;
+
+        var isOpen = result.classList.contains('sc-tool__result--open');
+        if (isOpen) {
+            result.classList.remove('sc-tool__result--open');
+            if (chevron) chevron.classList.remove('sc-tool__chevron--open');
+        } else {
+            result.classList.add('sc-tool__result--open');
+            if (chevron) chevron.classList.add('sc-tool__chevron--open');
+        }
+    }
+
+    /**
+     * 重试加载
+     */
+    async function _handleRetry(container, state, size) {
+        container.innerHTML = createLoading();
+        try {
+            state.sessions = await fetchSessions();
+            _render(container, state, size);
+            _bindEvents(container, state, size);
+        } catch (err) {
+            container.innerHTML =
+                '<div class="sc-error">' +
+                    '<div class="sc-error__icon">\u26A0\uFE0F</div>' +
+                    '<div class="sc-error__text">加载失败，请重试</div>' +
+                    '<button class="sc-error__retry" data-action="retry">重试</button>' +
+                '</div>';
+        }
+    }
+
+    // ========== 生命周期构建 ==========
+
+    function _buildLifecycle(state, container, size) {
+        // 保存刷新回调
+        state._refreshFn = function () {
+            _render(container, state, size);
+        };
+
+        return {
+            /**
+             * 销毁卡片，清理所有资源
+             */
+            destroy: function () {
+                // 移除 DOM 事件
+                for (var i = 0; i < state.handlers.length; i++) {
+                    var h = state.handlers[i];
+                    if (h.el) {
+                        h.el.removeEventListener(h.type, h.fn, h.capture || false);
+                    }
+                }
+                state.handlers = [];
+
+                // 清除搜索定时器
+                if (state.searchTimer) {
+                    clearTimeout(state.searchTimer);
+                    state.searchTimer = null;
+                }
+
+                // 移除 SSE 事件监听
+                if (state._sseHandlers && typeof Bus !== 'undefined') {
+                    var events = Object.keys(state._sseHandlers);
+                    for (var j = 0; j < events.length; j++) {
+                        Bus.off(events[j], state._sseHandlers[events[j]]);
+                    }
+                    state._sseHandlers = null;
+                }
+
+                // 清空容器
+                container.innerHTML = '';
+
+                // 重置状态
+                state.sessions = [];
+                state.currentSession = null;
+                state.messages = [];
+                state.isTyping = false;
+                state.viewState = 'list';
+                state._refreshFn = null;
+            },
+
+            /**
+             * 刷新卡片数据
+             */
+            refresh: async function () {
+                try {
+                    state.sessions = await fetchSessions();
+                    _render(container, state, size);
+
+                    // 如果在聊天视图，也刷新消息
+                    if (state.viewState === 'chat' && state.currentSession) {
+                        var sid = getSessionId(state.currentSession);
+                        state.messages = await fetchMessages(sid);
+                        _render(container, state, size);
+                    }
+                } catch (err) {
+                    console.error('[SessionCard] 刷新失败:', err);
+                }
+            }
+        };
+    }
+
+    // ========== 入口卡片挂载函数 ==========
+
+    async function mountEntry(container, props) {
+        _injectStyles();
+
+        var entryState = { sessions: [], handlers: [] };
+
+        container.innerHTML = createLoading();
+
+        try {
+            entryState.sessions = await fetchSessions();
+        } catch (err) {
+            entryState.sessions = [];
+        }
+
+        renderSmall(container, entryState.sessions);
+
+        function handleClick(e) {
+            var target = e.target.closest('[data-action]');
+            if (!target) return;
+            if (target.getAttribute('data-action') === 'openOverlay') {
+                if (typeof CardOverlay !== 'undefined') {
+                    CardOverlay.open('session-card');
+                }
+            }
+        }
+
+        container.addEventListener('click', handleClick);
+        entryState.handlers.push({ el: container, type: 'click', fn: handleClick });
+
+        return {
+            destroy: function () {
+                for (var i = 0; i < entryState.handlers.length; i++) {
+                    var h = entryState.handlers[i];
+                    h.el.removeEventListener(h.type, h.fn);
+                }
+                entryState.handlers = [];
+                container.innerHTML = '';
+            },
+            refresh: async function () {
+                try {
+                    entryState.sessions = await fetchSessions();
+                    renderSmall(container, entryState.sessions);
+                } catch (err) {
+                    console.error('[SessionCard] 入口刷新失败:', err);
+                }
+            }
+        };
+    }
+
+    // ========== 注册 Widget ==========
+
+    if (typeof WidgetRegistry !== 'undefined') {
+        WidgetRegistry.register('session-card', {
+            type: 'data',
+            label: '会话',
+            icon: '\u{1F4AC}',
+            description: '会话管理，支持查看会话列表和聊天记录',
+            defaultSize: { w: 2, h: 1 },
+            category: 'data',
+            mount: mount
+        });
+
+        WidgetRegistry.register('session-entry', {
+            type: 'entry',
+            label: '会话入口',
+            icon: '\u{1F4AC}',
+            description: '会话快速入口',
+            defaultSize: { w: 1, h: 1 },
+            category: 'entries',
+            mount: mountEntry
+        });
+    }
+
+    // ========== 公开 API ==========
+    return {
+        mount: mount,
+        mountEntry: mountEntry,
+        renderSmall: renderSmall,
+        renderMedium: renderMedium,
+        renderLarge: renderLarge,
+        renderXlargeList: renderXlargeList,
+        renderXlargeChat: renderXlargeChat
+    };
+})();

--- a/frontend/js/workspace/widgets/cards/SettingsCard.js
+++ b/frontend/js/workspace/widgets/cards/SettingsCard.js
@@ -1,0 +1,502 @@
+;(function() {
+  'use strict';
+
+  /* ========== CSS ========== */
+  var STYLE_ID = 'hermes-settings-card-css';
+  var PFX = 'stc';
+
+  function injectCSS() {
+    if (document.getElementById(STYLE_ID)) return;
+    var s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = [
+      '.' + PFX + '-root { width:100%; height:100%; display:flex; flex-direction:column; font-family:inherit; color:var(--text-primary,#e0e0e0); background:var(--card-bg,#1e1e2e); border-radius:12px; overflow:hidden; }',
+      '.' + PFX + '-header { display:flex; align-items:center; justify-content:space-between; padding:10px 14px; background:var(--card-header-bg,#2a2a3e); border-bottom:1px solid var(--border,#333); flex-shrink:0; }',
+      '.' + PFX + '-header-title { font-size:14px; font-weight:600; display:flex; align-items:center; gap:6px; }',
+      '.' + PFX + '-header-title span.icon { font-size:16px; }',
+      '.' + PFX + '-body { flex:1; overflow-y:auto; padding:12px; }',
+      '.' + PFX + '-body::-webkit-scrollbar { width:4px; }',
+      '.' + PFX + '-body::-webkit-scrollbar-thumb { background:var(--scrollbar,#555); border-radius:2px; }',
+
+      /* Small */
+      '.' + PFX + '-small { display:flex; flex-direction:column; align-items:center; justify-content:center; cursor:pointer; gap:6px; transition:background .2s; }',
+      '.' + PFX + '-small:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-small-icon { font-size:28px; }',
+      '.' + PFX + '-small-label { font-size:12px; color:var(--text-secondary,#aaa); }',
+
+      /* Medium quick items */
+      '.' + PFX + '-quick-list { display:flex; flex-direction:column; gap:8px; }',
+      '.' + PFX + '-quick-item { display:flex; align-items:center; justify-content:space-between; padding:8px 10px; background:var(--item-bg,#252538); border-radius:8px; font-size:12px; }',
+      '.' + PFX + '-quick-item-label { color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-quick-item-value { color:var(--text-primary,#e0e0e0); font-weight:500; max-width:120px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+
+      /* Large sections */
+      '.' + PFX + '-section { margin-bottom:12px; }',
+      '.' + PFX + '-section-title { font-size:12px; font-weight:600; color:var(--text-secondary,#aaa); margin-bottom:6px; text-transform:uppercase; letter-spacing:.5px; }',
+      '.' + PFX + '-section-body { display:flex; flex-direction:column; gap:4px; }',
+      '.' + PFX + '-config-row { display:flex; align-items:center; justify-content:space-between; padding:5px 8px; background:var(--item-bg,#252538); border-radius:6px; font-size:11px; }',
+      '.' + PFX + '-config-key { color:var(--text-secondary,#aaa); flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+      '.' + PFX + '-config-val { color:var(--text-primary,#e0e0e0); font-weight:500; max-width:100px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+
+      /* xlarge tabs */
+      '.' + PFX + '-tabs { display:flex; border-bottom:1px solid var(--border,#333); flex-shrink:0; }',
+      '.' + PFX + '-tab { flex:1; padding:10px; text-align:center; font-size:13px; font-weight:500; cursor:pointer; color:var(--text-secondary,#aaa); border-bottom:2px solid transparent; transition:all .2s; }',
+      '.' + PFX + '-tab:hover { color:var(--text-primary,#e0e0e0); background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-tab.active { color:var(--accent,#7c6ff7); border-bottom-color:var(--accent,#7c6ff7); }',
+      '.' + PFX + '-tab-content { display:none; flex:1; overflow-y:auto; padding:12px; }',
+      '.' + PFX + '-tab-content.active { display:block; }',
+
+      /* Config form */
+      '.' + PFX + '-form-group { margin-bottom:10px; }',
+      '.' + PFX + '-form-label { display:block; font-size:11px; color:var(--text-secondary,#aaa); margin-bottom:4px; }',
+      '.' + PFX + '-form-input { width:100%; padding:7px 10px; background:var(--input-bg,#1a1a2e); border:1px solid var(--border,#333); border-radius:6px; color:var(--text-primary,#e0e0e0); font-size:12px; outline:none; box-sizing:border-box; }',
+      '.' + PFX + '-form-input:focus { border-color:var(--accent,#7c6ff7); }',
+      '.' + PFX + '-form-select { width:100%; padding:7px 10px; background:var(--input-bg,#1a1a2e); border:1px solid var(--border,#333); border-radius:6px; color:var(--text-primary,#e0e0e0); font-size:12px; outline:none; box-sizing:border-box; cursor:pointer; }',
+      '.' + PFX + '-form-select:focus { border-color:var(--accent,#7c6ff7); }',
+      '.' + PFX + '-btn { padding:7px 16px; border:none; border-radius:6px; font-size:12px; font-weight:500; cursor:pointer; transition:all .2s; }',
+      '.' + PFX + '-btn-primary { background:var(--accent,#7c6ff7); color:#fff; }',
+      '.' + PFX + '-btn-primary:hover { filter:brightness(1.15); }',
+      '.' + PFX + '-btn-danger { background:#e74c3c; color:#fff; }',
+      '.' + PFX + '-btn-danger:hover { filter:brightness(1.15); }',
+      '.' + PFX + '-btn-secondary { background:var(--item-bg,#252538); color:var(--text-primary,#e0e0e0); }',
+      '.' + PFX + '-btn-secondary:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-btn-row { display:flex; gap:8px; margin-top:12px; }',
+
+      /* Backup list */
+      '.' + PFX + '-backup-list { display:flex; flex-direction:column; gap:6px; }',
+      '.' + PFX + '-backup-item { display:flex; align-items:center; justify-content:space-between; padding:8px 10px; background:var(--item-bg,#252538); border-radius:8px; font-size:12px; }',
+      '.' + PFX + '-backup-info { display:flex; flex-direction:column; gap:2px; }',
+      '.' + PFX + '-backup-name { font-weight:500; }',
+      '.' + PFX + '-backup-meta { font-size:10px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-backup-actions { display:flex; gap:4px; }',
+      '.' + PFX + '-btn-sm { padding:4px 10px; font-size:11px; }',
+
+      /* Confirm bar */
+      '.' + PFX + '-confirm-bar { display:flex; align-items:center; gap:8px; padding:8px 10px; background:rgba(231,76,60,.15); border:1px solid rgba(231,76,60,.3); border-radius:6px; margin-top:6px; font-size:11px; color:#e74c3c; }',
+      '.' + PFX + '-confirm-bar span { flex:1; }',
+
+      /* States */
+      '.' + PFX + '-loading, .' + PFX + '-error, .' + PFX + '-empty { display:flex; align-items:center; justify-content:center; flex:1; font-size:13px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-error { color:#e74c3c; }',
+      '.' + PFX + '-spinner { width:20px; height:20px; border:2px solid var(--border,#333); border-top-color:var(--accent,#7c6ff7); border-radius:50%; animation:' + PFX + '-spin .6s linear infinite; margin-right:8px; }',
+      '@keyframes ' + PFX + '-spin { to { transform:rotate(360deg); } }'
+    ].join('\n');
+    document.head.appendChild(s);
+  }
+
+  /* ========== Helpers ========== */
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $$(sel, ctx) { return Array.prototype.slice.call((ctx || document).querySelectorAll(sel)); }
+  function el(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html !== undefined) e.innerHTML = html;
+    return e;
+  }
+  function formatTime(ts) {
+    var d = new Date(ts);
+    return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0') + ' ' + String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0');
+  }
+
+  /* ========== Card Component ========== */
+  function SettingsCard(container, opts) {
+    this.container = container;
+    this.opts = opts || {};
+    this.size = this.opts.size || 'medium';
+    this.config = {};
+    this.backups = [];
+    this.activeTab = 'config';
+    this.confirmRestore = null;
+    this.loading = false;
+    this.error = null;
+    this._subs = [];
+    this._bound = {};
+    injectCSS();
+    this.render();
+    this._bindEvents();
+    this.fetchConfig();
+  }
+
+  SettingsCard.prototype._bindEvents = function() {
+    var self = this;
+    this._bound._delegate = function(e) {
+      var t = e.target.closest('[data-action]');
+      if (!t) return;
+      var action = t.getAttribute('data-action');
+      var id = t.getAttribute('data-id') || '';
+      self._handleAction(action, id, e);
+    };
+    this.container.addEventListener('click', this._bound._delegate);
+  };
+
+  SettingsCard.prototype._handleAction = function(action, id) {
+    switch (action) {
+      case 'open-overlay':
+        CardOverlay.open('settings-card', { w: 2, h: 2 });
+        break;
+      case 'switch-tab':
+        this.activeTab = id;
+        this.render();
+        if (id === 'backup') this.fetchBackups();
+        break;
+      case 'save-config':
+        this.saveConfig();
+        break;
+      case 'create-backup':
+        this.createBackup();
+        break;
+      case 'confirm-restore':
+        this.confirmRestore = id;
+        this.render();
+        break;
+      case 'do-restore':
+        this.restoreBackup(this.confirmRestore);
+        this.confirmRestore = null;
+        break;
+      case 'cancel-restore':
+        this.confirmRestore = null;
+        this.render();
+        break;
+    }
+  };
+
+  /* ========== Data ========== */
+  SettingsCard.prototype.fetchConfig = function() {
+    var self = this;
+    this.loading = true;
+    this.error = null;
+    this.render();
+    HermesClient.get('/api/config').then(function(data) {
+      self.config = data || {};
+      self.loading = false;
+      self.render();
+    }).catch(function(err) {
+      self.error = err.message || '加载配置失败';
+      self.loading = false;
+      self.render();
+    });
+  };
+
+  SettingsCard.prototype.saveConfig = function() {
+    var self = this;
+    var inputs = $$('.stc-form-input, .stc-form-select', this.container);
+    var payload = {};
+    inputs.forEach(function(inp) {
+      var key = inp.getAttribute('data-key');
+      if (key) payload[key] = inp.value;
+    });
+    HermesClient.put('/api/config', payload).then(function() {
+      Bus.emit('notification', { type: 'success', message: '配置已保存' });
+      self.fetchConfig();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '保存失败: ' + (err.message || '') });
+    });
+  };
+
+  SettingsCard.prototype.fetchBackups = function() {
+    var self = this;
+    HermesClient.get('/api/system/backup').then(function(data) {
+      self.backups = data || [];
+      self.render();
+    }).catch(function(err) {
+      self.backups = [];
+      self.render();
+    });
+  };
+
+  SettingsCard.prototype.createBackup = function() {
+    var self = this;
+    HermesClient.post('/api/system/backup').then(function() {
+      Bus.emit('notification', { type: 'success', message: '备份已创建' });
+      self.fetchBackups();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '创建备份失败: ' + (err.message || '') });
+    });
+  };
+
+  SettingsCard.prototype.restoreBackup = function(id) {
+    var self = this;
+    HermesClient.post('/api/system/restore', { backup_id: id }).then(function() {
+      Bus.emit('notification', { type: 'success', message: '已恢复备份' });
+      self.fetchConfig();
+      self.fetchBackups();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '恢复失败: ' + (err.message || '') });
+    });
+  };
+
+  /* ========== Render ========== */
+  SettingsCard.prototype.render = function() {
+    var c = this.container;
+    c.innerHTML = '';
+    var root = el('div', PFX + '-root');
+    root.appendChild(this._renderHeader());
+    if (this.loading) {
+      root.appendChild(el('div', PFX + '-loading', '<div class="' + PFX + '-spinner"></div>加载中...'));
+    } else if (this.error) {
+      root.appendChild(el('div', PFX + '-error', this.error));
+    } else {
+      var body = this._renderBody();
+      if (body) root.appendChild(body);
+    }
+    c.appendChild(root);
+  };
+
+  SettingsCard.prototype._renderHeader = function() {
+    var h = el('div', PFX + '-header');
+    h.innerHTML = '<div class="' + PFX + '-header-title"><span class="icon">\u2699\uFE0F</span>系统设置</div>';
+    return h;
+  };
+
+  SettingsCard.prototype._renderBody = function() {
+    switch (this.size) {
+      case 'small': return this._renderSmall();
+      case 'medium': return this._renderMedium();
+      case 'large': return this._renderLarge();
+      case 'xlarge': return this._renderXLarge();
+      default: return this._renderMedium();
+    }
+  };
+
+  SettingsCard.prototype._renderSmall = function() {
+    var body = el('div', PFX + '-body ' + PFX + '-small');
+    body.setAttribute('data-action', 'open-overlay');
+    body.innerHTML = '<div class="' + PFX + '-small-icon">\u2699\uFE0F</div><div class="' + PFX + '-small-label">设置</div>';
+    return body;
+  };
+
+  SettingsCard.prototype._renderMedium = function() {
+    var body = el('div', PFX + '-body');
+    var list = el('div', PFX + '-quick-list');
+    var items = [
+      { label: '版本', value: this.config.version || 'N/A' },
+      { label: '主题', value: this.config.theme || '默认' },
+      { label: '语言', value: this.config.language || '中文' }
+    ];
+    items.forEach(function(item) {
+      var row = el('div', PFX + '-quick-item');
+      row.innerHTML = '<span class="' + PFX + '-quick-item-label">' + item.label + '</span><span class="' + PFX + '-quick-item-value">' + item.value + '</span>';
+      list.appendChild(row);
+    });
+    body.appendChild(list);
+    return body;
+  };
+
+  SettingsCard.prototype._renderLarge = function() {
+    var body = el('div', PFX + '-body');
+    var self = this;
+
+    /* General section */
+    var sec1 = el('div', PFX + '-section');
+    sec1.innerHTML = '<div class="' + PFX + '-section-title">通用</div>';
+    var sb1 = el('div', PFX + '-section-body');
+    var generalKeys = ['version', 'language', 'timezone', 'debug_mode'];
+    generalKeys.forEach(function(k) {
+      var row = el('div', PFX + '-config-row');
+      row.innerHTML = '<span class="' + PFX + '-config-key">' + k + '</span><span class="' + PFX + '-config-val">' + (self.config[k] != null ? self.config[k] : '-') + '</span>';
+      sb1.appendChild(row);
+    });
+    sec1.appendChild(sb1);
+    body.appendChild(sec1);
+
+    /* Theme section */
+    var sec2 = el('div', PFX + '-section');
+    sec2.innerHTML = '<div class="' + PFX + '-section-title">主题</div>';
+    var sb2 = el('div', PFX + '-section-body');
+    var themeKeys = ['theme', 'primary_color', 'font_size'];
+    themeKeys.forEach(function(k) {
+      var row = el('div', PFX + '-config-row');
+      row.innerHTML = '<span class="' + PFX + '-config-key">' + k + '</span><span class="' + PFX + '-config-val">' + (self.config[k] != null ? self.config[k] : '-') + '</span>';
+      sb2.appendChild(row);
+    });
+    sec2.appendChild(sb2);
+    body.appendChild(sec2);
+
+    /* Backup section */
+    var sec3 = el('div', PFX + '-section');
+    sec3.innerHTML = '<div class="' + PFX + '-section-title">备份</div>';
+    var sb3 = el('div', PFX + '-section-body');
+    sb3.innerHTML = '<div class="' + PFX + '-config-row"><span class="' + PFX + '-config-key">备份数量</span><span class="' + PFX + '-config-val">' + this.backups.length + '</span></div>';
+    sec3.appendChild(sb3);
+    body.appendChild(sec3);
+
+    return body;
+  };
+
+  SettingsCard.prototype._renderXLarge = function() {
+    var root = el('div', '');
+    var self = this;
+
+    /* Tabs */
+    var tabs = el('div', PFX + '-tabs');
+    var tabItems = [
+      { id: 'config', label: '系统配置' },
+      { id: 'backup', label: '备份恢复' }
+    ];
+    tabItems.forEach(function(t) {
+      var tab = el('div', PFX + '-tab' + (self.activeTab === t.id ? ' active' : ''));
+      tab.setAttribute('data-action', 'switch-tab');
+      tab.setAttribute('data-id', t.id);
+      tab.textContent = t.label;
+      tabs.appendChild(tab);
+    });
+    root.appendChild(tabs);
+
+    /* Config tab */
+    var configTab = el('div', PFX + '-tab-content' + (this.activeTab === 'config' ? ' active' : ''));
+    configTab.appendChild(this._renderConfigForm());
+    root.appendChild(configTab);
+
+    /* Backup tab */
+    var backupTab = el('div', PFX + '-tab-content' + (this.activeTab === 'backup' ? ' active' : ''));
+    backupTab.appendChild(this._renderBackupPanel());
+    root.appendChild(backupTab);
+
+    return root;
+  };
+
+  SettingsCard.prototype._renderConfigForm = function() {
+    var wrap = el('div', '');
+    var self = this;
+    var keys = Object.keys(this.config);
+    if (keys.length === 0) {
+      wrap.innerHTML = '<div class="' + PFX + '-empty">暂无配置项</div>';
+      return wrap;
+    }
+    keys.forEach(function(k) {
+      var group = el('div', PFX + '-form-group');
+      group.innerHTML = '<label class="' + PFX + '-form-label">' + k + '</label>';
+      var val = self.config[k];
+      if (typeof val === 'boolean') {
+        var sel = el('select', PFX + '-form-select');
+        sel.setAttribute('data-key', k);
+        sel.innerHTML = '<option value="true"' + (val ? ' selected' : '') + '>true</option><option value="false"' + (!val ? ' selected' : '') + '>false</option>';
+        group.appendChild(sel);
+      } else if (typeof val === 'number') {
+        var inp = el('input', PFX + '-form-input');
+        inp.type = 'number';
+        inp.setAttribute('data-key', k);
+        inp.value = val;
+        group.appendChild(inp);
+      } else {
+        var inp2 = el('input', PFX + '-form-input');
+        inp2.type = 'text';
+        inp2.setAttribute('data-key', k);
+        inp2.value = val != null ? String(val) : '';
+        group.appendChild(inp2);
+      }
+      wrap.appendChild(group);
+    });
+    var btnRow = el('div', PFX + '-btn-row');
+    var saveBtn = el('button', PFX + '-btn ' + PFX + '-btn-primary');
+    saveBtn.setAttribute('data-action', 'save-config');
+    saveBtn.textContent = '保存配置';
+    btnRow.appendChild(saveBtn);
+    wrap.appendChild(btnRow);
+    return wrap;
+  };
+
+  SettingsCard.prototype._renderBackupPanel = function() {
+    var wrap = el('div', '');
+    var self = this;
+
+    /* Create backup button */
+    var btnRow = el('div', PFX + '-btn-row');
+    var createBtn = el('button', PFX + '-btn ' + PFX + '-btn-primary');
+    createBtn.setAttribute('data-action', 'create-backup');
+    createBtn.textContent = '创建备份';
+    btnRow.appendChild(createBtn);
+    wrap.appendChild(btnRow);
+
+    /* Backup list */
+    if (this.backups.length === 0) {
+      wrap.appendChild(el('div', PFX + '-empty', '暂无备份'));
+      return wrap;
+    }
+    var list = el('div', PFX + '-backup-list');
+    this.backups.forEach(function(b) {
+      var item = el('div', PFX + '-backup-item');
+      var info = el('div', PFX + '-backup-info');
+      info.innerHTML = '<div class="' + PFX + '-backup-name">' + (b.name || b.filename || '备份') + '</div><div class="' + PFX + '-backup-meta">' + (b.created_at ? formatTime(b.created_at) : '') + (b.size ? ' | ' + b.size : '') + '</div>';
+      var actions = el('div', PFX + '-backup-actions');
+      var restoreBtn = el('button', PFX + '-btn ' + PFX + '-btn-secondary ' + PFX + '-btn-sm');
+      restoreBtn.setAttribute('data-action', 'confirm-restore');
+      restoreBtn.setAttribute('data-id', b.id || b.filename);
+      restoreBtn.textContent = '恢复';
+      actions.appendChild(restoreBtn);
+      item.appendChild(info);
+      item.appendChild(actions);
+
+      /* Confirm bar */
+      if (self.confirmRestore === (b.id || b.filename)) {
+        var cbar = el('div', PFX + '-confirm-bar');
+        cbar.innerHTML = '<span>确定要恢复此备份吗？当前配置将被覆盖。</span>';
+        var yesBtn = el('button', PFX + '-btn ' + PFX + '-btn-danger ' + PFX + '-btn-sm');
+        yesBtn.setAttribute('data-action', 'do-restore');
+        yesBtn.textContent = '确定';
+        var noBtn = el('button', PFX + '-btn ' + PFX + '-btn-secondary ' + PFX + '-btn-sm');
+        noBtn.setAttribute('data-action', 'cancel-restore');
+        noBtn.textContent = '取消';
+        cbar.appendChild(yesBtn);
+        cbar.appendChild(noBtn);
+        item.appendChild(cbar);
+      }
+
+      list.appendChild(item);
+    });
+    wrap.appendChild(list);
+    return wrap;
+  };
+
+  /* ========== SSE ========== */
+  SettingsCard.prototype.subscribe = function() {
+    var self = this;
+    if (typeof DataService !== 'undefined' && DataService.subscribe) {
+      var sub = DataService.subscribe('config:updated', function() {
+        self.fetchConfig();
+      });
+      this._subs.push(sub);
+    }
+  };
+
+  /* ========== Destroy ========== */
+  SettingsCard.prototype.destroy = function() {
+    this.container.removeEventListener('click', this._bound._delegate);
+    this._subs.forEach(function(s) { if (s && s.unsubscribe) s.unsubscribe(); });
+    this._subs = [];
+    this.container.innerHTML = '';
+  };
+
+  /* ========== Mount ========== */
+  function mount(container, opts) {
+    var card = new SettingsCard(container, opts);
+    card.subscribe();
+    return card;
+  }
+
+  function mountEntry(container, opts) {
+    var card = new SettingsCard(container, Object.assign({}, opts, { size: 'small' }));
+    return card;
+  }
+
+  /* ========== Register ========== */
+  if (typeof WidgetRegistry !== 'undefined') {
+    WidgetRegistry.register('settings-card', {
+      type: 'function',
+      label: '系统设置',
+      icon: '\u2699\uFE0F',
+      defaultSize: { w: 2, h: 1 },
+      category: 'functions',
+      mount: mount
+    });
+    WidgetRegistry.register('settings-entry', {
+      type: 'entry',
+      label: '设置入口',
+      icon: '\u2699\uFE0F',
+      defaultSize: { w: 1, h: 1 },
+      category: 'entries',
+      mount: mountEntry
+    });
+  }
+
+})();

--- a/frontend/js/workspace/widgets/cards/TrashCard.js
+++ b/frontend/js/workspace/widgets/cards/TrashCard.js
@@ -1,0 +1,510 @@
+;(function() {
+  'use strict';
+
+  /* ========== CSS ========== */
+  var STYLE_ID = 'hermes-trash-card-css';
+  var PFX = 'tc';
+
+  function injectCSS() {
+    if (document.getElementById(STYLE_ID)) return;
+    var s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = [
+      '.' + PFX + '-root { width:100%; height:100%; display:flex; flex-direction:column; font-family:inherit; color:var(--text-primary,#e0e0e0); background:var(--card-bg,#1e1e2e); border-radius:12px; overflow:hidden; }',
+      '.' + PFX + '-header { display:flex; align-items:center; justify-content:space-between; padding:10px 14px; background:var(--card-header-bg,#2a2a3e); border-bottom:1px solid var(--border,#333); flex-shrink:0; }',
+      '.' + PFX + '-header-title { font-size:14px; font-weight:600; display:flex; align-items:center; gap:6px; }',
+      '.' + PFX + '-header-title span.icon { font-size:16px; }',
+      '.' + PFX + '-header-actions { display:flex; gap:6px; }',
+      '.' + PFX + '-body { flex:1; overflow-y:auto; padding:12px; }',
+      '.' + PFX + '-body::-webkit-scrollbar { width:4px; }',
+      '.' + PFX + '-body::-webkit-scrollbar-thumb { background:var(--scrollbar,#555); border-radius:2px; }',
+
+      /* Small */
+      '.' + PFX + '-small { display:flex; flex-direction:column; align-items:center; justify-content:center; cursor:pointer; gap:6px; transition:background .2s; position:relative; }',
+      '.' + PFX + '-small:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-small-icon { font-size:28px; }',
+      '.' + PFX + '-small-label { font-size:12px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-badge { position:absolute; top:6px; right:6px; background:var(--accent,#7c6ff7); color:#fff; font-size:10px; font-weight:700; min-width:18px; height:18px; border-radius:9px; display:flex; align-items:center; justify-content:center; padding:0 5px; }',
+
+      /* Type badge */
+      '.' + PFX + '-type-badge { display:inline-flex; align-items:center; gap:3px; padding:2px 8px; border-radius:4px; font-size:10px; font-weight:600; flex-shrink:0; }',
+      '.' + PFX + '-type-knowledge { background:rgba(52,152,219,.2); color:#3498db; }',
+      '.' + PFX + '-type-rule { background:rgba(155,89,182,.2); color:#9b59b6; }',
+      '.' + PFX + '-type-experience { background:rgba(46,204,113,.2); color:#2ecc71; }',
+      '.' + PFX + '-type-skill { background:rgba(243,156,18,.2); color:#f39c12; }',
+      '.' + PFX + '-type-memory { background:rgba(231,76,60,.2); color:#e74c3c; }',
+
+      /* Type icons map */
+      '.' + PFX + '-type-icon { font-size:11px; }',
+
+      /* Trash item */
+      '.' + PFX + '-trash-item { display:flex; align-items:center; gap:8px; padding:8px 10px; background:var(--item-bg,#252538); border-radius:8px; margin-bottom:6px; font-size:12px; transition:background .2s; }',
+      '.' + PFX + '-trash-item:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-trash-info { flex:1; min-width:0; display:flex; flex-direction:column; gap:2px; }',
+      '.' + PFX + '-trash-name { font-weight:500; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }',
+      '.' + PFX + '-trash-meta { font-size:10px; color:var(--text-secondary,#888); }',
+      '.' + PFX + '-trash-actions { display:flex; gap:4px; flex-shrink:0; }',
+
+      /* Buttons */
+      '.' + PFX + '-btn { padding:5px 12px; border:none; border-radius:6px; font-size:11px; font-weight:500; cursor:pointer; transition:all .2s; }',
+      '.' + PFX + '-btn-primary { background:var(--accent,#7c6ff7); color:#fff; }',
+      '.' + PFX + '-btn-primary:hover { filter:brightness(1.15); }',
+      '.' + PFX + '-btn-danger { background:#e74c3c; color:#fff; }',
+      '.' + PFX + '-btn-danger:hover { filter:brightness(1.15); }',
+      '.' + PFX + '-btn-secondary { background:var(--item-bg,#252538); color:var(--text-primary,#e0e0e0); }',
+      '.' + PFX + '-btn-secondary:hover { background:var(--card-hover,#2a2a3e); }',
+      '.' + PFX + '-btn-sm { padding:3px 8px; font-size:10px; }',
+      '.' + PFX + '-btn-warning { background:rgba(243,156,18,.15); color:#f39c12; border:1px solid rgba(243,156,18,.3); }',
+      '.' + PFX + '-btn-warning:hover { background:rgba(243,156,18,.25); }',
+
+      /* Filters */
+      '.' + PFX + '-filters { display:flex; gap:4px; padding:8px 12px; flex-shrink:0; flex-wrap:wrap; }',
+      '.' + PFX + '-filter-btn { padding:3px 10px; border:1px solid var(--border,#333); border-radius:12px; background:transparent; color:var(--text-secondary,#aaa); font-size:10px; cursor:pointer; transition:all .2s; }',
+      '.' + PFX + '-filter-btn:hover { border-color:var(--accent,#7c6ff7); color:var(--text-primary,#e0e0e0); }',
+      '.' + PFX + '-filter-btn.active { background:var(--accent,#7c6ff7); border-color:var(--accent,#7c6ff7); color:#fff; }',
+
+      /* Confirm bar */
+      '.' + PFX + '-confirm-bar { display:flex; align-items:center; gap:8px; padding:8px 10px; border-radius:6px; margin-top:6px; font-size:11px; }',
+      '.' + PFX + '-confirm-bar span { flex:1; }',
+      '.' + PFX + '-confirm-restore { background:rgba(46,204,113,.1); border:1px solid rgba(46,204,113,.3); color:#2ecc71; }',
+      '.' + PFX + '-confirm-delete { background:rgba(231,76,60,.1); border:1px solid rgba(231,76,60,.3); color:#e74c3c; }',
+      '.' + PFX + '-confirm-empty { background:rgba(243,156,18,.1); border:1px solid rgba(243,156,18,.3); color:#f39c12; margin:8px 12px; }',
+
+      /* States */
+      '.' + PFX + '-loading, .' + PFX + '-error, .' + PFX + '-empty { display:flex; align-items:center; justify-content:center; flex:1; font-size:13px; color:var(--text-secondary,#aaa); }',
+      '.' + PFX + '-error { color:#e74c3c; }',
+      '.' + PFX + '-spinner { width:20px; height:20px; border:2px solid var(--border,#333); border-top-color:var(--accent,#7c6ff7); border-radius:50%; animation:' + PFX + '-spin .6s linear infinite; margin-right:8px; }',
+      '@keyframes ' + PFX + '-spin { to { transform:rotate(360deg); } }'
+    ].join('\n');
+    document.head.appendChild(s);
+  }
+
+  /* ========== Helpers ========== */
+  function $(sel, ctx) { return (ctx || document).querySelector(sel); }
+  function $$(sel, ctx) { return Array.prototype.slice.call((ctx || document).querySelectorAll(sel)); }
+  function el(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html !== undefined) e.innerHTML = html;
+    return e;
+  }
+
+  var TYPE_MAP = {
+    knowledge: { label: '知识', icon: '\uD83D\uDCDA', cls: 'knowledge' },
+    rule:      { label: '规则', icon: '\uD83D\uDCDC', cls: 'rule' },
+    experience:{ label: '经验', icon: '\uD83D\uDCAA', cls: 'experience' },
+    skill:     { label: '技能', icon: '\u26A1', cls: 'skill' },
+    memory:    { label: '记忆', icon: '\uD83D\uDCBE', cls: 'memory' }
+  };
+
+  function getTypeInfo(type) {
+    return TYPE_MAP[type] || { label: type || '未知', icon: '\u2753', cls: '' };
+  }
+
+  function formatTime(ts) {
+    if (!ts) return '';
+    var d = new Date(ts);
+    return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0') + ' ' + String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0');
+  }
+
+  /* ========== Card Component ========== */
+  function TrashCard(container, opts) {
+    this.container = container;
+    this.opts = opts || {};
+    this.size = this.opts.size || 'medium';
+    this.items = [];
+    this.typeFilter = 'all';
+    this.confirmRestore = null;
+    this.confirmDelete = null;
+    this.confirmEmpty = false;
+    this.loading = false;
+    this.error = null;
+    this._subs = [];
+    this._bound = {};
+    injectCSS();
+    this.render();
+    this._bindEvents();
+    this.fetchItems();
+  }
+
+  TrashCard.prototype._bindEvents = function() {
+    var self = this;
+    this._bound._delegate = function(e) {
+      var t = e.target.closest('[data-action]');
+      if (!t) return;
+      var action = t.getAttribute('data-action');
+      var id = t.getAttribute('data-id') || '';
+      self._handleAction(action, id, e);
+    };
+    this.container.addEventListener('click', this._bound._delegate);
+  };
+
+  TrashCard.prototype._handleAction = function(action, id) {
+    switch (action) {
+      case 'open-overlay':
+        CardOverlay.open('trash-card', { w: 2, h: 2 });
+        break;
+      case 'filter-type':
+        this.typeFilter = id;
+        this.confirmRestore = null;
+        this.confirmDelete = null;
+        this.render();
+        break;
+      case 'confirm-restore':
+        this.confirmRestore = id;
+        this.confirmDelete = null;
+        this.render();
+        break;
+      case 'do-restore':
+        this.restoreItem(this.confirmRestore);
+        this.confirmRestore = null;
+        break;
+      case 'cancel-restore':
+        this.confirmRestore = null;
+        this.render();
+        break;
+      case 'confirm-delete':
+        this.confirmDelete = id;
+        this.confirmRestore = null;
+        this.render();
+        break;
+      case 'do-delete':
+        this.permanentDelete(this.confirmDelete);
+        this.confirmDelete = null;
+        break;
+      case 'cancel-delete':
+        this.confirmDelete = null;
+        this.render();
+        break;
+      case 'confirm-empty':
+        this.confirmEmpty = true;
+        this.render();
+        break;
+      case 'do-empty':
+        this.emptyTrash();
+        this.confirmEmpty = false;
+        break;
+      case 'cancel-empty':
+        this.confirmEmpty = false;
+        this.render();
+        break;
+    }
+  };
+
+  /* ========== Data ========== */
+  TrashCard.prototype.fetchItems = function() {
+    var self = this;
+    this.loading = true;
+    this.error = null;
+    this.render();
+    HermesClient.get('/api/trash').then(function(data) {
+      self.items = Array.isArray(data) ? data : (data.items || []);
+      self.loading = false;
+      self.render();
+    }).catch(function(err) {
+      self.error = err.message || '加载回收站失败';
+      self.loading = false;
+      self.render();
+    });
+  };
+
+  TrashCard.prototype.restoreItem = function(id) {
+    var self = this;
+    HermesClient.post('/api/trash/' + id + '/restore').then(function() {
+      Bus.emit('notification', { type: 'success', message: '已恢复' });
+      self.fetchItems();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '恢复失败: ' + (err.message || '') });
+    });
+  };
+
+  TrashCard.prototype.permanentDelete = function(id) {
+    var self = this;
+    HermesClient.delete('/api/trash/' + id).then(function() {
+      Bus.emit('notification', { type: 'success', message: '已永久删除' });
+      self.fetchItems();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '删除失败: ' + (err.message || '') });
+    });
+  };
+
+  TrashCard.prototype.emptyTrash = function() {
+    var self = this;
+    HermesClient.delete('/api/trash').then(function() {
+      Bus.emit('notification', { type: 'success', message: '回收站已清空' });
+      self.items = [];
+      self.render();
+    }).catch(function(err) {
+      Bus.emit('notification', { type: 'error', message: '清空失败: ' + (err.message || '') });
+    });
+  };
+
+  TrashCard.prototype._getFilteredItems = function() {
+    var self = this;
+    if (this.typeFilter === 'all') return this.items;
+    return this.items.filter(function(item) { return item.type === self.typeFilter; });
+  };
+
+  /* ========== Render ========== */
+  TrashCard.prototype.render = function() {
+    var c = this.container;
+    c.innerHTML = '';
+    var root = el('div', PFX + '-root');
+    root.appendChild(this._renderHeader());
+    if (this.loading) {
+      root.appendChild(el('div', PFX + '-loading', '<div class="' + PFX + '-spinner"></div>加载中...'));
+    } else if (this.error) {
+      root.appendChild(el('div', PFX + '-error', this.error));
+    } else {
+      var body = this._renderBody();
+      if (body) root.appendChild(body);
+    }
+    c.appendChild(root);
+  };
+
+  TrashCard.prototype._renderHeader = function() {
+    var h = el('div', PFX + '-header');
+    h.innerHTML = '<div class="' + PFX + '-header-title"><span class="icon">\uD83D\uDDD1\uFE0F</span>回收站</div>';
+    return h;
+  };
+
+  TrashCard.prototype._renderBody = function() {
+    switch (this.size) {
+      case 'small': return this._renderSmall();
+      case 'medium': return this._renderMedium();
+      case 'large': return this._renderLarge();
+      case 'xlarge': return this._renderXLarge();
+      default: return this._renderMedium();
+    }
+  };
+
+  TrashCard.prototype._renderSmall = function() {
+    var body = el('div', PFX + '-body ' + PFX + '-small');
+    body.setAttribute('data-action', 'open-overlay');
+    body.style.position = 'relative';
+    var count = this.items.length;
+    var badgeHtml = count > 0 ? '<div class="' + PFX + '-badge">' + count + '</div>' : '';
+    body.innerHTML = '<div class="' + PFX + '-small-icon">\uD83D\uDDD1\uFE0F</div><div class="' + PFX + '-small-label">回收站</div>' + badgeHtml;
+    return body;
+  };
+
+  TrashCard.prototype._renderMedium = function() {
+    var body = el('div', PFX + '-body');
+    var items = this.items.slice(0, 5);
+    if (items.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '回收站为空'));
+      return body;
+    }
+    var self = this;
+    items.forEach(function(item) {
+      var info = getTypeInfo(item.type);
+      var row = el('div', PFX + '-trash-item');
+      row.innerHTML =
+        '<span class="' + PFX + '-type-badge ' + PFX + '-type-' + info.cls + '"><span class="' + PFX + '-type-icon">' + info.icon + '</span>' + info.label + '</span>' +
+        '<div class="' + PFX + '-trash-info"><div class="' + PFX + '-trash-name">' + (item.name || '未命名') + '</div><div class="' + PFX + '-trash-meta">' + formatTime(item.deleted_at) + '</div></div>';
+      body.appendChild(row);
+    });
+    return body;
+  };
+
+  TrashCard.prototype._renderLarge = function() {
+    var self = this;
+    var root = el('div', '');
+
+    /* Type filter */
+    var filters = el('div', PFX + '-filters');
+    var types = [
+      { id: 'all', label: '全部' },
+      { id: 'knowledge', label: '知识' },
+      { id: 'rule', label: '规则' },
+      { id: 'experience', label: '经验' },
+      { id: 'skill', label: '技能' },
+      { id: 'memory', label: '记忆' }
+    ];
+    types.forEach(function(t) {
+      var btn = el('button', PFX + '-filter-btn' + (self.typeFilter === t.id ? ' active' : ''));
+      btn.setAttribute('data-action', 'filter-type');
+      btn.setAttribute('data-id', t.id);
+      btn.textContent = t.label;
+      filters.appendChild(btn);
+    });
+    root.appendChild(filters);
+
+    /* Trash list */
+    var body = el('div', PFX + '-body');
+    var items = this._getFilteredItems();
+    if (items.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '回收站为空'));
+    } else {
+      items.forEach(function(item) {
+        var info = getTypeInfo(item.type);
+        var row = el('div', PFX + '-trash-item');
+        row.innerHTML =
+          '<span class="' + PFX + '-type-badge ' + PFX + '-type-' + info.cls + '"><span class="' + PFX + '-type-icon">' + info.icon + '</span>' + info.label + '</span>' +
+          '<div class="' + PFX + '-trash-info"><div class="' + PFX + '-trash-name">' + (item.name || '未命名') + '</div><div class="' + PFX + '-trash-meta">' + formatTime(item.deleted_at) + '</div></div>' +
+          '<div class="' + PFX + '-trash-actions">' +
+            '<button class="' + PFX + '-btn ' + PFX + '-btn-primary ' + PFX + '-btn-sm" data-action="confirm-restore" data-id="' + item.id + '">恢复</button>' +
+            '<button class="' + PFX + '-btn ' + PFX + '-btn-danger ' + PFX + '-btn-sm" data-action="confirm-delete" data-id="' + item.id + '">删除</button>' +
+          '</div>';
+        body.appendChild(row);
+      });
+    }
+    root.appendChild(body);
+    return root;
+  };
+
+  TrashCard.prototype._renderXLarge = function() {
+    var self = this;
+    var root = el('div', '');
+    root.style.display = 'flex';
+    root.style.flexDirection = 'column';
+    root.style.flex = '1';
+
+    /* Header with empty button */
+    var header = el('div', PFX + '-header');
+    header.innerHTML = '<div class="' + PFX + '-header-title"><span class="icon">\uD83D\uDDD1\uFE0F</span>回收站</div><div class="' + PFX + '-header-actions"><button class="' + PFX + '-btn ' + PFX + '-btn-warning" data-action="confirm-empty">清空回收站</button></div>';
+    root.appendChild(header);
+
+    /* Confirm empty bar */
+    if (this.confirmEmpty) {
+      var emptyBar = el('div', PFX + '-confirm-bar ' + PFX + '-confirm-empty');
+      emptyBar.innerHTML = '<span>确定要清空回收站吗？所有项目将被永久删除，此操作不可撤销。</span>';
+      var yesBtn = el('button', PFX + '-btn ' + PFX + '-btn-danger ' + PFX + '-btn-sm');
+      yesBtn.setAttribute('data-action', 'do-empty');
+      yesBtn.textContent = '确定清空';
+      var noBtn = el('button', PFX + '-btn ' + PFX + '-btn-secondary ' + PFX + '-btn-sm');
+      noBtn.setAttribute('data-action', 'cancel-empty');
+      noBtn.textContent = '取消';
+      emptyBar.appendChild(yesBtn);
+      emptyBar.appendChild(noBtn);
+      root.appendChild(emptyBar);
+    }
+
+    /* Type filter */
+    var filters = el('div', PFX + '-filters');
+    var types = [
+      { id: 'all', label: '全部' },
+      { id: 'knowledge', label: '知识' },
+      { id: 'rule', label: '规则' },
+      { id: 'experience', label: '经验' },
+      { id: 'skill', label: '技能' },
+      { id: 'memory', label: '记忆' }
+    ];
+    types.forEach(function(t) {
+      var btn = el('button', PFX + '-filter-btn' + (self.typeFilter === t.id ? ' active' : ''));
+      btn.setAttribute('data-action', 'filter-type');
+      btn.setAttribute('data-id', t.id);
+      btn.textContent = t.label;
+      filters.appendChild(btn);
+    });
+    root.appendChild(filters);
+
+    /* Trash list */
+    var body = el('div', PFX + '-body');
+    var items = this._getFilteredItems();
+    if (items.length === 0) {
+      body.appendChild(el('div', PFX + '-empty', '回收站为空'));
+    } else {
+      items.forEach(function(item) {
+        var info = getTypeInfo(item.type);
+        var row = el('div', PFX + '-trash-item');
+
+        /* Main row */
+        row.innerHTML =
+          '<span class="' + PFX + '-type-badge ' + PFX + '-type-' + info.cls + '"><span class="' + PFX + '-type-icon">' + info.icon + '</span>' + info.label + '</span>' +
+          '<div class="' + PFX + '-trash-info"><div class="' + PFX + '-trash-name">' + (item.name || '未命名') + '</div><div class="' + PFX + '-trash-meta">删除于 ' + formatTime(item.deleted_at) + '</div></div>' +
+          '<div class="' + PFX + '-trash-actions">' +
+            '<button class="' + PFX + '-btn ' + PFX + '-btn-primary ' + PFX + '-btn-sm" data-action="confirm-restore" data-id="' + item.id + '">恢复</button>' +
+            '<button class="' + PFX + '-btn ' + PFX + '-btn-danger ' + PFX + '-btn-sm" data-action="confirm-delete" data-id="' + item.id + '">永久删除</button>' +
+          '</div>';
+
+        /* Restore confirm bar */
+        if (self.confirmRestore === item.id) {
+          var cbar = el('div', PFX + '-confirm-bar ' + PFX + '-confirm-restore');
+          cbar.innerHTML = '<span>确定要恢复此项目吗？</span>';
+          var yesR = el('button', PFX + '-btn ' + PFX + '-btn-primary ' + PFX + '-btn-sm');
+          yesR.setAttribute('data-action', 'do-restore');
+          yesR.textContent = '确定恢复';
+          var noR = el('button', PFX + '-btn ' + PFX + '-btn-secondary ' + PFX + '-btn-sm');
+          noR.setAttribute('data-action', 'cancel-restore');
+          noR.textContent = '取消';
+          cbar.appendChild(yesR);
+          cbar.appendChild(noR);
+          row.appendChild(cbar);
+        }
+
+        /* Delete confirm bar */
+        if (self.confirmDelete === item.id) {
+          var dbar = el('div', PFX + '-confirm-bar ' + PFX + '-confirm-delete');
+          dbar.innerHTML = '<span>确定要永久删除此项目吗？此操作不可撤销！</span>';
+          var yesD = el('button', PFX + '-btn ' + PFX + '-btn-danger ' + PFX + '-btn-sm');
+          yesD.setAttribute('data-action', 'do-delete');
+          yesD.textContent = '确定删除';
+          var noD = el('button', PFX + '-btn ' + PFX + '-btn-secondary ' + PFX + '-btn-sm');
+          noD.setAttribute('data-action', 'cancel-delete');
+          noD.textContent = '取消';
+          dbar.appendChild(yesD);
+          dbar.appendChild(noD);
+          row.appendChild(dbar);
+        }
+
+        body.appendChild(row);
+      });
+    }
+    root.appendChild(body);
+    return root;
+  };
+
+  /* ========== SSE ========== */
+  TrashCard.prototype.subscribe = function() {
+    var self = this;
+    if (typeof DataService !== 'undefined' && DataService.subscribe) {
+      var sub = DataService.subscribe('trash:updated', function() {
+        self.fetchItems();
+      });
+      this._subs.push(sub);
+    }
+  };
+
+  /* ========== Destroy ========== */
+  TrashCard.prototype.destroy = function() {
+    this.container.removeEventListener('click', this._bound._delegate);
+    this._subs.forEach(function(s) { if (s && s.unsubscribe) s.unsubscribe(); });
+    this._subs = [];
+    this.container.innerHTML = '';
+  };
+
+  /* ========== Mount ========== */
+  function mount(container, opts) {
+    var card = new TrashCard(container, opts);
+    card.subscribe();
+    return card;
+  }
+
+  function mountEntry(container, opts) {
+    var card = new TrashCard(container, Object.assign({}, opts, { size: 'small' }));
+    card.subscribe();
+    return card;
+  }
+
+  /* ========== Register ========== */
+  if (typeof WidgetRegistry !== 'undefined') {
+    WidgetRegistry.register('trash-card', {
+      type: 'function',
+      label: '回收站',
+      icon: '\uD83D\uDDD1\uFE0F',
+      defaultSize: { w: 2, h: 1 },
+      category: 'functions',
+      mount: mount
+    });
+    WidgetRegistry.register('trash-entry', {
+      type: 'entry',
+      label: '回收站入口',
+      icon: '\uD83D\uDDD1\uFE0F',
+      defaultSize: { w: 1, h: 1 },
+      category: 'entries',
+      mount: mountEntry
+    });
+  }
+
+})();


### PR DESCRIPTION
## 🚀 Hermes Workspace V2 — iOS 桌面式卡片工作台

### 版本: v17.0.0

### 核心变更

#### Phase 1: 基础架构改造
- **HermesClient.js**: 统一通信层 (HTTP+SSE+Cache+API)，合并 API/APIClient/SSEManager/DataService
- **CardOverlay.js**: 卡片放大覆盖层系统，支持卡片内导航 (列表↔详情)
- **StatusBar.js**: iOS 风格顶部状态栏 (时间/搜索/通知/连接状态)
- **Dock.js**: macOS 风格底部 Dock (悬停放大动画)
- **SpotlightSearch.js**: Cmd+K 聚焦搜索
- **index.html/app.js**: 移除侧边栏，直接渲染工作台桌面

#### Phase 2: 卡片内容系统 (12个卡片组件)
| 优先级 | 卡片 | 功能 |
|--------|------|------|
| P0 | KnowledgeCard | 知识库管理 (4尺寸+CRUD+卡片内导航) |
| P0 | SessionCard | 会话管理 (4尺寸+聊天界面) |
| P1 | MarketplaceCard | 功能商店 (MCP/技能/工具/插件) |
| P1 | AgentCard | AI助手 (Agent列表/进度/终止) |
| P1 | OpsCard | 运维中心 (系统概览/MCP健康/告警) |
| P2 | MemoryCard | 记忆管理 |
| P2 | CronCard | 定时任务管理 |
| P2 | SettingsCard | 系统设置 (配置+备份恢复) |
| P3 | RulesCard | 规则引擎 |
| P3 | ExperienceCard | 经验管理 |
| P3 | LogsCard | 系统日志 |
| P3 | TrashCard | 回收站 |

每个卡片均支持 4 种尺寸渲染 (small/medium/large/xlarge) + SSE 实时更新 + 骨架屏加载

#### Phase 3: 卡片增强
- **ContextMenuManager**: 卡片右键菜单 + 桌面右键菜单
- **SkeletonLoader**: 骨架屏加载组件

#### Phase 4: 移动端适配
- **ResponsiveManager**: 响应式布局管理 (断点检测/自动布局切换)
- **workspace-mobile.css**: 移动端响应式样式

### 新增文件: 24 个
### 修改文件: 5 个 (index.html, app.js, WorkspacePage.js, app.py, workspace.css)

### 构建系统更新
- `core_order` 新增 HermesClient.js
- `required_globals` 新增 14 个模块
- `css_files` 新增 workspace-mobile.css

### 标签
- `v17.0.0-alpha.1` → Phase 1
- `v17.0.0-alpha.2` → Phase 2 P0
- `v17.0.0-beta.1` → Phase 2 全部
- `v17.0.0-rc.1` → Phase 3
- `v17.0.0` → Phase 4 (正式发布)

### 测试清单
- [x] 桌面加载直接显示工作台（无侧边栏）
- [x] StatusBar/Dock 正常渲染
- [x] 卡片自由拖拽 + 8方向 resize
- [x] 卡片点击放大为 xlarge overlay
- [x] 卡片内导航 (列表↔详情)
- [x] Cmd+K 聚焦搜索
- [x] 右键菜单功能
- [x] 深色模式兼容
- [x] 移动端响应式布局