### PR TITLE
fix: StatusBar shows [object Promise] instead of version number

### DIFF
--- a/frontend/js/workspace/components/StatusBar.js
+++ b/frontend/js/workspace/components/StatusBar.js
@@ -356,17 +356,16 @@ var StatusBar = (() => {
     function _updateVersion() {
         if (!_versionEl) return;
 
-        // 尝试从 HermesClient 获取版本
+        // 尝试从 HermesClient 获取版本（异步）
         if (typeof HermesClient !== 'undefined' && HermesClient.getAppVersion) {
-            try {
-                var version = HermesClient.getAppVersion();
-                if (version) {
+            HermesClient.getAppVersion().then(function(version) {
+                if (version && _versionEl) {
                     _versionEl.textContent = 'v' + version;
-                    return;
                 }
-            } catch (e) {
+            }).catch(function() {
                 // 忽略错误
-            }
+            });
+            return;
         }
 
         // 尝试从全局变量获取


### PR DESCRIPTION
## Problem

`HermesClient.getAppVersion()` is an `async function` that returns a Promise, but `StatusBar.js` calls it synchronously and directly concatenates the result with `'v'`, producing `v[object Promise]`.

## Fix

Use `.then()` to properly handle the async result.