### PR TITLE
fix: add hidden contentBody div for backward compatibility

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,7 +27,8 @@
   <div id="cardOverlay"></div>
 
   <!-- 工作台主容器 -->
-  <div id="workspaceContainer"></div>
+  <div id="contentBody" style="display:none"></div>
+    <div id="workspaceContainer"></div>
 
   <!-- ==================== Scripts ==================== -->
 


### PR DESCRIPTION
Hotfix: Old page register.js files reference `contentBody` which was removed in V2. Adding a hidden div prevents null reference errors that cause blank page.