### PR TITLE
fix: restore Modal HTML elements (modalClose, modalTitle, modalBody, modalFooter)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,14 @@
 
   <!-- 模态框 -->
   <div id="modalOverlay" class="modal-overlay">
-    <div class="modal-content" id="modalContent"></div>
+    <div class="modal">
+      <div class="modal-header">
+        <h3 id="modalTitle" class="modal-title"></h3>
+        <button id="modalClose" class="modal-close">&times;</button>
+      </div>
+      <div id="modalBody" class="modal-body"></div>
+      <div id="modalFooter" class="modal-footer"></div>
+    </div>
   </div>
 
   <!-- 卡片放大覆盖层 -->


### PR DESCRIPTION
## Problem

`_Modal.init()` in `feedback.js` calls `document.getElementById('modalClose').addEventListener()`, but the Modal HTML in `index.html` was simplified during the V2 workspace rewrite and is missing these elements:

- `modalClose` ❌ (causes `TypeError: Cannot read properties of null (reading 'addEventListener')`)
- `modalTitle` ❌
- `modalBody` ❌
- `modalFooter` ❌

This causes a **blank white page** on HF Space deployment.

## Fix

Restore the full Modal HTML structure with all required element IDs.

## Root Cause

During Phase 3 (index.html rewrite), the Modal HTML was simplified to just `<div id="modalOverlay"><div id="modalContent"></div></div>`, but the JS code in `feedback.js` still references the old element IDs.