### PR TITLE
fix: remove LayoutEngine.init() - LayoutEngine is a pure calculation module

### DIFF
--- a/frontend/js/workspace/pages/WorkspacePage.js
+++ b/frontend/js/workspace/pages/WorkspacePage.js
@@ -45,11 +45,6 @@ var WorkspacePage = (function () {
             DesktopManager.init(_desktopContainer);
         }
 
-        // 初始化布局引擎
-        if (typeof LayoutEngine !== 'undefined') {
-            LayoutEngine.init(_desktopContainer);
-        }
-
         // 初始化卡片管理器
         if (typeof CardManager !== 'undefined') {
             CardManager.init(_desktopContainer);


### PR DESCRIPTION
## Problem

`LayoutEngine.init()` is called in `WorkspacePage.render()` but `LayoutEngine` is a pure calculation module that only exports `calculate`, `getRecommendedCols`, `clearPinned`, `pixelToGrid`, `gridToPixel`, `SIZE_MAP` — no `init` method.

This causes: `Uncaught TypeError: LayoutEngine.init is not a function`

## Fix

Remove the `LayoutEngine.init(_desktopContainer)` call block.